### PR TITLE
release v1.8.30 and reorganize repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: ['master']
+    branches: ['main']
   pull_request:
-    branches: ['master']
+    branches: ['main']
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: ['master']
+    branches: ['main']
   pull_request:
-    branches: ['master']
+    branches: ['main']
   schedule:
     - cron: '23 3 * * 1'
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ meridian.exe
 # OS
 .DS_Store
 Thumbs.db
+
+# Codex / local build artifacts
+.codex-remote-attachments/
+.tmp/
+.tmp-*.patch
+COLLABORATION_RULES.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,18 +5,20 @@
 ## 开发环境
 
 - Go 1.26+
+- Node.js 22+
 - 无 CGO 依赖（SQLite 使用纯 Go 实现 `modernc.org/sqlite`）
 
 ```bash
-git clone https://github.com/snnabb/Meridian.git
+git clone https://github.com/chanhui800/Meridian.git
 cd Meridian
 go build -o meridian .
 go test ./...
+node --test tests/*.test.js
 ```
 
 ## 项目架构约定
 
-- **后端保持单文件**：所有后端逻辑写在 `main.go` 中，不拆分子包或多文件。这是项目的有意设计选择
+- **后端保持轻量**：核心代理逻辑位于 `main.go`，独立模块按现有职责文件组织，不引入不必要的包层级
 - **前端是原生 JS**：不使用框架，不引入构建工具。页面按文件拆分在 `web/static/js/pages/` 下
 - **SQLite 驱动名是 `sqlite`**（不是 `sqlite3`），不要更换驱动
 - **嵌入方式**：前端通过 `web/embed.go` 的 `go:embed` 指令嵌入二进制
@@ -24,10 +26,10 @@ go test ./...
 ## 提交 PR 的流程
 
 1. Fork 仓库
-2. 从 `master` 分支创建你的特性分支
+2. 从 `main` 分支创建你的特性分支
 3. 修改代码
-4. 确保 `go test ./...` 通过
-5. 确保 `go build -o meridian .` 能正常编译
+4. 确保 `go test ./...`、`go vet ./...` 和 `node --test tests/*.test.js` 通过
+5. 确保 `go build -trimpath -buildvcs=false -o meridian .` 能正常编译
 6. 提交 PR，使用 [PR 模板](.github/PULL_REQUEST_TEMPLATE.md) 填写说明
 
 ## 提交规范
@@ -53,7 +55,7 @@ Commit message 应简明扼要地说明改了什么：
 
 ## 什么样的改动会被拒绝
 
-- 将 `main.go` 拆分成多文件的重构 PR
+- 仅为形式统一而进行的大范围目录或包拆分
 - 引入前端构建工具链（webpack、vite 等）
 - 更换 SQLite 驱动
 - 没有实际用途的"优化"或过度抽象

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-ARG VERSION=v1.8.29
+ARG VERSION=v1.8.30
 RUN CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags="-s -w -X main.appVersion=${VERSION}" -o meridian .
 
 # Runtime stage
@@ -31,7 +31,7 @@ ENV DB_PATH=/app/data/meridian.db
 VOLUME ["/app/data"]
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD sh -c 'db_path="${DB_PATH:-/app/data/meridian.db}"; marker="$(dirname "$db_path")/panel-port"; port="$(cat "$marker" 2>/dev/null || true)"; case "$port" in ""|*[!0-9]*) exit 1;; esac; wget --no-check-certificate -q -O - "https://127.0.0.1:$port/api/auth/check" >/dev/null 2>&1 || wget -q -O - "http://127.0.0.1:$port/api/auth/check" >/dev/null 2>&1' || exit 1
+  CMD ["/app/meridian", "--healthcheck"]
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["./meridian"]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 # Meridian（基于原项目的修改版）
 
+[![CI](https://github.com/chanhui800/Meridian/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/chanhui800/Meridian/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/chanhui800/Meridian/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/chanhui800/Meridian/actions/workflows/codeql.yml)
+[![Release](https://img.shields.io/github/v/release/chanhui800/Meridian)](https://github.com/chanhui800/Meridian/releases/latest)
+[![License](https://img.shields.io/github/license/chanhui800/Meridian)](LICENSE)
+
 本仓库是基于原项目 [snnabb/Meridian](https://github.com/snnabb/Meridian) 的修改版，保留原项目的核心反向代理能力，并针对实际部署补充和调整了域名前缀入口、自动后端改写、TLS 面板配置、缓存、日志和 UI。当前修改版仓库地址为 [chanhui800/Meridian](https://github.com/chanhui800/Meridian)。
 
 Meridian 是面向 Emby 及兼容媒体服务的反向代理面板。它把多个上游站点统一到一个管理界面，提供独立端口、域名前缀入口、动态后端发现、播放地址改写、TLS、流量统计、请求日志和静态资源缓存。
 
-当前正式版本：`v1.8.29`
+当前正式版本：`v1.8.30`
+
+本版本基于 `v1.8.29`，包含日志筛选精简、请求日志字段完善、移动端日志布局优化、账户管理和登录错误提示等改进。主视频流策略保持稳定：默认反代，选择直连时仅将符合主视频路径规则的媒体流交给客户端直连。
+
+快速导航：[Docker 部署](#docker) · [Linux 原生安装](#linux-原生-systemd) · [TLS 与域名前缀](#域名前缀入口与-tls) · [日志设置](#全局设置与日志) · [安全策略](SECURITY.md) · [贡献指南](CONTRIBUTING.md)
 
 客户端在切换页面、刷新列表或取消未完成的图片/媒体请求时，日志会记录为 HTTP `499`（客户端已关闭请求），不再误计为 Meridian 生成的 `502`。真实的上游 502 仍会按 502 记录。
 
@@ -60,8 +69,8 @@ Meridian 是面向 Emby 及兼容媒体服务的反向代理面板。它把多�
 - 自动识别并改写 PlaybackInfo、HLS、DASH 和 HTTP 30x 中的播放地址，使后端切换后仍经过当前站点代理；默认允许 HTTPS → HTTP 回源降级。
 - 对 localhost、回环、私网、链路本地和其他特殊目标执行拒绝，防止动态发现绕过目标安全边界。
 - 媒体认证头默认完全透传；UA 默认透传，可按站点覆盖。
-- 请求日志支持按日期、资源类别、状态、节点、客户端 IP、UA、路径和状态码检索，可直接调整 UA 列宽并清理日志或缓存。
-- 日志设置可分别控制资源类别写入，以及节点、资源类别、状态、客户端 IP、UA、时间线六个字段的写入与展示；图片海报和媒体元数据默认不写入。
+- 请求日志支持按日期、真实资源类别、状态、节点、客户端 IP、UA、后端地址、路径和状态码检索；筛选区直接平铺播放信息、播放状态同步、主视频流、播放清单、媒体分片、图片海报、媒体元数据、字幕、静态资源、WebSocket、常规 API 和用户认证，不再提供聚合视频流或高级分类。
+- 日志设置可分别控制播放信息、视频流、图片海报、媒体元数据、字幕、静态资源、WebSocket、常规 API 与用户认证的写入，以及节点、资源类别、状态、客户端 IP、UA、后端地址、时间线七个字段的写入与展示；图片海报和媒体元数据默认不写入。
 - Telegram 定时日报支持每天或每周发送，可配置发送时间、星期和目标会话；默认使用北京时间，可在系统 UI 中调整调度时区。
 - 全局设置统一管理系统 UI、日志、TLS、Telegram 通知和故障诊断，设置页采用紧凑卡片布局并支持缓存数据即时呈现。
 - 面板支持白色/黑色主题、桌面折叠导航和移动端可收起侧栏，右上角可直接进入本项目 GitHub 仓库。
@@ -148,7 +157,7 @@ ACME 证书订单只申请 `*.example.com` 泛域名，不会重复提交 `panel
 
 Meridian 会从 PlaybackInfo、HLS、DASH 和 HTTP 30x 响应中识别播放后端，并把播放地址重新指向当前 Meridian 入口。内部仍保留严格的目标校验、DNS 固定和动态能力边界；localhost、回环、私网、链路本地及其他保留目标不会因为自动识别而被放行。
 
-选择“直连”后，MP4、MKV、MOV、AVI、WebM 等主视频文件，以及 Emby / Jellyfin 的 `/Videos/.../stream`、`/original`、`/download`、`/file` 等厚媒体请求会通过 HTTP `307` 转到经过校验的实际后端。网盘服或 CDN 上游返回 HTTP `301`、`302`、`307`、`308` 时，Meridian 会校验最终公网目标，再将主视频直接交给播放器，不会让大流量视频体经过 Meridian。面板、普通 API、PlaybackInfo、WebSocket、HLS / DASH 清单与分片、字幕、图片和必要前端静态资源继续走 Meridian 反代。
+选择“直连”后，MP4、MKV、MOV、AVI、WebM 等主视频文件，以及 Emby / Jellyfin 的 `/Videos/.../stream`、`/original`、`/download`、`/file` 等厚媒体请求会先访问主站并只读取响应头。网盘服或 CDN 上游返回 HTTP `301`、`302`、`307`、`308` 时，Meridian 会校验第一层公网目标，再通过 HTTP `307` 将主视频直接交给播放器；主站直接返回媒体正文或探测失败时会回退到原主站直连地址，不会让大流量视频体经过 Meridian。非法、私网、回环或其他受限跳转仍会拒绝。面板、普通 API、PlaybackInfo、WebSocket、HLS / DASH 清单与分片、字幕、图片和必要前端静态资源继续走 Meridian 反代。
 
 认证头采用完全透传：`Authorization`、`X-Emby-Authorization` 和 `X-MediaBrowser-Authorization` 不会被面板改写。`X-Real-IP` 和 `X-Forwarded-For` 按可信代理配置生成或透传；只有明确配置的可信代理才会被采纳为前级身份来源。
 
@@ -171,8 +180,8 @@ Meridian 会从 PlaybackInfo、HLS、DASH 和 HTTP 30x 响应中识别播放后�
 
 日志设置分为三层：
 
-- 资源类别写入：控制媒体元数据、视频流、图片海报、常规 API 和用户认证是否进入后续新日志。
-- 日志字段写入：控制节点、资源类别、状态、客户端 IP、UA 和时间线是否保存在后续新日志中，旧日志不会被改写。
+- 资源类别写入：控制播放信息与状态同步、视频流、图片海报、媒体元数据、字幕、静态资源、WebSocket、常规 API 和用户认证是否进入后续新日志。PlaybackInfo 归入播放信息；Sessions/Playing、Progress、Stopped、Ping 独立显示为播放状态同步；Items、Shows、Movies、Users 才归入媒体元数据。
+- 日志字段写入：控制节点、资源类别、状态、客户端 IP、UA、后端地址和时间线是否保存在后续新日志中，旧日志不会被改写。
 - 日志字段展示：只控制日志表格列是否显示，不影响已经允许写入的字段。
 
 日志页不会保存查询参数、令牌、Cookie 或请求正文。客户端 IP 只会信任 `TRUSTED_PROXY_CIDRS` 中明确配置的前级代理；未配置可信代理时不会采纳外部伪造的转发头。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@
 
 请通过以下方式私下报告：
 
-- 使用 GitHub 的 [Security Advisory](https://github.com/snnabb/Meridian/security/advisories/new) 功能
+- 使用 GitHub 的 [Security Advisory](https://github.com/chanhui800/Meridian/security/advisories/new) 功能
 - 或发送邮件至仓库维护者（见仓库 Profile）
 
 我们会在收到报告后尽快确认并处理。

--- a/main.go
+++ b/main.go
@@ -1340,12 +1340,21 @@ type DynamicObservationsResponse struct {
 }
 
 const (
-	requestLogCategoryPlayback = "playback"
-	requestLogCategoryVideo    = "video"
-	requestLogCategoryImage    = "image"
-	requestLogCategoryAPI      = "api"
-	requestLogCategoryAuth     = "auth"
-	clientClosedRequestStatus  = 499
+	requestLogCategoryPlayback            = "playback"
+	requestLogCategoryPlaybackSync        = "playback_sync"
+	requestLogCategoryVideo               = "video" // legacy grouped value retained for old rows and filters
+	requestLogCategoryStream              = "stream"
+	requestLogCategoryManifest            = "manifest"
+	requestLogCategorySegment             = "segment"
+	requestLogCategoryImage               = "image"
+	requestLogCategoryMetadata            = "metadata"
+	requestLogCategorySubtitle            = "subtitle"
+	requestLogCategoryAsset               = "asset"
+	requestLogCategoryWebSocket           = "websocket"
+	requestLogCategoryAPI                 = "api"
+	requestLogCategoryAuth                = "auth"
+	clientClosedRequestStatus             = 499
+	requestLogLegacyPlaybackSyncPredicate = `(lower(request_logs.path)='/sessions/playing' OR lower(request_logs.path) LIKE '/sessions/playing/%' OR lower(request_logs.path)='/emby/sessions/playing' OR lower(request_logs.path) LIKE '/emby/sessions/playing/%')`
 )
 
 // requestLogEvent is the bounded hot-path payload accepted from a site proxy.
@@ -1398,7 +1407,10 @@ type RequestLogsResponse struct {
 
 func validRequestLogCategory(category string) bool {
 	switch category {
-	case requestLogCategoryPlayback, requestLogCategoryVideo, requestLogCategoryImage, requestLogCategoryAPI, requestLogCategoryAuth:
+	case requestLogCategoryPlayback, requestLogCategoryPlaybackSync, requestLogCategoryVideo, requestLogCategoryStream,
+		requestLogCategoryManifest, requestLogCategorySegment, requestLogCategoryImage,
+		requestLogCategoryMetadata, requestLogCategorySubtitle, requestLogCategoryAsset,
+		requestLogCategoryWebSocket, requestLogCategoryAPI, requestLogCategoryAuth:
 		return true
 	default:
 		return false
@@ -1665,8 +1677,12 @@ func (d *DB) EnqueueRequestLog(event requestLogEvent) {
 	settings := d.currentSystemSettings()
 	if !settings.LogEnabled || (settings.LogLevel == "error" && event.StatusCode < 400) ||
 		(!settings.LogWriteImage && event.ResourceCategory == requestLogCategoryImage) ||
-		(!settings.LogWriteMetadata && event.ResourceCategory == requestLogCategoryPlayback) ||
-		(!settings.LogWriteVideo && event.ResourceCategory == requestLogCategoryVideo) ||
+		(!settings.LogWritePlayback && (event.ResourceCategory == requestLogCategoryPlayback || event.ResourceCategory == requestLogCategoryPlaybackSync)) ||
+		(!settings.LogWriteMetadata && event.ResourceCategory == requestLogCategoryMetadata) ||
+		(!settings.LogWriteVideo && (event.ResourceCategory == requestLogCategoryVideo || event.ResourceCategory == requestLogCategoryStream || event.ResourceCategory == requestLogCategoryManifest || event.ResourceCategory == requestLogCategorySegment)) ||
+		(!settings.LogWriteSubtitle && event.ResourceCategory == requestLogCategorySubtitle) ||
+		(!settings.LogWriteAsset && event.ResourceCategory == requestLogCategoryAsset) ||
+		(!settings.LogWriteWebSocket && event.ResourceCategory == requestLogCategoryWebSocket) ||
 		(!settings.LogWriteAPI && event.ResourceCategory == requestLogCategoryAPI) ||
 		(!settings.LogWriteAuth && event.ResourceCategory == requestLogCategoryAuth) {
 		return
@@ -1803,8 +1819,20 @@ func (d *DB) ListRequestLogs(filter RequestLogFilter) ([]RequestLog, error) {
 		args = append(args, filter.ToMS)
 	}
 	if filter.Category != "" && filter.Category != "all" {
-		conditions = append(conditions, "resource_category=?")
-		args = append(args, filter.Category)
+		switch filter.Category {
+		case requestLogCategoryVideo:
+			conditions = append(conditions, "resource_category IN (?,?,?,?)")
+			args = append(args, requestLogCategoryVideo, requestLogCategoryStream, requestLogCategoryManifest, requestLogCategorySegment)
+		case requestLogCategoryPlaybackSync:
+			conditions = append(conditions, "(resource_category=? OR (resource_category=? AND "+requestLogLegacyPlaybackSyncPredicate+"))")
+			args = append(args, requestLogCategoryPlaybackSync, requestLogCategoryPlayback)
+		case requestLogCategoryPlayback:
+			conditions = append(conditions, "(resource_category=? AND NOT "+requestLogLegacyPlaybackSyncPredicate+")")
+			args = append(args, requestLogCategoryPlayback)
+		default:
+			conditions = append(conditions, "resource_category=?")
+			args = append(args, filter.Category)
+		}
 	}
 	switch filter.StatusGroup {
 	case "4xx":
@@ -1834,6 +1862,9 @@ func (d *DB) ListRequestLogs(filter RequestLogFilter) ([]RequestLog, error) {
 		var entry RequestLog
 		if err := rows.Scan(&entry.ID, &entry.SiteID, &entry.SiteName, &entry.ResourceCategory, &entry.StatusCode, &entry.ClientIP, &entry.UserAgent, &entry.BackendAddress, &entry.Method, &entry.Path, &entry.RecordedAtMS, &entry.InboundColo, &entry.OutboundColo); err != nil {
 			return nil, err
+		}
+		if entry.ResourceCategory == requestLogCategoryPlayback && isRequestLogPlaybackActivityPath(entry.Path) {
+			entry.ResourceCategory = requestLogCategoryPlaybackSync
 		}
 		logs = append(logs, entry)
 	}
@@ -2379,8 +2410,10 @@ func (d *DB) migrateOnce() error {
 		log_flush_threshold INTEGER NOT NULL DEFAULT 1, log_batch_size INTEGER NOT NULL DEFAULT 50,
 		log_retry_count INTEGER NOT NULL DEFAULT 2, log_retry_backoff_ms INTEGER NOT NULL DEFAULT 75,
 		log_task_lease_ms INTEGER NOT NULL DEFAULT 300000,
-		log_write_image INTEGER NOT NULL DEFAULT 0, log_write_metadata INTEGER NOT NULL DEFAULT 0,
+		log_write_image INTEGER NOT NULL DEFAULT 0, log_write_playback INTEGER NOT NULL DEFAULT 1, log_write_metadata INTEGER NOT NULL DEFAULT 0,
 		log_write_video INTEGER NOT NULL DEFAULT 1, log_write_api INTEGER NOT NULL DEFAULT 1, log_write_auth INTEGER NOT NULL DEFAULT 1,
+		log_write_subtitle INTEGER NOT NULL DEFAULT 1, log_write_asset INTEGER NOT NULL DEFAULT 1, log_write_websocket INTEGER NOT NULL DEFAULT 1,
+		log_resource_taxonomy_version INTEGER NOT NULL DEFAULT 1,
 		log_write_node INTEGER NOT NULL DEFAULT 1, log_write_category INTEGER NOT NULL DEFAULT 1, log_write_status INTEGER NOT NULL DEFAULT 1,
 		log_write_client_ip INTEGER NOT NULL DEFAULT 1, log_write_colo INTEGER NOT NULL DEFAULT 0,
 		log_write_ua INTEGER NOT NULL DEFAULT 1, log_write_backend_address INTEGER NOT NULL DEFAULT 1, log_write_timeline INTEGER NOT NULL DEFAULT 1, log_display_client_ip INTEGER NOT NULL DEFAULT 1,
@@ -2436,9 +2469,14 @@ func (d *DB) migrateOnce() error {
 		}
 	}
 	for _, migration := range []struct{ column, sql string }{
+		{"log_write_playback", "ALTER TABLE system_settings ADD COLUMN log_write_playback INTEGER NOT NULL DEFAULT 1"},
 		{"log_write_video", "ALTER TABLE system_settings ADD COLUMN log_write_video INTEGER NOT NULL DEFAULT 1"},
 		{"log_write_api", "ALTER TABLE system_settings ADD COLUMN log_write_api INTEGER NOT NULL DEFAULT 1"},
 		{"log_write_auth", "ALTER TABLE system_settings ADD COLUMN log_write_auth INTEGER NOT NULL DEFAULT 1"},
+		{"log_write_subtitle", "ALTER TABLE system_settings ADD COLUMN log_write_subtitle INTEGER NOT NULL DEFAULT 1"},
+		{"log_write_asset", "ALTER TABLE system_settings ADD COLUMN log_write_asset INTEGER NOT NULL DEFAULT 1"},
+		{"log_write_websocket", "ALTER TABLE system_settings ADD COLUMN log_write_websocket INTEGER NOT NULL DEFAULT 1"},
+		{"log_resource_taxonomy_version", "ALTER TABLE system_settings ADD COLUMN log_resource_taxonomy_version INTEGER NOT NULL DEFAULT 0"},
 		{"log_write_node", "ALTER TABLE system_settings ADD COLUMN log_write_node INTEGER NOT NULL DEFAULT 1"},
 		{"log_write_category", "ALTER TABLE system_settings ADD COLUMN log_write_category INTEGER NOT NULL DEFAULT 1"},
 		{"log_write_status", "ALTER TABLE system_settings ADD COLUMN log_write_status INTEGER NOT NULL DEFAULT 1"},
@@ -2458,6 +2496,19 @@ func (d *DB) migrateOnce() error {
 			if _, err := conn.ExecContext(ctx, migration.sql); err != nil {
 				return err
 			}
+		}
+	}
+	var logResourceTaxonomyVersion int
+	if err := conn.QueryRowContext(ctx, "SELECT log_resource_taxonomy_version FROM system_settings WHERE id=1").Scan(&logResourceTaxonomyVersion); err != nil {
+		return err
+	}
+	if logResourceTaxonomyVersion < 1 {
+		if _, err := conn.ExecContext(ctx, `UPDATE system_settings SET
+			log_write_playback=log_write_metadata,
+			log_write_metadata=0,
+			log_resource_taxonomy_version=1
+			WHERE id=1`); err != nil {
+			return err
 		}
 	}
 	if err := ensurePanelSettingsListenPortSchema(ctx, conn); err != nil {
@@ -3558,6 +3609,8 @@ type dynamicRequestEligibleContextKey struct{}
 type dynamicResponseContextKey struct{}
 type dynamicExpectedStructuredSourceContextKey struct{}
 type dynamicPlaybackInfoBaseContextKey struct{}
+type mainVideoDirectFallbackContextKey struct{}
+type mainVideoDirectResolvedContextKey struct{}
 
 // dynamicOutboundContext keeps request cancellation and deadlines while
 // dropping ReverseProxy's outbound httptrace and every other caller value.
@@ -9710,6 +9763,18 @@ func replaceResponseWithMainVideoRedirect(resp *http.Response, target *url.URL) 
 	if resp == nil || target == nil {
 		return resp
 	}
+	resp = replaceResponseWithMainVideoDirectTarget(resp, target)
+	if resp.Request != nil {
+		ctx := context.WithValue(resp.Request.Context(), mainVideoDirectResolvedContextKey{}, true)
+		resp.Request = resp.Request.WithContext(ctx)
+	}
+	return resp
+}
+
+func replaceResponseWithMainVideoDirectTarget(resp *http.Response, target *url.URL) *http.Response {
+	if resp == nil || target == nil {
+		return resp
+	}
 	if resp.Body != nil {
 		_ = resp.Body.Close()
 	}
@@ -9724,6 +9789,36 @@ func replaceResponseWithMainVideoRedirect(resp *http.Response, target *url.URL) 
 	resp.ContentLength = 0
 	resp.Trailer = nil
 	return resp
+}
+
+func mainVideoDirectFallbackTarget(ctx context.Context) *url.URL {
+	if ctx == nil {
+		return nil
+	}
+	target, _ := ctx.Value(mainVideoDirectFallbackContextKey{}).(*url.URL)
+	return target
+}
+
+func mainVideoDirectResponseResolved(resp *http.Response) bool {
+	if resp == nil || resp.Request == nil {
+		return false
+	}
+	resolved, _ := resp.Request.Context().Value(mainVideoDirectResolvedContextKey{}).(bool)
+	return resolved
+}
+
+func newMainVideoDirectFallbackResponse(req *http.Request, target *url.URL) *http.Response {
+	if req == nil || target == nil {
+		return nil
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusTemporaryRedirect,
+		Status:     strconv.Itoa(http.StatusTemporaryRedirect) + " " + http.StatusText(http.StatusTemporaryRedirect),
+		Header:     make(http.Header),
+		Body:       http.NoBody,
+		Request:    req,
+	}
+	return replaceResponseWithMainVideoDirectTarget(resp, target)
 }
 
 type dynamicTransportFactory func(*url.URL, []net.IP, *dynamicSelfTargetPolicy) (*http.Transport, error)
@@ -10066,7 +10161,6 @@ func (t *redirectFollowTransport) roundTripDynamic(req *http.Request, resp *http
 		}
 		return nil, t.denied(reasonCode, authority)
 	}
-
 	for {
 		if resp == nil {
 			return fail(dynamicObservationReasonResponseFailure, dynamicCanonicalAuthority(req.URL))
@@ -10419,9 +10513,32 @@ func (t *redirectFollowTransport) roundTripDynamic(req *http.Request, resp *http
 }
 
 func (t *redirectFollowTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	directFallback := mainVideoDirectFallbackTarget(req.Context())
 	resp, err := t.base.RoundTrip(req)
 	if err != nil {
+		if t.mainVideoDirect && directFallback != nil {
+			if tracker := backendAddressTrackerFromContext(req.Context()); tracker != nil {
+				tracker.SetURL(directFallback)
+			}
+			return newMainVideoDirectFallbackResponse(req, directFallback), nil
+		}
 		return nil, err
+	}
+	if t.mainVideoDirect && directFallback != nil {
+		if t.dynamicPolicy.configured && t.dynamicPolicy.sourceEnabled(dynamicDiscoverySourceRedirect) {
+			resolved, resolveErr := t.roundTripDynamic(req, resp)
+			if resolveErr != nil {
+				return nil, resolveErr
+			}
+			if mainVideoDirectResponseResolved(resolved) {
+				return resolved, nil
+			}
+			resp = resolved
+		}
+		if tracker := backendAddressTrackerFromContext(req.Context()); tracker != nil {
+			tracker.SetURL(directFallback)
+		}
+		return replaceResponseWithMainVideoDirectTarget(resp, directFallback), nil
 	}
 	eligible, _ := req.Context().Value(dynamicRequestEligibleContextKey{}).(bool)
 	if !t.dynamicPolicy.configured {
@@ -11158,16 +11275,61 @@ func classifyRequestLogResource(r *http.Request) string {
 	}
 	path := strings.ToLower(r.URL.Path)
 	switch {
+	case hasUpgradeIntent(r):
+		return requestLogCategoryWebSocket
 	case strings.Contains(path, "/authenticate"), strings.Contains(path, "/quickconnect"):
 		return requestLogCategoryAuth
-	case strings.Contains(path, "/images/"), strings.HasSuffix(path, "/images"), strings.Contains(path, "/image/"):
-		return requestLogCategoryImage
 	case isPlaybackInfoRequest(path):
 		return requestLogCategoryPlayback
-	case isPlaybackRequest(path), isPlaybackRedirectEndpoint(path), dynamicStructuredRequestSource(path) != "", isReservedDynamicRoute(path):
-		return requestLogCategoryVideo
+	case isRequestLogPlaybackActivityPath(path):
+		return requestLogCategoryPlaybackSync
+	case requestLogPathHasSuffix(path, ".m3u8", ".m3u", ".mpd"):
+		return requestLogCategoryManifest
+	case requestLogPathHasSuffix(path, ".ts", ".m4s"):
+		return requestLogCategorySegment
+	case strings.Contains(path, "/subtitles/"), strings.HasSuffix(path, "/subtitles"), strings.Contains(path, "/captions/"), requestLogPathHasSuffix(path, ".srt", ".ass", ".ssa", ".vtt", ".sub", ".idx", ".sup"):
+		return requestLogCategorySubtitle
+	case strings.Contains(path, "/images/"), strings.HasSuffix(path, "/images"), strings.Contains(path, "/image/"), strings.Contains(path, "/icons/"), strings.Contains(path, "/branding/"), strings.Contains(path, "/covers/"), requestLogPathHasSuffix(path, ".jpg", ".jpeg", ".gif", ".png", ".svg", ".ico", ".webp", ".avif"):
+		return requestLogCategoryImage
+	case requestLogPathHasSuffix(path, ".js", ".css", ".woff", ".woff2", ".ttf", ".otf", ".map", ".webmanifest"):
+		return requestLogCategoryAsset
+	case isPlaybackRequest(path), isPlaybackRedirectEndpoint(path), isReservedDynamicRoute(path), requestLogPathHasSuffix(path, ".mp4", ".m4v", ".ogv", ".webm", ".mkv", ".mov", ".avi", ".wmv", ".flv", ".mp3", ".m4a", ".aac", ".flac", ".wav", ".ogg", ".opus"):
+		return requestLogCategoryStream
+	case isRequestLogMetadataPath(path):
+		return requestLogCategoryMetadata
 	default:
 		return requestLogCategoryAPI
+	}
+}
+
+func requestLogPathHasSuffix(path string, suffixes ...string) bool {
+	for _, suffix := range suffixes {
+		if strings.HasSuffix(path, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func isRequestLogPlaybackActivityPath(path string) bool {
+	path = strings.TrimSuffix(strings.ToLower(path), "/")
+	return path == "/sessions/playing" || strings.HasPrefix(path, "/sessions/playing/") ||
+		path == "/emby/sessions/playing" || strings.HasPrefix(path, "/emby/sessions/playing/")
+}
+
+func isRequestLogMetadataPath(path string) bool {
+	parts := strings.Split(strings.Trim(strings.ToLower(path), "/"), "/")
+	if len(parts) > 0 && parts[0] == "emby" {
+		parts = parts[1:]
+	}
+	if len(parts) == 0 {
+		return false
+	}
+	switch parts[0] {
+	case "items", "shows", "movies", "users":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -13303,8 +13465,7 @@ func (pm *ProxyManager) StartSite(site Site) error {
 			if tracker := backendAddressTrackerFromContext(r.Context()); tracker != nil {
 				tracker.SetURL(directTarget)
 			}
-			writeMainVideoDirectRedirect(w, directTarget)
-			return
+			r = r.WithContext(context.WithValue(r.Context(), mainVideoDirectFallbackContextKey{}, directTarget))
 		}
 
 		if hasUpgradeIntent(r) {
@@ -16386,7 +16547,7 @@ func (a *App) sendSSEEvent(w http.ResponseWriter, flusher http.Flusher) error {
 var startTime = time.Now()
 
 // appVersion is overridable at build time via -ldflags "-X main.appVersion=vX.Y.Z".
-var appVersion = "v1.8.29"
+var appVersion = "v1.8.30"
 
 func runCommandLine(args []string, input io.Reader, output io.Writer) (bool, error) {
 	if len(args) == 0 {
@@ -16399,11 +16560,60 @@ func runCommandLine(args []string, input io.Reader, output io.Writer) (bool, err
 		}
 		_, err := fmt.Fprintln(output, appVersion)
 		return true, err
+	case "--healthcheck":
+		if len(args) != 1 {
+			return true, errors.New("healthcheck command does not accept arguments")
+		}
+		return true, runHealthcheckCommand()
 	case "admin":
 		return true, runAdminCommand(args[1:], input, output)
 	default:
 		return false, nil
 	}
+}
+
+func runHealthcheckCommand() error {
+	dbPath := strings.TrimSpace(os.Getenv("DB_PATH"))
+	if dbPath == "" {
+		dbPath = "/app/data/meridian.db"
+	}
+	markerPath := filepath.Join(filepath.Dir(dbPath), "panel-port")
+	marker, err := os.ReadFile(markerPath)
+	if err != nil {
+		return fmt.Errorf("read panel port: %w", err)
+	}
+	port, err := strconv.Atoi(strings.TrimSpace(string(marker)))
+	if err != nil || port < 1 || port > 65535 {
+		return fmt.Errorf("invalid panel port %q", strings.TrimSpace(string(marker)))
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // Local loopback readiness probe.
+	}
+	defer transport.CloseIdleConnections()
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   4 * time.Second,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	var lastErr error
+	for _, scheme := range []string{"https", "http"} {
+		endpoint := fmt.Sprintf("%s://127.0.0.1:%d/api/auth/check", scheme, port)
+		resp, requestErr := client.Get(endpoint)
+		if requestErr != nil {
+			lastErr = requestErr
+			continue
+		}
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		closeErr := resp.Body.Close()
+		if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices && closeErr == nil {
+			return nil
+		}
+		lastErr = fmt.Errorf("%s returned HTTP %d", endpoint, resp.StatusCode)
+	}
+	return fmt.Errorf("panel healthcheck failed: %w", lastErr)
 }
 
 func runAdminCommand(args []string, input io.Reader, output io.Writer) error {

--- a/main.go
+++ b/main.go
@@ -16578,6 +16578,7 @@ func runHealthcheckCommand() error {
 		dbPath = "/app/data/meridian.db"
 	}
 	markerPath := filepath.Join(filepath.Dir(dbPath), "panel-port")
+	// #nosec G703 G304 -- DB_PATH is an administrator-controlled local database location; this only reads the sibling panel-port marker written by Meridian itself.
 	marker, err := os.ReadFile(markerPath)
 	if err != nil {
 		return fmt.Errorf("read panel port: %w", err)
@@ -16588,7 +16589,8 @@ func runHealthcheckCommand() error {
 	}
 
 	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // Local loopback readiness probe.
+		// #nosec G402 -- the healthcheck connects only to the fixed 127.0.0.1 host; the configured panel certificate normally names its public domain rather than loopback.
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 	defer transport.CloseIdleConnections()
 	client := &http.Client{
@@ -16601,6 +16603,7 @@ func runHealthcheckCommand() error {
 	var lastErr error
 	for _, scheme := range []string{"https", "http"} {
 		endpoint := fmt.Sprintf("%s://127.0.0.1:%d/api/auth/check", scheme, port)
+		// #nosec G704 -- scheme is selected from the fixed list above, host/path are constant loopback values, and port is range-validated.
 		resp, requestErr := client.Get(endpoint)
 		if requestErr != nil {
 			lastErr = requestErr

--- a/main_test.go
+++ b/main_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -1247,7 +1248,7 @@ func TestMobileModalKeepsBodyScrollableAndActionsVisible(t *testing.T) {
 	if !strings.Contains(string(appJS), "document.body.classList.remove('auth-checking')") {
 		t.Error("app must reveal the authenticated shell or login form after the auth check")
 	}
-	for _, asset := range []string{"/js/theme.js?v=1.8.29", "/css/style.css?v=1.8.29", "/js/pages/sites.js?v=1.8.29", "/js/pages/request-logs.js?v=1.8.29", "/js/app.js?v=1.8.29"} {
+	for _, asset := range []string{"/js/theme.js?v=1.8.30", "/css/style.css?v=1.8.30", "/js/pages/sites.js?v=1.8.30", "/js/pages/request-logs.js?v=1.8.30", "/js/app.js?v=1.8.30"} {
 		if !strings.Contains(string(indexHTML), asset) {
 			t.Errorf("index must cache-bust updated asset %q", asset)
 		}
@@ -1816,6 +1817,47 @@ func TestResetAdminPasswordAcceptsLengthBoundaries(t *testing.T) {
 		if _, err := app.db.VerifyUser("admin", password); err != nil {
 			t.Fatalf("length %d password did not verify: %v", length, err)
 		}
+	}
+}
+
+func TestInternalHealthcheckUsesTLSWithoutExternalHelpers(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/auth/check" {
+			t.Fatalf("healthcheck path = %q", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	parsed, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse TLS server URL: %v", err)
+	}
+	_, port, err := net.SplitHostPort(parsed.Host)
+	if err != nil {
+		t.Fatalf("split TLS server address: %v", err)
+	}
+	dataDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dataDir, "panel-port"), []byte(port), 0600); err != nil {
+		t.Fatalf("write panel port marker: %v", err)
+	}
+	t.Setenv("DB_PATH", filepath.Join(dataDir, "meridian.db"))
+
+	handled, err := runCommandLine([]string{"--healthcheck"}, strings.NewReader(""), io.Discard)
+	if err != nil || !handled {
+		t.Fatalf("healthcheck handled=%v err=%v", handled, err)
+	}
+
+	dockerfile, err := os.ReadFile("Dockerfile")
+	if err != nil {
+		t.Fatalf("read Dockerfile: %v", err)
+	}
+	contents := string(dockerfile)
+	if !strings.Contains(contents, `CMD ["/app/meridian", "--healthcheck"]`) {
+		t.Fatal("Docker healthcheck must execute Meridian directly")
+	}
+	if strings.Contains(contents, "wget --no-check-certificate") {
+		t.Fatal("Docker healthcheck must not spawn BusyBox ssl_client zombies")
 	}
 }
 

--- a/main_video_stream_test.go
+++ b/main_video_stream_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -51,6 +53,15 @@ func TestMainVideoDirectModeRedirectsOnlyMainVideo(t *testing.T) {
 	var upstreamHits atomic.Int64
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		upstreamHits.Add(1)
+		if r.URL.Path == "/base/Videos/1/stream.mkv" {
+			if r.Header.Get("Range") != "bytes=0-1" || r.Header.Get("X-Emby-Token") != "client-token" {
+				t.Errorf("direct probe headers = %#v", r.Header)
+			}
+			w.Header().Set("Content-Range", "bytes 0-1/10")
+			w.WriteHeader(http.StatusPartialContent)
+			_, _ = io.WriteString(w, "video-body-must-not-cross")
+			return
+		}
 		_, _ = io.WriteString(w, "proxied:"+r.URL.Path)
 	}))
 	defer upstream.Close()
@@ -77,7 +88,13 @@ func TestMainVideoDirectModeRedirectsOnlyMainVideo(t *testing.T) {
 
 	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
 	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
-	resp, err := client.Get(baseURL + "/Videos/1/stream.mkv?api_key=client-visible")
+	req, err := http.NewRequest(http.MethodGet, baseURL+"/Videos/1/stream.mkv?api_key=client-visible", nil)
+	if err != nil {
+		t.Fatalf("build direct main video request: %v", err)
+	}
+	req.Header.Set("Range", "bytes=0-1")
+	req.Header.Set("X-Emby-Token", "client-token")
+	resp, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("request direct main video: %v", err)
 	}
@@ -86,8 +103,8 @@ func TestMainVideoDirectModeRedirectsOnlyMainVideo(t *testing.T) {
 	if resp.StatusCode != http.StatusTemporaryRedirect || !strings.HasSuffix(location, "/base/Videos/1/stream.mkv?api_key=client-visible") || strings.Contains(location, "origin_secret") {
 		t.Fatalf("direct response status=%d Location=%q", resp.StatusCode, location)
 	}
-	if got := upstreamHits.Load(); got != 0 {
-		t.Fatalf("direct main video reached upstream %d times", got)
+	if got := upstreamHits.Load(); got != 1 {
+		t.Fatalf("direct main video probe reached upstream %d times, want 1", got)
 	}
 
 	for _, path := range []string{"/media/segment.ts", "/Videos/1/Subtitles/2/Stream.ass", "/System/Info/Public"} {
@@ -101,8 +118,55 @@ func TestMainVideoDirectModeRedirectsOnlyMainVideo(t *testing.T) {
 			t.Fatalf("proxied path %s status=%d read=%v body=%q", path, resp.StatusCode, readErr, body)
 		}
 	}
-	if got := upstreamHits.Load(); got != 3 {
-		t.Fatalf("non-main-video upstream hits = %d, want 3", got)
+	if got := upstreamHits.Load(); got != 4 {
+		t.Fatalf("total upstream hits = %d, want 4", got)
+	}
+}
+
+func TestMainVideoDirectTransportFallsBackWithoutProxyingOriginBody(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusPartialContent, http.StatusBadGateway} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			body := &redirectRuntimeCloseSpy{Reader: strings.NewReader("origin-video-body")}
+			fallback, err := url.Parse("https://origin.example.net/Videos/42/stream.mkv?api_key=client-visible")
+			if err != nil {
+				t.Fatalf("parse fallback: %v", err)
+			}
+			transport := &redirectFollowTransport{
+				base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					return &http.Response{StatusCode: status, Status: fmt.Sprintf("%d %s", status, http.StatusText(status)), Header: make(http.Header), Body: body, Request: req}, nil
+				}),
+				mainVideoDirect: true,
+				dynamicPolicy:   redirectRuntimePolicy(dynamicProfileCompatible, true),
+			}
+			req := httptest.NewRequest(http.MethodGet, "https://origin.example.net/Videos/42/stream.mkv", nil)
+			req = req.WithContext(context.WithValue(req.Context(), mainVideoDirectFallbackContextKey{}, fallback))
+			resp, roundTripErr := transport.RoundTrip(req)
+			if roundTripErr != nil {
+				t.Fatalf("direct fallback round trip: %v", roundTripErr)
+			}
+			if resp.StatusCode != http.StatusTemporaryRedirect || resp.Header.Get("Location") != fallback.String() || !body.closed.Load() {
+				t.Fatalf("fallback response status/location/bodyClosed=%d/%q/%t", resp.StatusCode, resp.Header.Get("Location"), body.closed.Load())
+			}
+		})
+	}
+}
+
+func TestMainVideoDirectTransportFallsBackWhenOriginProbeFails(t *testing.T) {
+	fallback, err := url.Parse("https://origin.example.net/Videos/42/stream.mkv")
+	if err != nil {
+		t.Fatalf("parse fallback: %v", err)
+	}
+	transport := &redirectFollowTransport{
+		base: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("origin unavailable")
+		}),
+		mainVideoDirect: true,
+	}
+	req := httptest.NewRequest(http.MethodGet, fallback.String(), nil)
+	req = req.WithContext(context.WithValue(req.Context(), mainVideoDirectFallbackContextKey{}, fallback))
+	resp, roundTripErr := transport.RoundTrip(req)
+	if roundTripErr != nil || resp == nil || resp.StatusCode != http.StatusTemporaryRedirect || resp.Header.Get("Location") != fallback.String() {
+		t.Fatalf("probe failure fallback response/error = %#v/%v", resp, roundTripErr)
 	}
 }
 

--- a/request_logs_test.go
+++ b/request_logs_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -31,7 +32,7 @@ func TestRequestLogQueueFiltersAndClear(t *testing.T) {
 
 	for _, event := range []requestLogEvent{
 		{SiteID: site.ID, SiteName: site.Name, ResourceCategory: requestLogCategoryPlayback, StatusCode: 200, ClientIP: "203.0.113.10", UserAgent: "CapyPlayer/1.1.3", BackendAddress: "https://media.example:443", Method: http.MethodPost, Path: "/Items/abc/PlaybackInfo"},
-		{SiteID: site.ID, SiteName: site.Name, ResourceCategory: requestLogCategoryVideo, StatusCode: 206, ClientIP: "203.0.113.14", UserAgent: "StreamPlayer/1.0", Method: http.MethodGet, Path: "/Videos/abc/stream"},
+		{SiteID: site.ID, SiteName: site.Name, ResourceCategory: requestLogCategoryStream, StatusCode: 206, ClientIP: "203.0.113.14", UserAgent: "StreamPlayer/1.0", Method: http.MethodGet, Path: "/Videos/abc/stream"},
 		{SiteID: site.ID, SiteName: site.Name, ResourceCategory: requestLogCategoryImage, StatusCode: 404, ClientIP: "203.0.113.11", UserAgent: "Hills/1.8", Method: http.MethodGet, Path: "/Items/abc/Images/Primary"},
 		{SiteID: site.ID, SiteName: site.Name, ResourceCategory: requestLogCategoryAuth, StatusCode: 401, ClientIP: "203.0.113.12", UserAgent: "Hills/1.8", Method: http.MethodPost, Path: "/Users/AuthenticateByName"},
 		{SiteID: site.ID, SiteName: site.Name, ResourceCategory: requestLogCategoryAPI, StatusCode: 503, ClientIP: "203.0.113.13", UserAgent: "Browser/1.0", Method: http.MethodGet, Path: "/System/Info"},
@@ -143,30 +144,116 @@ func TestRequestLogWriteFieldSettingsOmitOnlyNewLogValues(t *testing.T) {
 	}
 }
 
+func TestRequestLogPlaybackAndMetadataWriteSettingsAreIndependent(t *testing.T) {
+	db, err := openDB(filepath.Join(t.TempDir(), "request-log-resource-settings.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	site, err := db.CreateSite("resource-settings-node", freePort(t), "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	db.EnqueueRequestLog(requestLogEvent{SiteID: site.ID, SiteName: site.Name, ResourceCategory: requestLogCategoryPlayback, StatusCode: 200, Method: http.MethodPost, Path: "/Items/abc/PlaybackInfo"})
+	db.EnqueueRequestLog(requestLogEvent{SiteID: site.ID, SiteName: site.Name, ResourceCategory: requestLogCategoryMetadata, StatusCode: 200, Method: http.MethodGet, Path: "/Items"})
+	logs, err := db.ListRequestLogs(RequestLogFilter{Limit: 10})
+	if err != nil || len(logs) != 1 || logs[0].ResourceCategory != requestLogCategoryPlayback {
+		t.Fatalf("default resource logs=%#v err=%v", logs, err)
+	}
+
+	settings := db.currentSystemSettings()
+	settings.LogWritePlayback = false
+	settings.LogWriteMetadata = true
+	if err := db.saveSystemSettings(settings); err != nil {
+		t.Fatal(err)
+	}
+	db.EnqueueRequestLog(requestLogEvent{SiteID: site.ID, SiteName: site.Name, ResourceCategory: requestLogCategoryPlayback, StatusCode: 200, Method: http.MethodPost, Path: "/Items/def/PlaybackInfo"})
+	db.EnqueueRequestLog(requestLogEvent{SiteID: site.ID, SiteName: site.Name, ResourceCategory: requestLogCategoryMetadata, StatusCode: 200, Method: http.MethodGet, Path: "/Shows/NextUp"})
+	metadata, err := db.ListRequestLogs(RequestLogFilter{Category: requestLogCategoryMetadata, Limit: 10})
+	if err != nil || len(metadata) != 1 || metadata[0].Path != "/Shows/NextUp" {
+		t.Fatalf("metadata logs=%#v err=%v", metadata, err)
+	}
+	playback, err := db.ListRequestLogs(RequestLogFilter{Category: requestLogCategoryPlayback, Limit: 10})
+	if err != nil || len(playback) != 1 || playback[0].Path != "/Items/abc/PlaybackInfo" {
+		t.Fatalf("playback logs=%#v err=%v", playback, err)
+	}
+}
+
 func TestRequestLogClassificationAndSanitization(t *testing.T) {
 	cases := []struct {
-		path string
-		want string
+		path    string
+		want    string
+		upgrade bool
 	}{
 		{path: "/Items/abc/PlaybackInfo", want: requestLogCategoryPlayback},
-		{path: "/Videos/abc/stream", want: requestLogCategoryVideo},
-		{path: "/_meridian/d/capability", want: requestLogCategoryVideo},
-		{path: "/Items/abc/PlaybackInfo.m3u8", want: requestLogCategoryVideo},
+		{path: "/Sessions/Playing/Progress", want: requestLogCategoryPlaybackSync},
+		{path: "/Videos/abc/stream", want: requestLogCategoryStream},
+		{path: "/_meridian/d/capability", want: requestLogCategoryStream},
+		{path: "/Videos/abc/master.m3u8", want: requestLogCategoryManifest},
+		{path: "/Videos/abc/segment.m4s", want: requestLogCategorySegment},
 		{path: "/Items/abc/Images/Primary", want: requestLogCategoryImage},
+		{path: "/Items?Recursive=true", want: requestLogCategoryMetadata},
+		{path: "/Shows/NextUp", want: requestLogCategoryMetadata},
+		{path: "/Videos/abc/Subtitles/0/Stream.vtt", want: requestLogCategorySubtitle},
+		{path: "/web/app.js", want: requestLogCategoryAsset},
+		{path: "/socket", want: requestLogCategoryWebSocket, upgrade: true},
 		{path: "/Users/AuthenticateByName", want: requestLogCategoryAuth},
 		{path: "/System/Info", want: requestLogCategoryAPI},
 	}
 	for _, tc := range cases {
-		req := httptest.NewRequest(http.MethodGet, "http://media.example"+tc.path+"?api_key=secret", nil)
+		requestURL := "http://media.example" + tc.path
+		if !strings.Contains(requestURL, "?") {
+			requestURL += "?api_key=secret"
+		}
+		req := httptest.NewRequest(http.MethodGet, requestURL, nil)
 		req.RemoteAddr = "203.0.113.20:12345"
 		req.Header.Set("User-Agent", "Capy\r\nPlayer")
+		if tc.upgrade {
+			req.Header.Set("Connection", "Upgrade")
+			req.Header.Set("Upgrade", "websocket")
+		}
 		event := newRequestLogEvent(Site{ID: 7, Name: "node"}, req, nil)
 		if event.ResourceCategory != tc.want {
 			t.Fatalf("path %s category=%s want=%s", tc.path, event.ResourceCategory, tc.want)
 		}
-		if event.Path != tc.path || event.ClientIP != "203.0.113.20" || event.UserAgent != "CapyPlayer" {
+		wantPath := strings.SplitN(tc.path, "?", 2)[0]
+		if event.Path != wantPath || event.ClientIP != "203.0.113.20" || event.UserAgent != "CapyPlayer" {
 			t.Fatalf("event=%#v", event)
 		}
+	}
+}
+
+func TestRequestLogPlaybackSyncFilterIncludesLegacyRows(t *testing.T) {
+	db, err := openDB(filepath.Join(t.TempDir(), "request-log-playback-sync.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	site, err := db.CreateSite("playback-sync-node", freePort(t), "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range []requestLogEvent{
+		{SiteID: site.ID, SiteName: site.Name, ResourceCategory: requestLogCategoryPlaybackSync, StatusCode: 204, Method: http.MethodPost, Path: "/Sessions/Playing/Progress"},
+		{SiteID: site.ID, SiteName: site.Name, ResourceCategory: requestLogCategoryPlayback, StatusCode: 204, Method: http.MethodPost, Path: "/emby/Sessions/Playing/Stopped"},
+		{SiteID: site.ID, SiteName: site.Name, ResourceCategory: requestLogCategoryPlayback, StatusCode: 200, Method: http.MethodPost, Path: "/Items/abc/PlaybackInfo"},
+	} {
+		db.EnqueueRequestLog(event)
+	}
+
+	syncLogs, err := db.ListRequestLogs(RequestLogFilter{Category: requestLogCategoryPlaybackSync, Limit: 10})
+	if err != nil || len(syncLogs) != 2 {
+		t.Fatalf("playback sync logs=%#v err=%v", syncLogs, err)
+	}
+	for _, entry := range syncLogs {
+		if entry.ResourceCategory != requestLogCategoryPlaybackSync {
+			t.Fatalf("legacy playback sync row was not normalized: %#v", entry)
+		}
+	}
+	playbackLogs, err := db.ListRequestLogs(RequestLogFilter{Category: requestLogCategoryPlayback, Limit: 10})
+	if err != nil || len(playbackLogs) != 1 || playbackLogs[0].Path != "/Items/abc/PlaybackInfo" {
+		t.Fatalf("playback info logs=%#v err=%v", playbackLogs, err)
 	}
 }
 

--- a/system_settings.go
+++ b/system_settings.go
@@ -44,8 +44,12 @@ type SystemSettings struct {
 	LogRetryBackoffMS        int    `json:"log_retry_backoff_ms"`
 	LogTaskLeaseMS           int    `json:"log_task_lease_ms"`
 	LogWriteImage            bool   `json:"log_write_image"`
+	LogWritePlayback         bool   `json:"log_write_playback"`
 	LogWriteMetadata         bool   `json:"log_write_metadata"`
 	LogWriteVideo            bool   `json:"log_write_video"`
+	LogWriteSubtitle         bool   `json:"log_write_subtitle"`
+	LogWriteAsset            bool   `json:"log_write_asset"`
+	LogWriteWebSocket        bool   `json:"log_write_websocket"`
 	LogWriteAPI              bool   `json:"log_write_api"`
 	LogWriteAuth             bool   `json:"log_write_auth"`
 	LogWriteNode             bool   `json:"log_write_node"`
@@ -73,7 +77,7 @@ func defaultSystemSettings() SystemSettings {
 		ScheduleTimezone: beijingTimezoneOffsetMinutes,
 		LogEnabled:       true, LogLevel: "info", LogRetentionDays: 30, LogFlushThreshold: 1,
 		LogBatchSize: 50, LogRetryCount: 2, LogRetryBackoffMS: 75, LogTaskLeaseMS: 300000,
-		LogWriteImage: false, LogWriteMetadata: false, LogWriteVideo: true, LogWriteAPI: true, LogWriteAuth: true,
+		LogWriteImage: false, LogWritePlayback: true, LogWriteMetadata: false, LogWriteVideo: true, LogWriteSubtitle: true, LogWriteAsset: true, LogWriteWebSocket: true, LogWriteAPI: true, LogWriteAuth: true,
 		LogWriteNode: true, LogWriteCategory: true, LogWriteStatus: true, LogWriteClientIP: true, LogWriteUA: true, LogWriteBackendAddress: true, LogWriteTimeline: true,
 		LogDisplayClientIP: true, LogDisplayUA: true, LogDisplayBackendAddress: true, LogDisplayNode: true, LogDisplayCategory: true, LogDisplayStatus: true, LogDisplayTimeline: true, LogSearchMode: "like",
 	}
@@ -106,22 +110,23 @@ func normalizeSystemSettings(settings SystemSettings) (SystemSettings, error) {
 
 func (d *DB) loadSystemSettings() (SystemSettings, error) {
 	settings := defaultSystemSettings()
-	var enabled, writeImage, writeMetadata, writeVideo, writeAPI, writeAuth, writeNode, writeCategory, writeStatus, writeIP, writeColo, writeUA, writeBackendAddress, writeTimeline, displayIP, displayColo, displayUA, displayBackendAddress, displayNode, displayCategory, displayStatus, displayTimeline int
+	var enabled, writeImage, writePlayback, writeMetadata, writeVideo, writeSubtitle, writeAsset, writeWebSocket, writeAPI, writeAuth, writeNode, writeCategory, writeStatus, writeIP, writeColo, writeUA, writeBackendAddress, writeTimeline, displayIP, displayColo, displayUA, displayBackendAddress, displayNode, displayCategory, displayStatus, displayTimeline int
 	err := d.db.QueryRow(`SELECT ui_mode, ui_radius, probe_timeout_ms, ping_cache_minutes, schedule_timezone_offset,
 		log_enabled, log_level, log_retention_days, log_write_delay_minutes, log_flush_threshold, log_batch_size,
-		log_retry_count, log_retry_backoff_ms, log_task_lease_ms, log_write_image, log_write_metadata, log_write_video, log_write_api, log_write_auth,
+		log_retry_count, log_retry_backoff_ms, log_task_lease_ms, log_write_image, log_write_playback, log_write_metadata, log_write_video, log_write_subtitle, log_write_asset, log_write_websocket, log_write_api, log_write_auth,
 		log_write_node, log_write_category, log_write_status, log_write_client_ip, log_write_colo, log_write_ua, log_write_backend_address, log_write_timeline, log_display_client_ip, log_display_colo,
 		log_display_ua, log_display_backend_address, log_display_node, log_display_category, log_display_status, log_display_timeline, log_search_mode FROM system_settings WHERE id=1`).Scan(
 		&settings.UIMode, &settings.UIRadius, &settings.ProbeTimeoutMS, &settings.PingCacheMinutes, &settings.ScheduleTimezone,
 		&enabled, &settings.LogLevel, &settings.LogRetentionDays, &settings.LogWriteDelayMinutes, &settings.LogFlushThreshold, &settings.LogBatchSize,
-		&settings.LogRetryCount, &settings.LogRetryBackoffMS, &settings.LogTaskLeaseMS, &writeImage, &writeMetadata, &writeVideo, &writeAPI, &writeAuth,
+		&settings.LogRetryCount, &settings.LogRetryBackoffMS, &settings.LogTaskLeaseMS, &writeImage, &writePlayback, &writeMetadata, &writeVideo, &writeSubtitle, &writeAsset, &writeWebSocket, &writeAPI, &writeAuth,
 		&writeNode, &writeCategory, &writeStatus, &writeIP, &writeColo, &writeUA, &writeBackendAddress, &writeTimeline, &displayIP, &displayColo, &displayUA, &displayBackendAddress, &displayNode, &displayCategory, &displayStatus, &displayTimeline, &settings.LogSearchMode)
 	if err != nil {
 		return settings, err
 	}
 	settings.LogEnabled = enabled == 1
-	settings.LogWriteImage, settings.LogWriteMetadata = writeImage == 1, writeMetadata == 1
+	settings.LogWriteImage, settings.LogWritePlayback, settings.LogWriteMetadata = writeImage == 1, writePlayback == 1, writeMetadata == 1
 	settings.LogWriteVideo, settings.LogWriteAPI, settings.LogWriteAuth = writeVideo == 1, writeAPI == 1, writeAuth == 1
+	settings.LogWriteSubtitle, settings.LogWriteAsset, settings.LogWriteWebSocket = writeSubtitle == 1, writeAsset == 1, writeWebSocket == 1
 	settings.LogWriteNode, settings.LogWriteCategory, settings.LogWriteStatus = writeNode == 1, writeCategory == 1, writeStatus == 1
 	settings.LogWriteClientIP, settings.LogWriteColo, settings.LogWriteUA, settings.LogWriteBackendAddress = writeIP == 1, writeColo == 1, writeUA == 1, writeBackendAddress == 1
 	settings.LogWriteTimeline = writeTimeline == 1
@@ -146,12 +151,12 @@ func (d *DB) saveSystemSettings(settings SystemSettings) error {
 	}
 	_, err = d.db.Exec(`UPDATE system_settings SET ui_mode=?, ui_radius=?, probe_timeout_ms=?, ping_cache_minutes=?, schedule_timezone_offset=?,
 		log_enabled=?, log_level=?, log_retention_days=?, log_write_delay_minutes=?, log_flush_threshold=?, log_batch_size=?,
-		log_retry_count=?, log_retry_backoff_ms=?, log_task_lease_ms=?, log_write_image=?, log_write_metadata=?, log_write_video=?, log_write_api=?, log_write_auth=?,
+		log_retry_count=?, log_retry_backoff_ms=?, log_task_lease_ms=?, log_write_image=?, log_write_playback=?, log_write_metadata=?, log_write_video=?, log_write_subtitle=?, log_write_asset=?, log_write_websocket=?, log_write_api=?, log_write_auth=?,
 		log_write_node=?, log_write_category=?, log_write_status=?, log_write_client_ip=?, log_write_colo=?, log_write_ua=?, log_write_backend_address=?, log_write_timeline=?, log_display_client_ip=?, log_display_colo=?,
 		log_display_ua=?, log_display_backend_address=?, log_display_node=?, log_display_category=?, log_display_status=?, log_display_timeline=?, log_search_mode=?, updated_at=CURRENT_TIMESTAMP WHERE id=1`,
 		settings.UIMode, settings.UIRadius, settings.ProbeTimeoutMS, settings.PingCacheMinutes, settings.ScheduleTimezone,
 		sqliteBool(settings.LogEnabled), settings.LogLevel, settings.LogRetentionDays, settings.LogWriteDelayMinutes, settings.LogFlushThreshold, settings.LogBatchSize,
-		settings.LogRetryCount, settings.LogRetryBackoffMS, settings.LogTaskLeaseMS, sqliteBool(settings.LogWriteImage), sqliteBool(settings.LogWriteMetadata), sqliteBool(settings.LogWriteVideo), sqliteBool(settings.LogWriteAPI), sqliteBool(settings.LogWriteAuth),
+		settings.LogRetryCount, settings.LogRetryBackoffMS, settings.LogTaskLeaseMS, sqliteBool(settings.LogWriteImage), sqliteBool(settings.LogWritePlayback), sqliteBool(settings.LogWriteMetadata), sqliteBool(settings.LogWriteVideo), sqliteBool(settings.LogWriteSubtitle), sqliteBool(settings.LogWriteAsset), sqliteBool(settings.LogWriteWebSocket), sqliteBool(settings.LogWriteAPI), sqliteBool(settings.LogWriteAuth),
 		sqliteBool(settings.LogWriteNode), sqliteBool(settings.LogWriteCategory), sqliteBool(settings.LogWriteStatus), sqliteBool(settings.LogWriteClientIP), sqliteBool(settings.LogWriteColo), sqliteBool(settings.LogWriteUA), sqliteBool(settings.LogWriteBackendAddress), sqliteBool(settings.LogWriteTimeline), sqliteBool(settings.LogDisplayClientIP), sqliteBool(settings.LogDisplayColo),
 		sqliteBool(settings.LogDisplayUA), sqliteBool(settings.LogDisplayBackendAddress), sqliteBool(settings.LogDisplayNode), sqliteBool(settings.LogDisplayCategory), sqliteBool(settings.LogDisplayStatus), sqliteBool(settings.LogDisplayTimeline), settings.LogSearchMode)
 	if err != nil {

--- a/system_settings_test.go
+++ b/system_settings_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -10,7 +11,7 @@ func TestSystemSettingsDefaultsUseBeijingSchedule(t *testing.T) {
 	if settings.ScheduleTimezone != 480 {
 		t.Fatalf("schedule timezone = %d, want 480", settings.ScheduleTimezone)
 	}
-	if settings.LogEnabled != true || settings.LogBatchSize != 50 || settings.LogDisplayUA != true || settings.LogWriteImage || settings.LogWriteMetadata || !settings.LogWriteVideo || !settings.LogWriteAPI || !settings.LogWriteAuth || !settings.LogWriteNode || !settings.LogWriteCategory || !settings.LogWriteStatus || !settings.LogWriteClientIP || !settings.LogWriteUA || !settings.LogWriteTimeline {
+	if settings.LogEnabled != true || settings.LogBatchSize != 50 || settings.LogDisplayUA != true || settings.LogWriteImage || !settings.LogWritePlayback || settings.LogWriteMetadata || !settings.LogWriteVideo || !settings.LogWriteSubtitle || !settings.LogWriteAsset || !settings.LogWriteWebSocket || !settings.LogWriteAPI || !settings.LogWriteAuth || !settings.LogWriteNode || !settings.LogWriteCategory || !settings.LogWriteStatus || !settings.LogWriteClientIP || !settings.LogWriteUA || !settings.LogWriteTimeline {
 		t.Fatalf("unexpected defaults: %+v", settings)
 	}
 }
@@ -30,5 +31,30 @@ func TestSystemSettingsAllowManualScheduleTimezone(t *testing.T) {
 	normalized, err := normalizeSystemSettings(settings)
 	if err != nil || normalized.ScheduleTimezone != -300 {
 		t.Fatalf("manual timezone = %d, err = %v", normalized.ScheduleTimezone, err)
+	}
+}
+
+func TestLegacyMetadataWriteSettingMigratesToPlayback(t *testing.T) {
+	db, err := openDB(filepath.Join(t.TempDir(), "legacy-log-taxonomy.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.db.Exec(`UPDATE system_settings SET
+		log_write_playback=0,
+		log_write_metadata=1,
+		log_resource_taxonomy_version=0
+		WHERE id=1`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.migrateOnce(); err != nil {
+		t.Fatal(err)
+	}
+	var playback, metadata, version int
+	if err := db.db.QueryRow("SELECT log_write_playback, log_write_metadata, log_resource_taxonomy_version FROM system_settings WHERE id=1").Scan(&playback, &metadata, &version); err != nil {
+		t.Fatal(err)
+	}
+	if playback != 1 || metadata != 0 || version != 1 {
+		t.Fatalf("migrated taxonomy = playback:%d metadata:%d version:%d", playback, metadata, version)
 	}
 }

--- a/tests/request_logs.test.js
+++ b/tests/request_logs.test.js
@@ -46,6 +46,27 @@ test('global log write settings cover every visible request log column', () => {
   }
 });
 
+test('global log resource settings cover the complete request taxonomy', () => {
+  const source = fs.readFileSync(
+    path.join(__dirname, '..', 'web', 'static', 'js', 'pages', 'global-settings.js'),
+    'utf8',
+  );
+  for (const [id, property] of [
+    ['setting-write-playback', 'log_write_playback'],
+    ['setting-write-video', 'log_write_video'],
+    ['setting-write-image', 'log_write_image'],
+    ['setting-write-metadata', 'log_write_metadata'],
+    ['setting-write-subtitle', 'log_write_subtitle'],
+    ['setting-write-asset', 'log_write_asset'],
+    ['setting-write-websocket', 'log_write_websocket'],
+    ['setting-write-api', 'log_write_api'],
+    ['setting-write-auth', 'log_write_auth'],
+  ]) {
+    assert.match(source, new RegExp(id));
+    assert.match(source, new RegExp(`s\\.${property} = checkedSetting`));
+  }
+});
+
 test('global settings rendering stays scoped to the active page and keeps cached content visible', () => {
   const source = fs.readFileSync(
     path.join(__dirname, '..', 'web', 'static', 'js', 'pages', 'global-settings.js'),
@@ -62,8 +83,16 @@ test('global settings rendering stays scoped to the active page and keeps cached
 test('request log helpers map categories and status colors', () => {
   const sandbox = loadRequestLogHelpers();
   assert.equal(sandbox.requestLogCategoryLabel('playback'), '播放信息');
+  assert.equal(sandbox.requestLogCategoryLabel('playback_sync'), '播放状态同步');
   assert.equal(sandbox.requestLogCategoryLabel('video'), '视频流');
+  assert.equal(sandbox.requestLogCategoryLabel('stream'), '主视频流');
+  assert.equal(sandbox.requestLogCategoryLabel('manifest'), '播放清单');
+  assert.equal(sandbox.requestLogCategoryLabel('segment'), '媒体分片');
   assert.equal(sandbox.requestLogCategoryLabel('image'), '图片海报');
+  assert.equal(sandbox.requestLogCategoryLabel('metadata'), '媒体元数据');
+  assert.equal(sandbox.requestLogCategoryLabel('subtitle'), '字幕');
+  assert.equal(sandbox.requestLogCategoryLabel('asset'), '静态资源');
+  assert.equal(sandbox.requestLogCategoryLabel('websocket'), 'WebSocket');
   assert.equal(sandbox.requestLogCategoryLabel('api'), '常规 API');
   assert.equal(sandbox.requestLogCategoryLabel('auth'), '用户认证');
   assert.equal(sandbox.requestLogCategoryLabel(''), '—');
@@ -72,12 +101,16 @@ test('request log helpers map categories and status colors', () => {
   assert.equal(sandbox.requestLogStatusClass(503), 'request-log-status-server');
 });
 
-test('request log panel exposes video stream filtering and live refresh', () => {
+test('request log panel exposes only concrete resource-category filters and live refresh', () => {
   const source = fs.readFileSync(
     path.join(__dirname, '..', 'web', 'static', 'js', 'pages', 'request-logs.js'),
     'utf8',
   );
-  assert.match(source, /data-category="video">只看视频流/);
+  for (const category of ['playback', 'playback_sync', 'stream', 'manifest', 'segment', 'image', 'metadata', 'subtitle', 'asset', 'websocket', 'api', 'auth']) {
+    assert.match(source, new RegExp(`data-category="${category}"`));
+  }
+  assert.doesNotMatch(source, /data-category="video"/);
+  assert.doesNotMatch(source, /request-log-advanced-filters|<details|高级分类/);
   assert.match(source, /requestLogRefreshTimer = setInterval/);
   assert.match(source, /Router\.current === 'request-logs'/);
   assert.match(source, /class="request-log-ip mono"/);
@@ -200,6 +233,21 @@ test('request log UA width slider stays compact', () => {
   );
   assert.match(source, /\.request-log-ua-width-control\s*\{[^}]*max-width:\s*380px;/s);
   assert.match(source, /\.request-log-ua-width-control input\[type="range"\]\s*\{[^}]*max-width:\s*220px;/s);
+});
+
+test('mobile request log table uses fixed readable columns without overlap', () => {
+  const source = fs.readFileSync(
+    path.join(__dirname, '..', 'web', 'static', 'css', 'style.css'),
+    'utf8',
+  );
+  assert.match(source, /\.request-log-table col\.request-log-col-node,\s*\.request-log-table th:nth-child\(1\)\s*\{\s*width:\s*112px !important;/s);
+  assert.match(source, /\.request-log-table col\.request-log-col-category,\s*\.request-log-table th:nth-child\(2\)\s*\{\s*width:\s*144px !important;/s);
+  assert.match(source, /\.request-log-table col\.request-log-col-status,\s*\.request-log-table th:nth-child\(3\)\s*\{\s*width:\s*76px !important;/s);
+  assert.match(source, /\.request-log-table col\.request-log-col-ip,\s*\.request-log-table th:nth-child\(4\)\s*\{\s*width:\s*170px !important;/s);
+  assert.match(source, /\.request-log-table tbody tr\s*\{\s*height:\s*58px;/s);
+  assert.match(source, /\.request-log-table th,\s*\.request-log-table td\s*\{[^}]*overflow:\s*hidden;[^}]*padding:\s*10px 12px;[^}]*font-size:\s*13px;[^}]*line-height:\s*1\.3;/s);
+  assert.match(source, /\.request-log-category,\s*\.request-log-node,\s*\.request-log-status\s*\{\s*white-space:\s*nowrap;/s);
+  assert.match(source, /\.request-log-table th\s*\{[^}]*font-size:\s*12px;[^}]*white-space:\s*nowrap;/s);
 });
 
 test('request log timeline uses concise Chinese relative time', () => {

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -4873,4 +4873,59 @@ html { font-size: 15px; }
     border-top: 1px solid var(--panel-border);
     text-align: left;
   }
+
+  /* Keep the mobile log table dense enough to scan several requests at once. */
+  .request-log-table {
+    width: calc(844px + var(--request-log-ua-width, 240px));
+    min-width: calc(844px + var(--request-log-ua-width, 240px));
+  }
+  .request-log-table col.request-log-col-node,
+  .request-log-table th:nth-child(1) { width: 112px !important; }
+  .request-log-table col.request-log-col-category,
+  .request-log-table th:nth-child(2) { width: 144px !important; }
+  .request-log-table col.request-log-col-status,
+  .request-log-table th:nth-child(3) { width: 76px !important; }
+  .request-log-table col.request-log-col-ip,
+  .request-log-table th:nth-child(4) { width: 170px !important; }
+  .request-log-table col.request-log-col-ua,
+  .request-log-table th:nth-child(5) { width: var(--request-log-ua-width, 240px) !important; }
+  .request-log-table col.request-log-col-backend,
+  .request-log-table th:nth-child(6) { width: 220px !important; }
+  .request-log-table col.request-log-col-time,
+  .request-log-table th:nth-child(7) { width: 122px !important; }
+  .request-log-table tbody tr { height: 58px; }
+  .request-log-table th,
+  .request-log-table td {
+    overflow: hidden;
+    padding: 10px 12px;
+    font-size: 13px;
+    line-height: 1.3;
+  }
+  .request-log-table th {
+    font-size: 12px;
+    line-height: 1.2;
+    white-space: nowrap;
+  }
+  .request-log-category,
+  .request-log-node,
+  .request-log-status {
+    white-space: nowrap;
+  }
+  .request-log-node {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .request-log-category {
+    max-width: 100%;
+    overflow: hidden;
+    font-size: 12px;
+    text-overflow: ellipsis;
+  }
+  .request-log-ip,
+  .request-log-ua,
+  .request-log-backend {
+    line-height: 1.3;
+  }
+  .request-log-region { font-size: 11px; line-height: 1.2; }
 }

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -6,8 +6,8 @@
 <title>Meridian — Emby 反代管理面板</title>
 <meta name="description" content="Meridian 轻量级 Emby 反向代理管理面板">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg?v=1.8.0">
-<script src="/js/theme.js?v=1.8.29"></script>
-<link rel="stylesheet" href="/css/style.css?v=1.8.29">
+<script src="/js/theme.js?v=1.8.30"></script>
+<link rel="stylesheet" href="/css/style.css?v=1.8.30">
 </head>
 <body class="auth-checking">
 
@@ -46,7 +46,7 @@
     <div class="sidebar-brand">
       <img src="/favicon.svg" alt="" class="sidebar-logo">
       <span class="sidebar-brand-name">Meridian</span>
-      <span class="sidebar-version" id="sidebar-version">v1.8.29</span>
+      <span class="sidebar-version" id="sidebar-version">v1.8.30</span>
     </div>
     <nav class="sidebar-nav" aria-label="功能菜单">
       <a href="#dashboard" class="topnav-link active" data-page="dashboard" title="仪表盘">
@@ -135,17 +135,17 @@
 <!-- Login errors must remain visible while the application shell is hidden. -->
 <div id="toast-container" aria-live="polite"></div>
 
-<script src="/js/api.js?v=1.8.29"></script>
-<script src="/js/toast.js?v=1.8.29"></script>
-<script src="/js/router.js?v=1.8.29"></script>
-<script src="/js/pages/dashboard.js?v=1.8.29"></script>
-<script src="/js/pages/sites.js?v=1.8.29"></script>
-<script src="/js/pages/traffic.js?v=1.8.29"></script>
-<script src="/js/pages/diag.js?v=1.8.29"></script>
-<script src="/js/pages/request-logs.js?v=1.8.29"></script>
-<script src="/js/pages/telegram-report.js?v=1.8.29"></script>
-<script src="/js/pages/global-settings.js?v=1.8.29"></script>
-<script src="/js/pages/account.js?v=1.8.29"></script>
-<script src="/js/app.js?v=1.8.29"></script>
+<script src="/js/api.js?v=1.8.30"></script>
+<script src="/js/toast.js?v=1.8.30"></script>
+<script src="/js/router.js?v=1.8.30"></script>
+<script src="/js/pages/dashboard.js?v=1.8.30"></script>
+<script src="/js/pages/sites.js?v=1.8.30"></script>
+<script src="/js/pages/traffic.js?v=1.8.30"></script>
+<script src="/js/pages/diag.js?v=1.8.30"></script>
+<script src="/js/pages/request-logs.js?v=1.8.30"></script>
+<script src="/js/pages/telegram-report.js?v=1.8.30"></script>
+<script src="/js/pages/global-settings.js?v=1.8.30"></script>
+<script src="/js/pages/account.js?v=1.8.30"></script>
+<script src="/js/app.js?v=1.8.30"></script>
 </body>
 </html>

--- a/web/static/js/pages/global-settings.js
+++ b/web/static/js/pages/global-settings.js
@@ -120,9 +120,11 @@ function renderLogSettingsForm(s) {
     ${settingsNumber('setting-log-lease', '定时任务租约时长', s.log_task_lease_ms, 1000, 900000, 'ms')}
   </div></section>
   <section class="settings-panel"><header><span>RESOURCE CATEGORIES</span><h2>资源类别写入</h2><b>默认按需写入</b></header><p class="settings-panel-help">图片海报与媒体元数据默认不写入。勾选后，后续命中的请求才会写入日志，并自然出现在日志页中。</p><div class="settings-grid">
-    ${settingsCheck('setting-write-playback', '媒体元数据', s.log_write_metadata === true, 'PlaybackInfo 等媒体元数据请求。')}${settingsCheck('setting-write-video', '视频流', s.log_write_video !== false, '视频流、HLS 与 DASH 请求。')}
-    ${settingsCheck('setting-write-image', '图片海报', s.log_write_image === true, '图片与海报资源请求。')}${settingsCheck('setting-write-api', '常规 API', s.log_write_api !== false, '普通 API 与状态查询请求。')}
-    ${settingsCheck('setting-write-auth', '用户认证', s.log_write_auth !== false, '登录、鉴权与会话请求。')}
+    ${settingsCheck('setting-write-playback', '播放信息与状态同步', s.log_write_playback !== false, 'PlaybackInfo，以及 Sessions/Playing、Progress、Stopped、Ping 等播放状态同步请求。')}${settingsCheck('setting-write-video', '视频流', s.log_write_video !== false, '主视频或音频流、HLS/DASH 清单与媒体分片。')}
+    ${settingsCheck('setting-write-image', '图片海报', s.log_write_image === true, 'Images、Icons、Branding、封面与常见图片文件。')}${settingsCheck('setting-write-metadata', '媒体元数据', s.log_write_metadata === true, 'Items、Shows、Movies 与 Users 等媒体资料请求。')}
+    ${settingsCheck('setting-write-api', '常规 API', s.log_write_api !== false, '不属于其他明确类别的普通 API 与状态查询请求。')}${settingsCheck('setting-write-auth', '用户认证', s.log_write_auth !== false, 'Authenticate 与 QuickConnect 等登录认证请求。')}
+    ${settingsCheck('setting-write-subtitle', '字幕', s.log_write_subtitle !== false, '字幕路径以及 SRT、ASS、VTT 等字幕文件。')}${settingsCheck('setting-write-asset', '静态资源', s.log_write_asset !== false, 'JavaScript、CSS、字体、Source Map 与 Web Manifest。')}
+    ${settingsCheck('setting-write-websocket', 'WebSocket', s.log_write_websocket !== false, '带 Upgrade 意图的实时连接请求。')}
   </div></section>
   <div class="settings-two-column"><section class="settings-panel"><header><span>WRITE</span><h2>日志字段写入</h2><b>仅影响后续新日志</b></header><p class="settings-panel-help">关闭后，新写入日志会直接省略对应字段；旧日志不会被回收或改写。</p>${settingsCheck('setting-write-node', '写入节点', s.log_write_node !== false, '保存请求命中的站点节点名称。')}${settingsCheck('setting-write-category', '写入资源类别', s.log_write_category !== false, '保存媒体元数据、视频流、图片海报、API 或认证类别。')}${settingsCheck('setting-write-status', '写入状态', s.log_write_status !== false, '保存请求返回的 HTTP 状态码。')}${settingsCheck('setting-write-ip', '写入客户端 IP', s.log_write_client_ip !== false, '保存访问来源 IP，便于区分客户端。')}${settingsCheck('setting-write-ua', '写入 UA', s.log_write_ua !== false, '保存客户端 UA，用于识别播放客户端。')}${settingsCheck('setting-write-backend-address', '写入后端地址', s.log_write_backend_address !== false, '保存该请求实际连接的推流后端 authority，不写入路径、查询参数或令牌。')}${settingsCheck('setting-write-timeline', '写入时间线', s.log_write_timeline !== false, '保存日志页展示的请求发生时间；内部清理与统计时间不受影响。')}</section>
   <section class="settings-panel"><header><span>DISPLAY</span><h2>日志字段展示</h2><b>仅影响日志页</b></header><p class="settings-panel-help">关闭后，字段仍可按写入设置保留在新日志里，但日志表格会隐藏对应列。</p>${settingsCheck('setting-display-node', '展示节点', s.log_display_node !== false, '在日志表格中显示节点名称。')}${settingsCheck('setting-display-category', '展示资源类别', s.log_display_category !== false, '在日志表格中显示资源类别。')}${settingsCheck('setting-display-status', '展示状态', s.log_display_status !== false, '在日志表格中显示 HTTP 状态码。')}${settingsCheck('setting-display-ip', '展示客户端 IP', s.log_display_client_ip !== false, '在日志表格中显示客户端 IP 列。')}${settingsCheck('setting-display-ua', '展示 UA', s.log_display_ua !== false, '在日志表格中显示 UA 列。')}${settingsCheck('setting-display-backend-address', '展示后端地址', s.log_display_backend_address !== false, '在日志表格中显示该请求最终使用的推流后端。')}${settingsCheck('setting-display-timeline', '展示时间线', s.log_display_timeline !== false, '在日志表格中显示请求相对时间。')}</section></div>
@@ -163,9 +165,13 @@ async function saveGlobalSettings() {
     s.log_retry_count = numericSetting('setting-log-retries', s.log_retry_count);
     s.log_retry_backoff_ms = numericSetting('setting-log-backoff', s.log_retry_backoff_ms);
     s.log_task_lease_ms = numericSetting('setting-log-lease', s.log_task_lease_ms);
-    s.log_write_image = checkedSetting('setting-write-image', true);
-    s.log_write_metadata = checkedSetting('setting-write-playback', true);
+    s.log_write_image = checkedSetting('setting-write-image', false);
+    s.log_write_playback = checkedSetting('setting-write-playback', true);
+    s.log_write_metadata = checkedSetting('setting-write-metadata', false);
     s.log_write_video = checkedSetting('setting-write-video', true);
+    s.log_write_subtitle = checkedSetting('setting-write-subtitle', true);
+    s.log_write_asset = checkedSetting('setting-write-asset', true);
+    s.log_write_websocket = checkedSetting('setting-write-websocket', true);
     s.log_write_api = checkedSetting('setting-write-api', true);
     s.log_write_auth = checkedSetting('setting-write-auth', true);
     s.log_write_node = checkedSetting('setting-write-node', true);

--- a/web/static/js/pages/request-logs.js
+++ b/web/static/js/pages/request-logs.js
@@ -79,8 +79,16 @@ function requestLogRangeMilliseconds(fromValue, toValue) {
 function requestLogCategoryLabel(category) {
   return ({
     playback: '播放信息',
+    playback_sync: '播放状态同步',
     video: '视频流',
+    stream: '主视频流',
+    manifest: '播放清单',
+    segment: '媒体分片',
     image: '图片海报',
+    metadata: '媒体元数据',
+    subtitle: '字幕',
+    asset: '静态资源',
+    websocket: 'WebSocket',
     api: '常规 API',
     auth: '用户认证',
   })[category] || '—';
@@ -141,11 +149,18 @@ function renderRequestLogs() {
       <div class="request-log-filter-row">
         <span class="request-log-filter-label">筛选模式</span>
         <div class="request-log-pills" id="request-log-category-pills">
-          <button type="button" class="request-log-pill active" data-category="all">全部模式</button>
-          <button type="button" class="request-log-pill" data-category="playback">只看播放信息</button>
-          <button type="button" class="request-log-pill" data-category="video">只看视频流</button>
-          <button type="button" class="request-log-pill" data-category="image">只看图片海报</button>
-          <button type="button" class="request-log-pill" data-category="api">只看常规 API</button>
+          <button type="button" class="request-log-pill active" data-category="all">全部</button>
+          <button type="button" class="request-log-pill" data-category="playback">播放信息</button>
+          <button type="button" class="request-log-pill" data-category="playback_sync">播放状态同步</button>
+          <button type="button" class="request-log-pill" data-category="stream">主视频流</button>
+          <button type="button" class="request-log-pill" data-category="manifest">播放清单</button>
+          <button type="button" class="request-log-pill" data-category="segment">媒体分片</button>
+          <button type="button" class="request-log-pill" data-category="image">图片海报</button>
+          <button type="button" class="request-log-pill" data-category="metadata">媒体元数据</button>
+          <button type="button" class="request-log-pill" data-category="subtitle">字幕</button>
+          <button type="button" class="request-log-pill" data-category="asset">静态资源</button>
+          <button type="button" class="request-log-pill" data-category="websocket">WebSocket</button>
+          <button type="button" class="request-log-pill" data-category="api">常规 API</button>
           <button type="button" class="request-log-pill" data-category="auth">用户认证</button>
         </div>
       </div>


### PR DESCRIPTION
## 改动内容

- 发布正式版 `v1.8.30`，统一后端、Docker、页面显示及静态资源缓存版本。
- 完善请求日志资源分类、后端地址记录、字段写入与展示设置。
- 精简日志筛选，移除聚合视频流和高级分类，平铺真实资源类别。
- 修复移动端日志布局、UA 列宽和时间线显示。
- 完善账户管理、登录错误提示及系统设置加载体验。
- 整理仓库 README、贡献指南、安全报告链接和本地忽略规则。
- 修正 CI 与 CodeQL 的默认分支监听，从 `master` 改为 `main`。

## 用户影响

日志页与全局设置更清晰，移动端显示更紧凑；主视频流策略保持 `v1.8.30-pre.6` 已验证行为，不包含后续多跳 OpenList 探测实验。

## 验证

- `go mod verify`
- `go test ./...`
- `go vet ./...`
- Windows amd64 与 macOS arm64 `go vet`
- Linux amd64 静态构建
- 全部前端 JavaScript 语法检查
- `node --test tests/*.test.js`（81 项通过）
- AWS 测试容器健康，11 个站点正常加载
