### PR TITLE
fix: harden agent reports, TLS state, backups, and release checks

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,33 @@
+name: Fuzz
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 3 * * 0'
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 12
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - FuzzNormalizeDynamicURL
+          - FuzzHLSRewrite
+          - FuzzDASHRewrite
+          - FuzzPlaybackInfoRewrite
+          - FuzzBackupArchiveParser
+          - FuzzEmbyAuthorizationParser
+          - FuzzDynamicCapabilityClaims
+          - FuzzCrossAuthorityHeaders
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      - name: Fuzz ${{ matrix.target }}
+        run: go test -run '^$' -fuzz '^${{ matrix.target }}$' -fuzztime 60s ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,16 @@ jobs:
           build darwin amd64 darwin-amd64
           build darwin arm64 darwin-arm64
 
+      - name: Verify release binary metadata
+        env:
+          RELEASE_TAG: ${{ needs.verify.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          test "$(./meridian-linux-amd64 --version)" = "$RELEASE_TAG"
+          test "$(./meridian-linux-amd64 --build-mode)" = "controller"
+          test "$(./meridian-agent-linux-amd64 --version)" = "$RELEASE_TAG"
+          test "$(./meridian-agent-linux-amd64 --build-mode)" = "agent"
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: meridian-release-binaries
@@ -167,6 +177,21 @@ jobs:
           subject-path: |
             meridian-*
             SHA256SUMS
+
+      - name: Refuse to mutate a published release
+        env:
+          RELEASE_TAG: ${{ needs.verify.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          # A published release is immutable from Meridian's workflow. This
+          # also protects manual reruns of an older tag from replacing assets
+          # that agents may already trust.
+          existing_draft="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+            --jq '.[] | select(.tag_name == env.RELEASE_TAG) | select(.draft == false) | .id' | head -n1)"
+          if [ -n "$existing_draft" ]; then
+            echo "Release ${RELEASE_TAG} is already published and cannot be mutated." >&2
+            exit 1
+          fi
 
       - name: Create Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2

--- a/agent_report_guard.go
+++ b/agent_report_guard.go
@@ -26,6 +26,88 @@ type nodeReportAdmission struct {
 	entries map[int64]*nodeReportAdmissionEntry
 }
 
+const (
+	agentPreAuthRatePerSecond = 10.0
+	agentPreAuthBurst         = 20.0
+	agentPreAuthEntryTTL      = 15 * time.Minute
+	agentPreAuthConcurrency   = 32
+)
+
+type agentPreAuthEntry struct {
+	tokens   float64
+	last     time.Time
+	lastSeen time.Time
+}
+
+// agentPreAuthAdmission is deliberately keyed by the trusted-proxy-aware
+// client identity rather than an Agent token. It runs before the SQLite token
+// lookup so a stream of invalid credentials cannot monopolize the sole DB
+// connection.
+type agentPreAuthAdmission struct {
+	mu      sync.Mutex
+	entries map[string]*agentPreAuthEntry
+	active  int
+}
+
+func newAgentPreAuthAdmission() *agentPreAuthAdmission {
+	return &agentPreAuthAdmission{entries: make(map[string]*agentPreAuthEntry)}
+}
+
+func (a *agentPreAuthAdmission) prune(now time.Time) {
+	for key, entry := range a.entries {
+		if now.Sub(entry.lastSeen) > agentPreAuthEntryTTL {
+			delete(a.entries, key)
+		}
+	}
+}
+
+func (a *agentPreAuthAdmission) admit(key string, now time.Time) (func(), time.Duration, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if key == "" {
+		key = "unknown"
+	}
+	a.prune(now)
+	if a.active >= agentPreAuthConcurrency {
+		return func() {}, time.Second, false
+	}
+	entry := a.entries[key]
+	if entry == nil {
+		entry = &agentPreAuthEntry{tokens: agentPreAuthBurst, last: now, lastSeen: now}
+		a.entries[key] = entry
+	}
+	if entry.last.IsZero() {
+		entry.last = now
+	}
+	if elapsed := now.Sub(entry.last).Seconds(); elapsed > 0 {
+		entry.tokens += elapsed * agentPreAuthRatePerSecond
+		if entry.tokens > agentPreAuthBurst {
+			entry.tokens = agentPreAuthBurst
+		}
+		entry.last = now
+	}
+	entry.lastSeen = now
+	if entry.tokens < 1 {
+		wait := time.Duration((1 - entry.tokens) / agentPreAuthRatePerSecond * float64(time.Second))
+		if wait < time.Millisecond {
+			wait = time.Millisecond
+		}
+		return func() {}, wait, false
+	}
+	entry.tokens--
+	a.active++
+	return func() {
+		a.mu.Lock()
+		if a.active > 0 {
+			a.active--
+		}
+		if current := a.entries[key]; current != nil {
+			current.lastSeen = time.Now()
+		}
+		a.mu.Unlock()
+	}, 0, true
+}
+
 func newNodeReportAdmission() *nodeReportAdmission {
 	return &nodeReportAdmission{entries: make(map[int64]*nodeReportAdmissionEntry)}
 }
@@ -98,4 +180,16 @@ func (a *App) agentReports() *nodeReportAdmission {
 		a.agentReportLimiter = newNodeReportAdmission()
 	}
 	return a.agentReportLimiter
+}
+
+func (a *App) agentPreAuthAdmission() *agentPreAuthAdmission {
+	if a == nil {
+		return newAgentPreAuthAdmission()
+	}
+	a.agentPreAuthMu.Lock()
+	defer a.agentPreAuthMu.Unlock()
+	if a.agentPreAuth == nil {
+		a.agentPreAuth = newAgentPreAuthAdmission()
+	}
+	return a.agentPreAuth
 }

--- a/agent_report_guard_test.go
+++ b/agent_report_guard_test.go
@@ -1,86 +1,75 @@
 package main
 
 import (
-	"sync"
 	"testing"
 	"time"
 )
 
-func TestNodeReportAdmissionLimitsBurstAndRefills(t *testing.T) {
-	guard := newNodeReportAdmission()
-	now := time.Unix(100, 0)
-	for i := 0; i < int(nodeReportBurst); i++ {
-		release, _, ok := guard.admit(7, now)
-		if !ok {
-			t.Fatalf("burst admission %d rejected", i)
-		}
-		release()
+func TestAgentSecurityAuditStateIsBoundedByNodeAndCategory(t *testing.T) {
+	db := &DB{}
+	for siteID := int64(1); siteID <= 100000; siteID++ {
+		db.recordAgentSecurityRejection(7, siteID, "request-event")
 	}
-	if release, _, ok := guard.admit(7, now); ok {
-		release()
-		t.Fatal("report beyond burst was admitted")
+	db.agentSecurityMu.Lock()
+	entries := len(db.agentSecurityLastLog)
+	db.agentSecurityMu.Unlock()
+	if entries != 1 {
+		t.Fatalf("security audit limiter retained %d site-specific entries, want 1", entries)
 	}
-	release, _, ok := guard.admit(7, now.Add(time.Second))
-	if !ok {
-		t.Fatal("one report should be admitted after one second")
-	}
-	release()
-}
-
-func TestNodeReportAdmissionSerializesOneReportPerNode(t *testing.T) {
-	guard := newNodeReportAdmission()
-	now := time.Unix(200, 0)
-	release, _, ok := guard.admit(9, now)
-	if !ok {
-		t.Fatal("first report rejected")
-	}
-	if secondRelease, _, secondOK := guard.admit(9, now); secondOK {
-		secondRelease()
-		t.Fatal("concurrent report for one node was admitted")
-	}
-	release()
-	if nextRelease, _, nextOK := guard.admit(9, now); !nextOK {
-		t.Fatal("report should be admitted after release")
-	} else {
-		nextRelease()
+	if got := db.agentSecurityRejected.Load(); got != 100000 {
+		t.Fatalf("rejection counter=%d, want 100000", got)
 	}
 }
 
-func TestNodeReportAdmissionKeepsNodesIndependentAndPrunesIdleEntries(t *testing.T) {
-	guard := newNodeReportAdmission()
+func TestAgentPreAuthAdmissionRateAndConcurrency(t *testing.T) {
+	admission := newAgentPreAuthAdmission()
 	now := time.Now()
-	releases := make([]func(), 0, 2)
-	for _, nodeID := range []int64{1, 2} {
-		release, _, ok := guard.admit(nodeID, now)
+	releases := make([]func(), 0, agentPreAuthConcurrency)
+	for i := 0; i < agentPreAuthConcurrency; i++ {
+		release, _, ok := admission.admit("client-"+string(rune('a'+i)), now)
 		if !ok {
-			t.Fatalf("node %d rejected", nodeID)
+			t.Fatalf("pre-auth admission %d was rejected before concurrency ceiling", i)
 		}
 		releases = append(releases, release)
+	}
+	if _, _, ok := admission.admit("other-client", now); ok {
+		t.Fatal("pre-auth concurrency ceiling was bypassed")
 	}
 	for _, release := range releases {
 		release()
 	}
-	guard.mu.Lock()
-	guard.prune(now.Add(nodeReportEntryTTL + time.Second))
-	guard.mu.Unlock()
-	if len(guard.entries) != 0 {
-		t.Fatalf("idle limiter entries remain: %d", len(guard.entries))
+	// A separate client has its own token bucket and is admitted immediately;
+	// a single noisy client is rate limited without affecting it.
+	for i := 0; i < agentPreAuthBurst; i++ {
+		release, _, ok := admission.admit("noisy", now)
+		if !ok {
+			t.Fatalf("burst admission %d was rejected", i)
+		}
+		release()
+	}
+	if _, _, ok := admission.admit("noisy", now); ok {
+		t.Fatal("pre-auth token bucket did not reject an exhausted client")
+	}
+	if release, _, ok := admission.admit("independent", now); !ok {
+		t.Fatal("one client's pre-auth limiter affected another client")
+	} else {
+		release()
 	}
 }
 
-func TestNodeReportAdmissionIsSafeForConcurrentNodes(t *testing.T) {
-	guard := newNodeReportAdmission()
+func TestNodeReportAdmissionReclaimsIdleEntries(t *testing.T) {
+	admission := newNodeReportAdmission()
 	now := time.Now()
-	var wg sync.WaitGroup
-	for i := int64(1); i <= 32; i++ {
-		wg.Add(1)
-		go func(nodeID int64) {
-			defer wg.Done()
-			release, _, ok := guard.admit(nodeID, now)
-			if ok {
-				release()
-			}
-		}(i)
+	release, _, ok := admission.admit(42, now)
+	if !ok {
+		t.Fatal("node report was rejected")
 	}
-	wg.Wait()
+	release()
+	admission.mu.Lock()
+	admission.prune(now.Add(nodeReportEntryTTL + time.Second))
+	_, exists := admission.entries[42]
+	admission.mu.Unlock()
+	if exists {
+		t.Fatal("idle node report limiter entry was not reclaimed")
+	}
 }

--- a/app_core.go
+++ b/app_core.go
@@ -36,6 +36,8 @@ type App struct {
 	tmdbOnce           sync.Once
 	agentReportMu      sync.Mutex
 	agentReportLimiter *nodeReportAdmission
+	agentPreAuthMu     sync.Mutex
+	agentPreAuth       *agentPreAuthAdmission
 }
 
 func (a *App) tmdbService() *tmdbService {

--- a/app_nodes.go
+++ b/app_nodes.go
@@ -648,8 +648,19 @@ func (a *App) handleAgentReport(w http.ResponseWriter, r *http.Request) {
 		a.jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
+	preRelease, retryAfter, preAdmitted := a.agentPreAuthAdmission().admit(requestClientKey(r, a.trustedProxies), time.Now())
+	if !preAdmitted {
+		seconds := int(retryAfter.Seconds())
+		if seconds < 1 {
+			seconds = 1
+		}
+		w.Header().Set("Retry-After", strconv.Itoa(seconds))
+		a.jsonErr(w, http.StatusTooManyRequests, "agent authentication rate limit exceeded")
+		return
+	}
 	token := requestBearerToken(r)
 	node, authErr := a.db.nodeByAgentToken(token, time.Now())
+	preRelease()
 	if authErr != nil {
 		a.jsonErr(w, http.StatusUnauthorized, "invalid agent token")
 		return
@@ -692,6 +703,15 @@ func (a *App) handleAgentReport(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+type agentWebSocketNodeContextKey struct{}
+
+func withAgentWebSocketNode(r *http.Request, node ControlNode) *http.Request {
+	if r == nil {
+		return r
+	}
+	return r.WithContext(context.WithValue(r.Context(), agentWebSocketNodeContextKey{}, node))
+}
+
 // handleAgentWebSocket is a control-plane heartbeat channel. It deliberately
 // shares RecordNodeReport with the POST fallback so sequence/event idempotency,
 // node traffic accounting, and metadata replay have one implementation.
@@ -700,9 +720,17 @@ func (a *App) handleAgentWebSocket(ws *websocket.Conn) {
 		return
 	}
 	token := requestBearerToken(ws.Request())
-	node, err := a.db.nodeByAgentToken(token, time.Now())
-	if err != nil {
-		return
+	node, ok := ws.Request().Context().Value(agentWebSocketNodeContextKey{}).(ControlNode)
+	if !ok || node.ID <= 0 {
+		// Keep direct handler tests and embedders functional when they do not
+		// install the main router's handshake context. The production router
+		// always supplies the authenticated node and therefore performs no
+		// second lookup for a connection.
+		var authErr error
+		node, authErr = a.db.nodeByAgentToken(token, time.Now())
+		if authErr != nil {
+			return
+		}
 	}
 	ws.MaxPayloadBytes = maxAgentReportBodyBytes
 	defer ws.Close()
@@ -710,23 +738,25 @@ func (a *App) handleAgentWebSocket(ws *websocket.Conn) {
 		if err := ws.SetReadDeadline(time.Now().Add(nodeOnlineWindow)); err != nil {
 			return
 		}
-		// Read only the bounded WebSocket frame before decoding it. The
-		// connection was authenticated above; admission is shared with the
-		// HTTP endpoint so a node cannot bypass its report budget by switching
-		// transports. MaxPayloadBytes bounds the frame allocation.
-		var payload []byte
-		if err := websocket.Message.Receive(ws, &payload); err != nil {
-			return
-		}
 		release, retryAfter, admitted := a.agentReports().admit(node.ID, time.Now())
 		if !admitted {
-			_ = ws.SetWriteDeadline(time.Now().Add(10 * time.Second))
+			// Do not receive or decode another frame after admission is denied.
+			// Closing prevents an over-limit peer from keeping the connection in
+			// a tight error loop while it continues sending large frames.
+			_ = ws.SetWriteDeadline(time.Now().Add(2 * time.Second))
 			_ = websocket.JSON.Send(ws, map[string]interface{}{
 				"accepted":            false,
 				"error":               "agent report rate or concurrency limit exceeded",
 				"retry_after_seconds": max(1, int(retryAfter.Seconds()+0.5)),
 			})
-			continue
+			return
+		}
+		// Read only the bounded WebSocket frame after admission. MaxPayloadBytes
+		// bounds the frame allocation before JSON decoding.
+		var payload []byte
+		if err := websocket.Message.Receive(ws, &payload); err != nil {
+			release()
+			return
 		}
 		var report NodeReport
 		if err := json.Unmarshal(payload, &report); err != nil {

--- a/backup_restore.go
+++ b/backup_restore.go
@@ -479,6 +479,32 @@ func (a *App) databaseSnapshot() (string, func(), error) {
 	if a == nil || a.db == nil || a.dbPath == "" || a.dbPath == ":memory:" || strings.HasPrefix(a.dbPath, "file:") {
 		return "", func() {}, errors.New("当前数据库模式不支持备份")
 	}
+	// VACUUM INTO must not be the first operation that discovers a nearly full
+	// filesystem. Account for the live database and SQLite sidecars before any
+	// snapshot directory is created. The later check covers the actual snapshot
+	// size, which may be larger after vacuuming.
+	var databaseBytes int64
+	for _, candidate := range []string{a.dbPath, a.dbPath + "-wal", a.dbPath + "-shm"} {
+		info, statErr := os.Stat(candidate)
+		if statErr == nil {
+			if !info.Mode().IsRegular() {
+				return "", func() {}, errors.New("数据库文件必须是普通文件")
+			}
+			databaseBytes += info.Size()
+		} else if !errors.Is(statErr, os.ErrNotExist) {
+			return "", func() {}, fmt.Errorf("检查数据库空间: %w", statErr)
+		}
+	}
+	if databaseBytes <= 0 {
+		databaseBytes = 1 << 20
+	}
+	archiveEstimate := databaseBytes
+	if archiveEstimate > backupMaxUploadBytes {
+		archiveEstimate = backupMaxUploadBytes
+	}
+	if err := ensureDiskSpace(filepath.Dir(a.dbPath), databaseBytes*2+archiveEstimate+(64<<20)); err != nil {
+		return "", func() {}, err
+	}
 	if a.pm != nil {
 		a.pm.FlushTraffic()
 	}
@@ -584,32 +610,53 @@ func addBackupEntry(writer *zip.Writer, files *[]string, expandedSize *int64, na
 	return nil
 }
 
-func (a *App) buildBackup(password string, includeTLS bool) ([]byte, error) {
+type builtBackupFile struct {
+	Path    string
+	Size    int64
+	Cleanup func()
+}
+
+func (a *App) buildBackupToFile(password string, includeTLS bool) (builtBackupFile, error) {
 	if err := validateBackupPassword(password); err != nil {
-		return nil, err
+		return builtBackupFile{}, err
 	}
 	if includeTLS && a != nil {
 		if err := validateTLSPathConfiguration(a.dbPath); err != nil {
-			return nil, fmt.Errorf("invalid TLS path configuration: %w", err)
+			return builtBackupFile{}, fmt.Errorf("invalid TLS path configuration: %w", err)
 		}
 	}
 	snapshot, cleanup, err := a.databaseSnapshot()
 	if err != nil {
-		return nil, err
+		return builtBackupFile{}, err
 	}
-	defer cleanup()
-
+	retainSnapshot := false
+	defer func() {
+		if !retainSnapshot {
+			cleanup()
+		}
+	}()
+	if info, statErr := os.Stat(snapshot); statErr == nil {
+		// Snapshot, ZIP, encrypted payload, and a small rollback margin coexist
+		// for the duration of export. Refuse early when the filesystem cannot hold
+		// those bounded temporary copies.
+		required := info.Size()*3 + 64<<20
+		if err := ensureDiskSpace(filepath.Dir(snapshot), required); err != nil {
+			return builtBackupFile{}, err
+		}
+	} else {
+		return builtBackupFile{}, statErr
+	}
 	archivePath := filepath.Join(filepath.Dir(snapshot), "archive.zip")
 	archiveFile, err := os.OpenFile(archivePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600) // #nosec G304 -- archivePath is inside the private snapshot directory.
 	if err != nil {
-		return nil, err
+		return builtBackupFile{}, err
 	}
 	defer archiveFile.Close()
 	zipWriter := zip.NewWriter(archiveFile)
 	files := make([]string, 0, 8)
 	expandedSize := int64(0)
 	if err := addBackupEntry(zipWriter, &files, &expandedSize, backupDatabaseEntry, snapshot); err != nil {
-		return nil, err
+		return builtBackupFile{}, err
 	}
 	if includeTLS {
 		certFile, keyFile := panelTLSBackupPaths(a.dbPath)
@@ -620,13 +667,13 @@ func (a *App) buildBackup(password string, includeTLS bool) ([]byte, error) {
 			certExists := certErr == nil
 			keyExists := keyErr == nil
 			if certExists != keyExists {
-				return nil, errors.New("面板 TLS 证书和私钥不成对，无法创建包含 TLS 的备份")
+				return builtBackupFile{}, errors.New("面板 TLS 证书和私钥不成对，无法创建包含 TLS 的备份")
 			}
 			if certErr != nil && !errors.Is(certErr, os.ErrNotExist) {
-				return nil, fmt.Errorf("检查面板 TLS 证书: %w", certErr)
+				return builtBackupFile{}, fmt.Errorf("检查面板 TLS 证书: %w", certErr)
 			}
 			if keyErr != nil && !errors.Is(keyErr, os.ErrNotExist) {
-				return nil, fmt.Errorf("检查面板 TLS 私钥: %w", keyErr)
+				return builtBackupFile{}, fmt.Errorf("检查面板 TLS 私钥: %w", keyErr)
 			}
 		}
 		tlsCandidates := []struct{ name, path string }{
@@ -645,7 +692,7 @@ func (a *App) buildBackup(password string, includeTLS bool) ([]byte, error) {
 				continue
 			}
 			if err := addBackupEntry(zipWriter, &files, &expandedSize, candidate.name, candidate.path); err != nil {
-				return nil, fmt.Errorf("读取 %s: %w", candidate.name, err)
+				return builtBackupFile{}, fmt.Errorf("读取 %s: %w", candidate.name, err)
 			}
 		}
 		// Per-node Edge certificates live behind an atomic current pointer.
@@ -654,7 +701,7 @@ func (a *App) buildBackup(password string, includeTLS bool) ([]byte, error) {
 		if edgeRoot := edgeNodeTLSRoot(a.dbPath); edgeRoot != "" {
 			entries, readErr := os.ReadDir(edgeRoot)
 			if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
-				return nil, fmt.Errorf("读取 Edge 节点证书目录: %w", readErr)
+				return builtBackupFile{}, fmt.Errorf("读取 Edge 节点证书目录: %w", readErr)
 			}
 			for _, entry := range entries {
 				if !entry.IsDir() {
@@ -671,24 +718,24 @@ func (a *App) buildBackup(password string, includeTLS bool) ([]byte, error) {
 						certExists := certErr == nil
 						keyExists := keyErr == nil
 						if certExists != keyExists {
-							return nil, fmt.Errorf("Edge 节点 %s 的证书和私钥不成对", guid)
+							return builtBackupFile{}, fmt.Errorf("Edge 节点 %s 的证书和私钥不成对", guid)
 						}
 						if !certExists {
 							if certErr != nil && !errors.Is(certErr, os.ErrNotExist) || keyErr != nil && !errors.Is(keyErr, os.ErrNotExist) {
-								return nil, fmt.Errorf("检查 Edge 节点 %s 证书: %v / %v", guid, certErr, keyErr)
+								return builtBackupFile{}, fmt.Errorf("检查 Edge 节点 %s 证书: %v / %v", guid, certErr, keyErr)
 							}
 							break
 						}
 					}
 					if addErr := addBackupEntry(zipWriter, &files, &expandedSize, name, path); addErr != nil {
-						return nil, fmt.Errorf("读取 %s: %w", name, addErr)
+						return builtBackupFile{}, fmt.Errorf("读取 %s: %w", name, addErr)
 					}
 				}
 			}
 		}
 	}
 	if len(files)+1 > backupMaxFiles {
-		return nil, errors.New("备份文件数量超过可恢复上限")
+		return builtBackupFile{}, errors.New("备份文件数量超过可恢复上限")
 	}
 	manifest := backupManifest{
 		Format:                "meridian-backup",
@@ -703,57 +750,63 @@ func (a *App) buildBackup(password string, includeTLS bool) ([]byte, error) {
 	}
 	manifestData, err := json.Marshal(manifest) // #nosec G117 -- the manifest is immediately encrypted before it leaves the process.
 	if err != nil {
-		return nil, err
+		return builtBackupFile{}, err
 	}
 	header := &zip.FileHeader{Name: backupManifestEntry, Method: zip.Deflate}
 	header.SetMode(0o600)
 	header.Modified = time.Unix(0, 0).UTC()
 	entry, err := zipWriter.CreateHeader(header)
 	if err != nil {
-		return nil, err
+		return builtBackupFile{}, err
 	}
 	if _, err := entry.Write(manifestData); err != nil {
-		return nil, err
+		return builtBackupFile{}, err
 	}
 	if expandedSize+int64(len(manifestData)) > backupMaxExpandedBytes {
-		return nil, errors.New("备份解压后总大小超出限制")
+		return builtBackupFile{}, errors.New("备份解压后总大小超出限制")
 	}
 	if err := zipWriter.Close(); err != nil {
-		return nil, err
+		return builtBackupFile{}, err
 	}
 	if err := archiveFile.Sync(); err != nil {
-		return nil, err
+		return builtBackupFile{}, err
 	}
 	if _, err := archiveFile.Seek(0, io.SeekStart); err != nil {
-		return nil, err
+		return builtBackupFile{}, err
 	}
 	payloadPath := filepath.Join(filepath.Dir(snapshot), "backup.mrbak")
 	payloadFile, err := os.OpenFile(payloadPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600) // #nosec G304 -- payloadPath is inside the private snapshot directory.
 	if err != nil {
-		return nil, err
+		return builtBackupFile{}, err
 	}
 	defer payloadFile.Close()
 	payloadSize, err := sealBackupV2Reader(archiveFile, password, payloadFile)
 	if err != nil {
-		return nil, err
+		return builtBackupFile{}, err
 	}
 	if payloadSize > backupMaxUploadBytes {
-		return nil, fmt.Errorf("生成的备份为 %d MiB，超过当前恢复接口支持的 %d MiB", payloadSize>>20, backupMaxUploadBytes>>20)
+		return builtBackupFile{}, fmt.Errorf("生成的备份为 %d MiB，超过当前恢复接口支持的 %d MiB", payloadSize>>20, backupMaxUploadBytes>>20)
 	}
 	if err := payloadFile.Sync(); err != nil {
-		return nil, err
+		return builtBackupFile{}, err
 	}
-	if _, err := payloadFile.Seek(0, io.SeekStart); err != nil {
-		return nil, err
+	if err := syncDirectory(filepath.Dir(payloadPath)); err != nil {
+		return builtBackupFile{}, err
 	}
-	payload, err := io.ReadAll(io.LimitReader(payloadFile, backupMaxUploadBytes+1))
+	retainSnapshot = true
+	return builtBackupFile{Path: payloadPath, Size: payloadSize, Cleanup: cleanup}, nil
+}
+
+// buildBackup keeps the byte-slice API for unit tests and legacy callers. The
+// production HTTP path uses buildBackupToFile so it never materializes the
+// final encrypted backup in memory.
+func (a *App) buildBackup(password string, includeTLS bool) ([]byte, error) {
+	artifact, err := a.buildBackupToFile(password, includeTLS)
 	if err != nil {
 		return nil, err
 	}
-	if int64(len(payload)) > backupMaxUploadBytes {
-		return nil, fmt.Errorf("生成的备份为 %d MiB，超过当前恢复接口支持的 %d MiB", len(payload)>>20, backupMaxUploadBytes>>20)
-	}
-	return payload, nil
+	defer artifact.Cleanup()
+	return os.ReadFile(artifact.Path) // #nosec G304 -- path is a private temporary backup artifact.
 }
 
 func readZipEntry(file *zip.File, maxBytes int64) ([]byte, error) {
@@ -798,6 +851,173 @@ func parseBackupArchiveFile(path string) (backupManifest, map[string][]byte, err
 		return backupManifest{}, nil, errors.New("备份压缩包损坏")
 	}
 	return parseBackupZipReader(reader)
+}
+
+// parseBackupArchiveFileToPaths validates a decrypted archive while keeping
+// each entry on disk. The restore path uses this variant so a legal large
+// backup never becomes an in-memory map[string][]byte.
+func parseBackupArchiveFileToPaths(path, entriesDir string) (backupManifest, map[string]string, error) {
+	var manifest backupManifest
+	file, err := os.Open(path) // #nosec G304 -- path is an internal restore staging file.
+	if err != nil {
+		return manifest, nil, err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return manifest, nil, err
+	}
+	reader, err := zip.NewReader(file, info.Size())
+	if err != nil {
+		return manifest, nil, errors.New("备份压缩包损坏")
+	}
+	if len(reader.File) < 2 || len(reader.File) > backupMaxFiles {
+		return manifest, nil, errors.New("备份文件数量无效")
+	}
+	if err := os.MkdirAll(entriesDir, 0o700); err != nil {
+		return manifest, nil, err
+	}
+	entries := make(map[string]string, len(reader.File))
+	var expanded int64
+	for index, archiveEntry := range reader.File {
+		limit, allowed := backupEntryLimit(archiveEntry.Name)
+		if !allowed || filepath.ToSlash(filepath.Clean(archiveEntry.Name)) != archiveEntry.Name || strings.HasPrefix(archiveEntry.Name, "/") {
+			return manifest, nil, fmt.Errorf("备份包含不允许的文件: %s", archiveEntry.Name)
+		}
+		if _, duplicate := entries[archiveEntry.Name]; duplicate {
+			return manifest, nil, fmt.Errorf("备份包含重复文件: %s", archiveEntry.Name)
+		}
+		if archiveEntry.UncompressedSize64 > uint64(limit) || archiveEntry.UncompressedSize64 > uint64(backupMaxExpandedBytes) { // #nosec G115 -- limits are fixed positive constants returned by backupEntryLimit.
+			return manifest, nil, fmt.Errorf("%s 解压后过大", archiveEntry.Name)
+		}
+		if archiveEntry.UncompressedSize64 > uint64(backupMaxExpandedBytes)-uint64(expanded) {
+			return manifest, nil, errors.New("备份解压后总大小超出限制")
+		}
+		expanded += int64(archiveEntry.UncompressedSize64)
+		entryPath := filepath.Join(entriesDir, fmt.Sprintf("%08d.entry", index))
+		if err := copyZipEntryToFile(archiveEntry, limit, entryPath); err != nil {
+			return manifest, nil, err
+		}
+		entries[archiveEntry.Name] = entryPath
+	}
+	manifestPath, ok := entries[backupManifestEntry]
+	if !ok {
+		return manifest, nil, errors.New("备份缺少清单")
+	}
+	manifestData, err := os.ReadFile(manifestPath) // #nosec G304 -- path is a private parser staging entry.
+	if err != nil {
+		return manifest, nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(manifestData))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&manifest); err != nil {
+		return manifest, nil, errors.New("备份清单无效")
+	}
+	if manifest.Format != "meridian-backup" || (manifest.FormatVersion != backupFormatVersion && manifest.FormatVersion != backupLegacyFormatVersion) {
+		return manifest, nil, errors.New("不支持的备份格式版本")
+	}
+	if manifest.DatabaseSchemaVersion > databaseSchemaVersion {
+		return manifest, nil, errors.New("该备份由更高数据库版本的 Meridian 创建，请先升级 Meridian 后再恢复")
+	}
+	if !manifestIncludesTLS(manifest) {
+		for name := range entries {
+			if strings.HasPrefix(name, "tls/") {
+				return manifest, nil, errors.New("备份清单声明不包含 TLS，但压缩包中存在 TLS 文件")
+			}
+		}
+	}
+	if _, ok := entries[backupDatabaseEntry]; !ok {
+		return manifest, nil, errors.New("备份缺少数据库")
+	}
+	declared := make(map[string]bool, len(manifest.Files)+1)
+	declared[backupManifestEntry] = true
+	for _, name := range manifest.Files {
+		if _, ok := backupEntryLimit(name); !ok || name == backupManifestEntry || declared[name] {
+			return manifest, nil, errors.New("备份清单文件列表无效")
+		}
+		declared[name] = true
+	}
+	if len(declared) != len(entries) {
+		return manifest, nil, errors.New("备份清单与文件内容不一致")
+	}
+	for name := range entries {
+		if !declared[name] {
+			return manifest, nil, errors.New("备份清单与文件内容不一致")
+		}
+	}
+	return manifest, entries, nil
+}
+
+func copyZipEntryToFile(file *zip.File, maxBytes int64, target string) error {
+	reader, err := file.Open()
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+	out, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) // #nosec G304 -- target is an internal parser staging path.
+	if err != nil {
+		return err
+	}
+	remove := true
+	defer func() {
+		_ = out.Close()
+		if remove {
+			_ = os.Remove(target)
+		}
+	}()
+	written, copyErr := io.Copy(out, io.LimitReader(reader, maxBytes+1))
+	if copyErr != nil {
+		return copyErr
+	}
+	if written > maxBytes {
+		return fmt.Errorf("%s 解压后过大", file.Name)
+	}
+	if err := out.Sync(); err != nil {
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	remove = false
+	return nil
+}
+
+func ensureRestoreDiskSpace(dbPath string, entries map[string]string) error {
+	if strings.TrimSpace(dbPath) == "" || len(entries) == 0 {
+		return nil
+	}
+	var incomingDB, incomingTLS, currentDB int64
+	if path := entries[backupDatabaseEntry]; path != "" {
+		if info, err := os.Stat(path); err == nil {
+			incomingDB = info.Size()
+		} else {
+			return err
+		}
+	}
+	if info, err := os.Stat(dbPath); err == nil {
+		currentDB = info.Size()
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	for name, path := range entries {
+		if !strings.HasPrefix(name, "tls/") {
+			continue
+		}
+		if info, err := os.Stat(path); err == nil {
+			incomingTLS += info.Size()
+		} else {
+			return err
+		}
+	}
+	if incomingDB <= 0 {
+		return errors.New("备份缺少数据库")
+	}
+	// The restore transaction keeps the uploaded/decrypted artifacts, a staged
+	// database, and a rollback copy of the current database alive at once. TLS
+	// state is similarly copied into pending and rollback namespaces. Keep a
+	// generous fixed margin for SQLite journals and directory metadata.
+	required := incomingDB*2 + currentDB + incomingTLS*2 + (64 << 20)
+	return ensureDiskSpace(filepath.Dir(dbPath), required)
 }
 
 func parseBackupZipReader(reader *zip.Reader) (backupManifest, map[string][]byte, error) {
@@ -1045,6 +1265,48 @@ func reencryptRestoredSecrets(path string, oldJWT, oldHeaderKey, newJWT, newHead
 			}
 		}
 	}
+	if hasProbeSecret, err := backupSQLiteColumnExists(tx, "control_nodes", "probe_secret_ciphertext"); err != nil {
+		return err
+	} else if hasProbeSecret {
+		rows, err := tx.Query("SELECT id,probe_secret_ciphertext FROM control_nodes WHERE probe_secret_ciphertext <> ''")
+		if err != nil {
+			return err
+		}
+		type probeUpdate struct {
+			id         int64
+			ciphertext string
+		}
+		updates := make([]probeUpdate, 0)
+		for rows.Next() {
+			var item probeUpdate
+			if err := rows.Scan(&item.id, &item.ciphertext); err != nil {
+				_ = rows.Close()
+				return err
+			}
+			secret, err := decryptNodeProbeSecretWithSecret(item.ciphertext, oldJWT)
+			if err != nil {
+				if _, currentErr := decryptNodeProbeSecretWithSecret(item.ciphertext, newJWT); currentErr != nil {
+					_ = rows.Close()
+					return fmt.Errorf("无法解密节点健康探针密钥: %w", err)
+				}
+				continue
+			}
+			migrated, err := encryptNodeProbeSecretWithSecret(secret, newJWT)
+			if err != nil {
+				_ = rows.Close()
+				return fmt.Errorf("无法迁移节点健康探针密钥: %w", err)
+			}
+			updates = append(updates, probeUpdate{id: item.id, ciphertext: migrated})
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+		for _, item := range updates {
+			if _, err := tx.Exec("UPDATE control_nodes SET probe_secret_ciphertext=? WHERE id=?", item.ciphertext, item.id); err != nil {
+				return err
+			}
+		}
+	}
 	return tx.Commit()
 }
 
@@ -1080,6 +1342,10 @@ func backupHasJWTProtectedToken(database []byte) (bool, error) {
 	if err := writePrivateFileAtomic(path, database); err != nil {
 		return false, err
 	}
+	return backupHasJWTProtectedTokenFile(path)
+}
+
+func backupHasJWTProtectedTokenFile(path string) (bool, error) {
 	db, err := sql.Open("sqlite", "file:"+filepath.ToSlash(path)+"?mode=ro&_pragma=query_only(1)")
 	if err != nil {
 		return false, err
@@ -1195,7 +1461,7 @@ func reconcileRestoredSiteIngress(path string, hostIngressAvailable bool) (int64
 	return result.RowsAffected()
 }
 
-func writeRestorePending(dbPath string, manifest backupManifest, entries map[string][]byte, targetJWT, targetHeaderKey []byte, preservedPanelSettings *backupPanelSettings, targetHostIngressWithoutTLS bool) (int64, error) {
+func writeRestorePendingFromPaths(dbPath string, manifest backupManifest, entries map[string]string, targetJWT, targetHeaderKey []byte, preservedPanelSettings *backupPanelSettings, targetHostIngressWithoutTLS bool) (int64, error) {
 	if dbPath == "" || dbPath == ":memory:" || strings.HasPrefix(dbPath, "file:") {
 		return 0, errors.New("当前数据库模式不支持恢复")
 	}
@@ -1214,7 +1480,7 @@ func writeRestorePending(dbPath string, manifest backupManifest, entries map[str
 	}
 	defer os.RemoveAll(tmp)
 	databasePath := filepath.Join(tmp, backupDatabaseEntry)
-	if err := writePrivateFileAtomic(databasePath, entries[backupDatabaseEntry]); err != nil {
+	if err := copyPrivateFile(entries[backupDatabaseEntry], databasePath); err != nil {
 		return 0, err
 	}
 	if err := validateSQLiteBackup(databasePath); err != nil {
@@ -1264,11 +1530,11 @@ func writeRestorePending(dbPath string, manifest backupManifest, entries map[str
 	if err := validateSQLiteBackup(databasePath); err != nil {
 		return 0, err
 	}
-	for name, data := range entries {
+	for name, source := range entries {
 		if !strings.HasPrefix(name, "tls/") {
 			continue
 		}
-		if err := writePrivateFileAtomic(filepath.Join(tmp, filepath.FromSlash(name)), data); err != nil {
+		if err := copyPrivateFile(source, filepath.Join(tmp, filepath.FromSlash(name))); err != nil {
 			return 0, err
 		}
 	}
@@ -1286,6 +1552,29 @@ func writeRestorePending(dbPath string, manifest backupManifest, entries map[str
 		return 0, err
 	}
 	return resetIngressCount, nil
+}
+
+// writeRestorePending keeps the byte-slice API for existing callers and unit
+// tests. HTTP restore uses writeRestorePendingFromPaths to avoid retaining the
+// whole decrypted archive in memory.
+func writeRestorePending(dbPath string, manifest backupManifest, entries map[string][]byte, targetJWT, targetHeaderKey []byte, preservedPanelSettings *backupPanelSettings, targetHostIngressWithoutTLS bool) (int64, error) {
+	stage, err := os.MkdirTemp("", ".meridian-restore-entries-*")
+	if err != nil {
+		return 0, err
+	}
+	defer os.RemoveAll(stage)
+	paths := make(map[string]string, len(entries))
+	for name, data := range entries {
+		if _, allowed := backupEntryLimit(name); !allowed {
+			return 0, fmt.Errorf("备份包含不允许的文件: %s", name)
+		}
+		path := filepath.Join(stage, fmt.Sprintf("%08d.entry", len(paths)))
+		if err := writePrivateFileAtomic(path, data); err != nil {
+			return 0, err
+		}
+		paths[name] = path
+	}
+	return writeRestorePendingFromPaths(dbPath, manifest, paths, targetJWT, targetHeaderKey, preservedPanelSettings, targetHostIngressWithoutTLS)
 }
 
 func copyPrivateFile(source, target string) error {
@@ -2039,17 +2328,24 @@ func (a *App) handleBackupExport(w http.ResponseWriter, r *http.Request) {
 	if request.IncludeTLS != nil {
 		includeTLS = *request.IncludeTLS
 	}
-	payload, err := a.buildBackup(request.Password, includeTLS)
+	artifact, err := a.buildBackupToFile(request.Password, includeTLS)
 	if err != nil {
 		a.jsonErr(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	defer artifact.Cleanup()
+	file, err := os.Open(artifact.Path) // #nosec G304 -- artifact is a private temporary backup file created above.
+	if err != nil {
+		a.jsonErr(w, http.StatusInternalServerError, "备份文件读取失败")
+		return
+	}
+	defer file.Close()
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="meridian-backup-%s.mrbak"`, time.Now().Format("20060102-150405")))
 	w.Header().Set("Cache-Control", "no-store")
-	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(payload)))
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", artifact.Size))
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(payload)
+	_, _ = io.Copy(w, file)
 }
 
 func (a *App) handleBackupRestore(w http.ResponseWriter, r *http.Request) {
@@ -2096,6 +2392,10 @@ func (a *App) handleBackupRestore(w http.ResponseWriter, r *http.Request) {
 	closeErr := encrypted.Close()
 	if copyErr != nil || closeErr != nil || readBytes > backupMaxUploadBytes {
 		a.jsonErr(w, http.StatusBadRequest, "备份文件读取失败或超过 256 MiB")
+		return
+	}
+	if err := ensureDiskSpace(restoreTemp, readBytes*3+64<<20); err != nil {
+		a.jsonErr(w, http.StatusInsufficientStorage, err.Error())
 		return
 	}
 	plainPath := filepath.Join(restoreTemp, "archive.zip")
@@ -2147,13 +2447,18 @@ func (a *App) handleBackupRestore(w http.ResponseWriter, r *http.Request) {
 	}
 	a.backupMu.Lock()
 	defer a.backupMu.Unlock()
-	manifest, entries, err := parseBackupArchiveFile(plainPath)
+	entriesDir := filepath.Join(restoreTemp, "entries")
+	manifest, entries, err := parseBackupArchiveFileToPaths(plainPath, entriesDir)
 	if err != nil {
 		a.jsonErr(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	if err := ensureRestoreDiskSpace(a.dbPath, entries); err != nil {
+		a.jsonErr(w, http.StatusInsufficientStorage, err.Error())
+		return
+	}
 	if jwtSecretEphemeral {
-		hasToken, tokenErr := backupHasJWTProtectedToken(entries[backupDatabaseEntry])
+		hasToken, tokenErr := backupHasJWTProtectedTokenFile(entries[backupDatabaseEntry])
 		if tokenErr != nil {
 			a.jsonErr(w, http.StatusBadRequest, "恢复校验失败：无法检查加密 Token 配置")
 			return
@@ -2180,7 +2485,7 @@ func (a *App) handleBackupRestore(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			tempDB := filepath.Join(tempDir, backupDatabaseEntry)
-			writeErr := writePrivateFileAtomic(tempDB, entries[backupDatabaseEntry])
+			writeErr := copyPrivateFile(entries[backupDatabaseEntry], tempDB)
 			hasHeaders := false
 			if writeErr == nil {
 				checkDB, openErr := sql.Open("sqlite", "file:"+filepath.ToSlash(tempDB)+"?mode=ro&_pragma=query_only(1)")
@@ -2213,7 +2518,7 @@ func (a *App) handleBackupRestore(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	targetHostIngressWithoutTLS := a.panelBindLoopback || len(a.trustedProxies) > 0
-	resetIngressCount, err := writeRestorePending(a.dbPath, manifest, entries, jwtSecret, targetHeaderKey, preservedPanelSettings, targetHostIngressWithoutTLS)
+	resetIngressCount, err := writeRestorePendingFromPaths(a.dbPath, manifest, entries, jwtSecret, targetHeaderKey, preservedPanelSettings, targetHostIngressWithoutTLS)
 	if err != nil {
 		a.jsonErr(w, http.StatusBadRequest, "恢复校验失败："+err.Error())
 		return

--- a/backup_restore_test.go
+++ b/backup_restore_test.go
@@ -238,6 +238,55 @@ func TestBuildBackupIncludesTLSOnlyWhenSelected(t *testing.T) {
 	}
 }
 
+func TestBuildBackupToFileRoundTripsThroughStreamingParser(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "meridian.db")
+	db, err := openDB(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.db.Exec(`INSERT INTO users (username, password_hash) VALUES ('backup-test', 'hash')`); err != nil {
+		t.Fatal(err)
+	}
+	app := &App{db: db, dbPath: dbPath, pm: NewProxyManager(db, bytes.Repeat([]byte("h"), 32))}
+	artifact, err := app.buildBackupToFile("correct horse battery staple", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer artifact.Cleanup()
+	if artifact.Size <= int64(len(backupMagicV2)) {
+		t.Fatalf("backup artifact is unexpectedly small: %d", artifact.Size)
+	}
+	encrypted, err := os.Open(artifact.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer encrypted.Close()
+	plainPath := filepath.Join(dir, "archive.zip")
+	plain, err := os.OpenFile(plainPath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := openBackupV2Reader(encrypted, "correct horse battery staple", plain); err != nil {
+		_ = plain.Close()
+		t.Fatal(err)
+	}
+	if err := plain.Close(); err != nil {
+		t.Fatal(err)
+	}
+	manifest, entries, err := parseBackupArchiveFileToPaths(plainPath, filepath.Join(dir, "entries"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.FormatVersion != backupFormatVersion || len(entries) < 2 {
+		t.Fatalf("streaming backup parse manifest=%#v entries=%d", manifest, len(entries))
+	}
+	if _, ok := entries[backupDatabaseEntry]; !ok {
+		t.Fatal("streaming backup parse omitted database entry")
+	}
+}
+
 func TestParseBackupArchiveRejectsNewerDatabaseSchema(t *testing.T) {
 	includeTLS := false
 	manifest := backupManifest{

--- a/command_line.go
+++ b/command_line.go
@@ -27,6 +27,12 @@ func runCommandLine(args []string, input io.Reader, output io.Writer) (bool, err
 		}
 		_, err := fmt.Fprintln(output, appVersion)
 		return true, err
+	case "--build-mode":
+		if len(args) != 1 {
+			return true, errors.New("build-mode command does not accept arguments")
+		}
+		_, err := fmt.Fprintln(output, buildMode)
+		return true, err
 	case "--healthcheck":
 		if len(args) != 1 {
 			return true, errors.New("healthcheck command does not accept arguments")

--- a/database.go
+++ b/database.go
@@ -27,6 +27,12 @@ type DB struct {
 	droppedRequestLogs          atomic.Uint64
 	droppedWatchHistory         atomic.Uint64
 	agentSecurityRejected       atomic.Uint64
+	agentSecurityRequestEvent   atomic.Uint64
+	agentSecuritySiteStat       atomic.Uint64
+	agentSecurityMediaCount     atomic.Uint64
+	agentSecurityRetention      atomic.Uint64
+	agentSecurityObservation    atomic.Uint64
+	agentSecurityLastRejectedMS atomic.Int64
 	agentSecurityMu             sync.Mutex
 	agentSecurityLastLog        map[string]time.Time
 	systemSettings              atomic.Pointer[SystemSettings]

--- a/database_migrations.go
+++ b/database_migrations.go
@@ -19,7 +19,7 @@ const (
 	// databaseSchemaVersion is independent from the application and backup
 	// format versions. It is persisted in SQLite so restores can reject a
 	// database whose columns/state are newer than this binary understands.
-	databaseSchemaVersion = 28
+	databaseSchemaVersion = 29
 )
 
 func (d *DB) migrate() error {
@@ -369,6 +369,7 @@ func (d *DB) migrateOnce() error {
 		event_dropped BIGINT NOT NULL DEFAULT 0,
 		enrollment_token_hash TEXT NOT NULL DEFAULT '',
 		enrollment_expires_at_ms INTEGER NOT NULL DEFAULT 0,
+		probe_secret_ciphertext TEXT NOT NULL DEFAULT '',
 		agent_token_hash TEXT NOT NULL DEFAULT '',
 		enrolled_at_ms INTEGER NOT NULL DEFAULT 0,
 		last_seen_at_ms INTEGER NOT NULL DEFAULT 0,
@@ -511,6 +512,17 @@ func (d *DB) migrateOnce() error {
 					return err
 				}
 			}
+		}
+	}
+	// Probe secrets were introduced after the original control node table. Keep
+	// existing databases upgradeable without exposing the plaintext secret.
+	var probeSecretColumnCount int
+	if err := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM pragma_table_info('control_nodes') WHERE name=?", "probe_secret_ciphertext").Scan(&probeSecretColumnCount); err != nil {
+		return err
+	}
+	if probeSecretColumnCount == 0 {
+		if _, err := conn.ExecContext(ctx, "ALTER TABLE control_nodes ADD COLUMN probe_secret_ciphertext TEXT NOT NULL DEFAULT ''"); err != nil {
+			return err
 		}
 	}
 	for _, migration := range []struct {

--- a/disk_space.go
+++ b/disk_space.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// diskSpaceProvider is replaceable by tests so low-space behavior can be
+// verified without filling the host filesystem.
+var diskSpaceProvider = diskAvailableBytes
+
+// ensureDiskSpace fails before a backup/restore transaction starts when the
+// filesystem cannot hold its temporary copies. Platforms without a portable
+// free-space syscall return nil from diskAvailableBytes and retain the
+// existing bounded-size protections.
+func ensureDiskSpace(path string, required int64) error {
+	if required <= 0 {
+		return nil
+	}
+	available, err := diskSpaceProvider(path)
+	if err != nil || available <= 0 {
+		return nil
+	}
+	if available < required {
+		return fmt.Errorf("磁盘剩余空间不足：需要至少 %d MiB，可用 %d MiB", required>>20, available>>20)
+	}
+	return nil
+}
+
+func diskSpacePath(path string) string {
+	path = filepath.Clean(path)
+	if info, err := os.Stat(path); err == nil && !info.IsDir() {
+		return filepath.Dir(path)
+	}
+	return path
+}

--- a/disk_space_test.go
+++ b/disk_space_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEnsureDiskSpaceRejectsInsufficientCapacity(t *testing.T) {
+	previous := diskSpaceProvider
+	diskSpaceProvider = func(string) (int64, error) { return 10 << 20, nil }
+	t.Cleanup(func() { diskSpaceProvider = previous })
+	if err := ensureDiskSpace(t.TempDir(), 11<<20); err == nil || !strings.Contains(err.Error(), "磁盘剩余空间不足") {
+		t.Fatalf("low disk space was accepted: %v", err)
+	}
+}
+
+func TestEnsureDiskSpaceAllowsUnknownPlatformCapacity(t *testing.T) {
+	previous := diskSpaceProvider
+	diskSpaceProvider = func(string) (int64, error) { return 0, nil }
+	t.Cleanup(func() { diskSpaceProvider = previous })
+	if err := ensureDiskSpace(t.TempDir(), 1<<30); err != nil {
+		t.Fatalf("unknown disk capacity should retain bounded-size fallback: %v", err)
+	}
+}

--- a/disk_space_unix.go
+++ b/disk_space_unix.go
@@ -11,5 +11,14 @@ func diskAvailableBytes(path string) (int64, error) {
 	if err := unix.Statfs(diskSpacePath(path), &stat); err != nil {
 		return 0, err
 	}
-	return int64(stat.Bavail) * int64(stat.Bsize), nil
+	blocks := stat.Bavail
+	blockSize := uint64(stat.Bsize)
+	if blockSize == 0 {
+		return 0, nil
+	}
+	const maxInt64 = uint64(1<<63 - 1)
+	if blocks > maxInt64/blockSize {
+		return int64(maxInt64), nil // #nosec G115 -- maxInt64 is the largest representable result.
+	}
+	return int64(blocks * blockSize), nil // #nosec G115 -- the overflow check above bounds the product.
 }

--- a/disk_space_unix.go
+++ b/disk_space_unix.go
@@ -12,10 +12,10 @@ func diskAvailableBytes(path string) (int64, error) {
 		return 0, err
 	}
 	blocks := stat.Bavail
-	blockSize := uint64(stat.Bsize)
-	if blockSize == 0 {
+	if stat.Bsize <= 0 || blocks == 0 {
 		return 0, nil
 	}
+	blockSize := uint64(stat.Bsize) // #nosec G115 -- Bsize is checked positive before conversion.
 	const maxInt64 = uint64(1<<63 - 1)
 	if blocks > maxInt64/blockSize {
 		return int64(maxInt64), nil // #nosec G115 -- maxInt64 is the largest representable result.

--- a/disk_space_unix.go
+++ b/disk_space_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package main
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func diskAvailableBytes(path string) (int64, error) {
+	var stat unix.Statfs_t
+	if err := unix.Statfs(diskSpacePath(path), &stat); err != nil {
+		return 0, err
+	}
+	return int64(stat.Bavail) * int64(stat.Bsize), nil
+}

--- a/disk_space_windows.go
+++ b/disk_space_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package main
+
+func diskAvailableBytes(string) (int64, error) {
+	return 0, nil
+}

--- a/edge_agent.go
+++ b/edge_agent.go
@@ -753,11 +753,18 @@ func edgeClientIP(remote string) string {
 	return remote
 }
 
-func (runtime *edgeAgentRuntime) observe(siteIDs map[string]int64, next http.Handler) http.Handler {
+func (runtime *edgeAgentRuntime) observe(siteIDs map[string]int64, next http.Handler, probeSecret ...[]byte) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// The scheduler probes this endpoint before a site has been assigned to
-		// the node. Let it reach the router without requiring a route mapping.
+		// the node. It still requires the per-node runtime key so the endpoint
+		// cannot be used as an unauthenticated public liveness oracle.
 		if r.Method == http.MethodGet && r.URL.Path == "/.well-known/meridian-agent-health" {
+			if len(probeSecret) == 0 || !hmac.Equal([]byte(strings.TrimSpace(r.Header.Get("X-Meridian-Probe"))), []byte(encodeRuntimeKey(probeSecret[0]))) {
+				// Return not-found for unauthenticated probes so the endpoint does
+				// not disclose that an Agent is present or reveal its identity.
+				http.NotFound(w, r)
+				return
+			}
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -822,6 +829,10 @@ type edgeReplayBody struct {
 
 func buildEdgeProxy(config AgentRuntimeConfig, runtime *edgeAgentRuntime) (*edgeProxyBundle, error) {
 	dynamicKey, err := edgeDecodeKey(config.DynamicKey)
+	if err != nil {
+		return nil, err
+	}
+	probeSecret, err := edgeDecodeKey(config.ProbeSecret)
 	if err != nil {
 		return nil, err
 	}
@@ -922,7 +933,7 @@ func buildEdgeProxy(config AgentRuntimeConfig, runtime *edgeAgentRuntime) (*edge
 		ctx := context.WithValue(r.Context(), publicHostIngressContextKey{}, true)
 		handler.ServeHTTP(w, r.WithContext(ctx))
 	})
-	bundle.handler = runtime.observe(siteIDs, router)
+	bundle.handler = runtime.observe(siteIDs, router, probeSecret)
 	return bundle, nil
 }
 

--- a/edge_agent_test.go
+++ b/edge_agent_test.go
@@ -98,12 +98,14 @@ func TestEdgeObserverMarksReplayEventsCritical(t *testing.T) {
 
 func TestEdgeAgentHealthProbeBypassesRouteAssignment(t *testing.T) {
 	runtime := &edgeAgentRuntime{}
+	probeSecret := []byte("probe-secret")
 	handler := runtime.observe(map[string]int64{}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Meridian-Node", "edge-node")
 		w.WriteHeader(http.StatusOK)
-	}))
+	}), probeSecret)
 
 	request := httptest.NewRequest(http.MethodGet, "https://unassigned.example.test/.well-known/meridian-agent-health", nil)
+	request.Header.Set("X-Meridian-Probe", encodeRuntimeKey(probeSecret))
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
 
@@ -112,6 +114,18 @@ func TestEdgeAgentHealthProbeBypassesRouteAssignment(t *testing.T) {
 	}
 	if got := response.Header().Get("X-Meridian-Node"); got != "edge-node" {
 		t.Fatalf("health probe node header = %q, want edge-node", got)
+	}
+}
+
+func TestEdgeAgentHealthProbeRequiresSecret(t *testing.T) {
+	handler := (&edgeAgentRuntime{}).observe(map[string]int64{}, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("unauthorized health probe reached router")
+	}), []byte("probe-secret"))
+	request := httptest.NewRequest(http.MethodGet, "https://unassigned.example.test/.well-known/meridian-agent-health", nil)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("health probe status = %d, want %d", response.Code, http.StatusNotFound)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -46,16 +46,16 @@ var appVersion = "dev"
 var buildMode = "controller"
 
 func main() {
-	if strings.EqualFold(strings.TrimSpace(buildMode), "agent") {
-		if err := runEdgeAgent(); err != nil {
-			fmt.Fprintf(os.Stderr, "meridian-agent: %v\n", err)
+	if handled, err := runCommandLine(os.Args[1:], os.Stdin, os.Stdout); handled {
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "meridian: %v\n", err)
 			os.Exit(1)
 		}
 		return
 	}
-	if handled, err := runCommandLine(os.Args[1:], os.Stdin, os.Stdout); handled {
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "meridian: %v\n", err)
+	if strings.EqualFold(strings.TrimSpace(buildMode), "agent") {
+		if err := runEdgeAgent(); err != nil {
+			fmt.Fprintf(os.Stderr, "meridian-agent: %v\n", err)
 			os.Exit(1)
 		}
 		return
@@ -265,9 +265,19 @@ func main() {
 	mux.HandleFunc("/api/agent/config", app.handleAgentConfig)
 	mux.Handle("/api/agent/ws", websocket.Server{
 		Handshake: func(config *websocket.Config, request *http.Request) error {
-			if _, err := app.db.nodeByAgentToken(requestBearerToken(request), time.Now()); err != nil {
+			preRelease, retryAfter, admitted := app.agentPreAuthAdmission().admit(requestClientKey(request, app.trustedProxies), time.Now())
+			if !admitted {
+				return fmt.Errorf("agent authentication rate limit exceeded; retry after %s", retryAfter.Round(time.Millisecond))
+			}
+			node, err := app.db.nodeByAgentToken(requestBearerToken(request), time.Now())
+			preRelease()
+			if err != nil {
 				return errors.New("invalid agent token")
 			}
+			// x/net/websocket passes the same request pointer to the handler. Carry
+			// the authenticated node through its context so the handler never
+			// performs a second SQLite token lookup for this connection.
+			*request = *withAgentWebSocketNode(request, node)
 			// Agent clients are not browsers; token authentication is the origin
 			// boundary, so do not apply the package's browser Origin check.
 			return nil

--- a/node_probe_secret.go
+++ b/node_probe_secret.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+const nodeProbeSecretCipherPrefix = "v1:"
+
+func nodeProbeSecretKey(secret []byte) []byte {
+	hash := sha256.New()
+	_, _ = hash.Write([]byte("meridian-node-probe-secret-v1\x00"))
+	_, _ = hash.Write(secret)
+	return hash.Sum(nil)
+}
+
+func encryptNodeProbeSecretWithSecret(value string, secret []byte) (string, error) {
+	value = strings.TrimSpace(value)
+	if len(value) < 32 || len(value) > 256 || strings.ContainsAny(value, "\r\n") {
+		return "", errors.New("invalid node probe secret")
+	}
+	if len(secret) < 32 {
+		return "", errors.New("JWT secret is unavailable")
+	}
+	block, err := aes.NewCipher(nodeProbeSecretKey(secret))
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	sealed := gcm.Seal(nil, nonce, []byte(value), []byte("meridian-node-probe-secret"))
+	return nodeProbeSecretCipherPrefix + base64.RawURLEncoding.EncodeToString(append(nonce, sealed...)), nil
+}
+
+func decryptNodeProbeSecretWithSecret(ciphertext string, secret []byte) (string, error) {
+	if !strings.HasPrefix(ciphertext, nodeProbeSecretCipherPrefix) || len(secret) < 32 {
+		return "", errors.New("invalid node probe secret ciphertext")
+	}
+	payload, err := base64.RawURLEncoding.Strict().DecodeString(strings.TrimPrefix(ciphertext, nodeProbeSecretCipherPrefix))
+	if err != nil {
+		return "", fmt.Errorf("decode node probe secret: %w", err)
+	}
+	block, err := aes.NewCipher(nodeProbeSecretKey(secret))
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil || len(payload) < gcm.NonceSize()+gcm.Overhead() {
+		return "", errors.New("invalid node probe secret ciphertext")
+	}
+	plain, err := gcm.Open(nil, payload[:gcm.NonceSize()], payload[gcm.NonceSize():], []byte("meridian-node-probe-secret"))
+	if err != nil {
+		return "", errors.New("invalid node probe secret ciphertext")
+	}
+	value := strings.TrimSpace(string(plain))
+	if len(value) < 32 || len(value) > 256 || strings.ContainsAny(value, "\r\n") {
+		return "", errors.New("invalid node probe secret")
+	}
+	return value, nil
+}
+
+func newNodeProbeSecret() (string, error) {
+	return newNodeToken()
+}
+
+// dNodeProbeSecret returns the plaintext only at the two places that need it:
+// the Agent config response and the Controller's private readiness probe. The
+// database stores only JWT-secret-encrypted material; the in-memory ControlNode
+// never exposes this value through JSON.
+func dNodeProbeSecret(db *DB, node ControlNode) (string, error) {
+	if db == nil || db.db == nil || node.ID <= 0 {
+		return "", errors.New("node probe secret is unavailable")
+	}
+	if strings.TrimSpace(node.probeSecretCiphertext) != "" {
+		return decryptNodeProbeSecretWithSecret(node.probeSecretCiphertext, jwtSecret)
+	}
+	secret, err := newNodeProbeSecret()
+	if err != nil {
+		return "", err
+	}
+	ciphertext, err := encryptNodeProbeSecretWithSecret(secret, jwtSecret)
+	if err != nil {
+		return "", err
+	}
+	result, err := db.db.Exec("UPDATE control_nodes SET probe_secret_ciphertext=?,updated_at_ms=? WHERE id=? AND probe_secret_ciphertext=''", ciphertext, time.Now().UnixMilli(), node.ID)
+	if err != nil {
+		return "", err
+	}
+	if affected, rowsErr := result.RowsAffected(); rowsErr != nil {
+		return "", rowsErr
+	} else if affected == 0 {
+		var existing string
+		if err := db.db.QueryRow("SELECT probe_secret_ciphertext FROM control_nodes WHERE id=?", node.ID).Scan(&existing); err != nil {
+			return "", err
+		}
+		return decryptNodeProbeSecretWithSecret(existing, jwtSecret)
+	}
+	return secret, nil
+}

--- a/node_repository.go
+++ b/node_repository.go
@@ -66,14 +66,15 @@ type ControlNode struct {
 	Depleted            bool   `json:"depleted"`
 	Active              bool   `json:"active"`
 
-	lastRawRXBytes      int64
-	lastRawTXBytes      int64
-	lastBootID          string // counter epoch (kernel boot + interface)
-	lastReportSessionID string
-	lastSequence        int64
-	enrollmentTokenHash string
-	agentTokenHash      string
-	enrollmentExpiresMS int64
+	lastRawRXBytes        int64
+	lastRawTXBytes        int64
+	lastBootID            string // counter epoch (kernel boot + interface)
+	lastReportSessionID   string
+	lastSequence          int64
+	enrollmentTokenHash   string
+	agentTokenHash        string
+	enrollmentExpiresMS   int64
+	probeSecretCiphertext string
 }
 
 type NodeSchedulerSettings struct {
@@ -84,8 +85,22 @@ type NodeSchedulerSettings struct {
 }
 
 type NodeControlSnapshot struct {
-	Nodes     []ControlNode         `json:"nodes"`
-	Scheduler NodeSchedulerSettings `json:"scheduler"`
+	Nodes         []ControlNode            `json:"nodes"`
+	Scheduler     NodeSchedulerSettings    `json:"scheduler"`
+	AgentSecurity AgentSecurityDiagnostics `json:"agent_security"`
+}
+
+// AgentSecurityDiagnostics contains bounded, aggregate counters for report
+// authorization failures. It intentionally excludes tokens, headers and site
+// payloads so the diagnostics response is safe for administrators to inspect.
+type AgentSecurityDiagnostics struct {
+	RejectedTotal  uint64 `json:"rejected_total"`
+	RequestEvent   uint64 `json:"request_event"`
+	SiteStat       uint64 `json:"site_stat"`
+	MediaCount     uint64 `json:"media_count"`
+	Retention      uint64 `json:"retention"`
+	Observation    uint64 `json:"observation"`
+	LastRejectedAt string `json:"last_rejected_at,omitempty"`
 }
 
 type NodeCreateInput struct {
@@ -335,13 +350,21 @@ func (d *DB) CreateControlNode(input NodeCreateInput, now time.Time) (ControlNod
 	if err != nil {
 		return ControlNode{}, "", err
 	}
+	probeSecret, err := newNodeProbeSecret()
+	if err != nil {
+		return ControlNode{}, "", err
+	}
+	probeSecretCiphertext, err := encryptNodeProbeSecretWithSecret(probeSecret, jwtSecret)
+	if err != nil {
+		return ControlNode{}, "", err
+	}
 	nowMS := now.UnixMilli()
 	cycleStart := nodeCycleStart(now, input.ResetDay, d.currentSystemSettings().ScheduleTimezone)
 	result, err := d.db.Exec(`INSERT INTO control_nodes
 		(guid,name,address,entry_mode,http_port,https_port,priority,traffic_quota,billing_mode,reset_day,cycle_started_at_ms,
-		 enrollment_token_hash,enrollment_expires_at_ms,created_at_ms,updated_at_ms)
-		VALUES(?,?,?,'direct',0,?,?,?,?,?,?,?,?,?,?)`, guid, input.Name, input.Address, input.Port, input.Priority, input.TrafficQuota,
-		input.BillingMode, input.ResetDay, cycleStart, hashNodeToken(enrollmentToken), now.Add(nodeEnrollmentLifetime).UnixMilli(), nowMS, nowMS)
+		 enrollment_token_hash,enrollment_expires_at_ms,probe_secret_ciphertext,created_at_ms,updated_at_ms)
+		VALUES(?,?,?,'direct',0,?,?,?,?,?,?,?,?,?,?,?)`, guid, input.Name, input.Address, input.Port, input.Priority, input.TrafficQuota,
+		input.BillingMode, input.ResetDay, cycleStart, hashNodeToken(enrollmentToken), now.Add(nodeEnrollmentLifetime).UnixMilli(), probeSecretCiphertext, nowMS, nowMS)
 	if err != nil {
 		if isSQLiteUniqueConstraintError(err) {
 			return ControlNode{}, "", errNodeNameConflict
@@ -361,7 +384,7 @@ type rowScanner interface{ Scan(...interface{}) error }
 const controlNodeSelect = `SELECT id,guid,name,address,https_port,enabled,priority,traffic_quota,billing_mode,reset_day,
 	cycle_started_at_ms,period_rx_bytes,period_tx_bytes,lifetime_rx_bytes,lifetime_tx_bytes,traffic_manual_offset_bytes,
 	last_raw_rx_bytes,last_raw_tx_bytes,last_boot_id,last_report_session_id,last_sequence,interface_name,agent_version,desired_config_hash,applied_config_hash,agent_listener_error,event_spool_error,event_queue_depth,event_dropped,
-	enrollment_token_hash,enrollment_expires_at_ms,agent_token_hash,enrolled_at_ms,last_seen_at_ms,created_at_ms,updated_at_ms
+	enrollment_token_hash,enrollment_expires_at_ms,probe_secret_ciphertext,agent_token_hash,enrolled_at_ms,last_seen_at_ms,created_at_ms,updated_at_ms
 	FROM control_nodes`
 
 func scanControlNode(scanner rowScanner, now time.Time) (ControlNode, error) {
@@ -370,7 +393,7 @@ func scanControlNode(scanner rowScanner, now time.Time) (ControlNode, error) {
 	err := scanner.Scan(&node.ID, &node.GUID, &node.Name, &node.Address, &node.Port, &enabled, &node.Priority, &node.TrafficQuota,
 		&node.BillingMode, &node.ResetDay, &node.CycleStartedAtMS, &node.PeriodRXBytes, &node.PeriodTXBytes,
 		&node.LifetimeRXBytes, &node.LifetimeTXBytes, &node.TrafficManualOffset, &node.lastRawRXBytes, &node.lastRawTXBytes, &node.lastBootID, &node.lastReportSessionID,
-		&node.lastSequence, &node.InterfaceName, &node.AgentVersion, &node.DesiredConfigHash, &node.AppliedConfigHash, &node.AgentListenerError, &node.EventSpoolError, &node.EventQueueDepth, &node.EventDropped, &node.enrollmentTokenHash, &node.enrollmentExpiresMS,
+		&node.lastSequence, &node.InterfaceName, &node.AgentVersion, &node.DesiredConfigHash, &node.AppliedConfigHash, &node.AgentListenerError, &node.EventSpoolError, &node.EventQueueDepth, &node.EventDropped, &node.enrollmentTokenHash, &node.enrollmentExpiresMS, &node.probeSecretCiphertext,
 		&node.agentTokenHash, &node.EnrolledAtMS, &node.LastSeenAtMS, &node.CreatedAtMS, &node.UpdatedAtMS)
 	if err != nil {
 		return ControlNode{}, err
@@ -496,7 +519,7 @@ func (d *DB) NodeControlSnapshot(now time.Time) (NodeControlSnapshot, error) {
 	for i := range nodes {
 		nodes[i].Active = nodes[i].ID == scheduler.ActiveNodeID
 	}
-	return NodeControlSnapshot{Nodes: nodes, Scheduler: scheduler}, nil
+	return NodeControlSnapshot{Nodes: nodes, Scheduler: scheduler, AgentSecurity: d.agentSecuritySnapshot()}, nil
 }
 
 func nullableNodeID(id int64) interface{} {
@@ -627,6 +650,14 @@ func (d *DB) EnrollControlNode(token string, now time.Time) (ControlNode, string
 	if err != nil {
 		return ControlNode{}, "", err
 	}
+	probeSecret, err := newNodeProbeSecret()
+	if err != nil {
+		return ControlNode{}, "", err
+	}
+	probeSecretCiphertext, err := encryptNodeProbeSecretWithSecret(probeSecret, jwtSecret)
+	if err != nil {
+		return ControlNode{}, "", err
+	}
 	tx, err := d.db.Begin()
 	if err != nil {
 		return ControlNode{}, "", err
@@ -641,7 +672,7 @@ func (d *DB) EnrollControlNode(token string, now time.Time) (ControlNode, string
 		return ControlNode{}, "", err
 	}
 	result, err := tx.Exec(`UPDATE control_nodes SET enrollment_token_hash='',enrollment_expires_at_ms=0,
-		agent_token_hash=?,enrolled_at_ms=?,updated_at_ms=? WHERE id=? AND enrollment_token_hash<>''`, hashNodeToken(agentToken), now.UnixMilli(), now.UnixMilli(), id)
+		agent_token_hash=?,probe_secret_ciphertext=?,enrolled_at_ms=?,updated_at_ms=? WHERE id=? AND enrollment_token_hash<>''`, hashNodeToken(agentToken), probeSecretCiphertext, now.UnixMilli(), now.UnixMilli(), id)
 	if err != nil {
 		return ControlNode{}, "", err
 	}
@@ -779,9 +810,45 @@ func (d *DB) recordAgentSecurityRejection(nodeID, siteID int64, category string)
 		return
 	}
 	d.agentSecurityRejected.Add(1)
-	key := fmt.Sprintf("%d:%d:%s", nodeID, siteID, category)
+	switch category {
+	case "request-event":
+		d.agentSecurityRequestEvent.Add(1)
+	case "site-stats":
+		d.agentSecuritySiteStat.Add(1)
+	case "media-counts":
+		d.agentSecurityMediaCount.Add(1)
+	case "retention":
+		d.agentSecurityRetention.Add(1)
+	case "observation":
+		d.agentSecurityObservation.Add(1)
+	}
+	d.agentSecurityLastRejectedMS.Store(time.Now().UnixMilli())
+	// SiteID is deliberately excluded from the log key. It is attacker
+	// controlled input and must not create an unbounded map entry per spoofed
+	// site. One bounded key per node/category is sufficient for rate limiting.
+	key := fmt.Sprintf("%d:%s", nodeID, category)
 	now := time.Now()
 	d.agentSecurityMu.Lock()
+	if d.agentSecurityLastLog == nil {
+		d.agentSecurityLastLog = make(map[string]time.Time)
+	}
+	for existingKey, timestamp := range d.agentSecurityLastLog {
+		if now.Sub(timestamp) >= 10*time.Minute {
+			delete(d.agentSecurityLastLog, existingKey)
+		}
+	}
+	if len(d.agentSecurityLastLog) >= 4096 {
+		var oldestKey string
+		var oldest time.Time
+		for existingKey, timestamp := range d.agentSecurityLastLog {
+			if oldestKey == "" || timestamp.Before(oldest) {
+				oldestKey, oldest = existingKey, timestamp
+			}
+		}
+		if oldestKey != "" {
+			delete(d.agentSecurityLastLog, oldestKey)
+		}
+	}
 	last := d.agentSecurityLastLog[key]
 	if last.IsZero() || now.Sub(last) >= time.Minute {
 		d.agentSecurityLastLog[key] = now
@@ -790,6 +857,24 @@ func (d *DB) recordAgentSecurityRejection(nodeID, siteID int64, category string)
 		return
 	}
 	d.agentSecurityMu.Unlock()
+}
+
+func (d *DB) agentSecuritySnapshot() AgentSecurityDiagnostics {
+	if d == nil {
+		return AgentSecurityDiagnostics{}
+	}
+	result := AgentSecurityDiagnostics{
+		RejectedTotal: d.agentSecurityRejected.Load(),
+		RequestEvent:  d.agentSecurityRequestEvent.Load(),
+		SiteStat:      d.agentSecuritySiteStat.Load(),
+		MediaCount:    d.agentSecurityMediaCount.Load(),
+		Retention:     d.agentSecurityRetention.Load(),
+		Observation:   d.agentSecurityObservation.Load(),
+	}
+	if timestamp := d.agentSecurityLastRejectedMS.Load(); timestamp > 0 {
+		result.LastRejectedAt = time.UnixMilli(timestamp).UTC().Format(time.RFC3339)
+	}
+	return result
 }
 
 func isHexString(value string) bool {
@@ -881,43 +966,65 @@ func recordNodeSiteTrafficTx(tx *sql.Tx, nodeID int64, bootID string, stat NodeS
 	return err
 }
 
-func (d *DB) RecordNodeReport(agentToken string, report NodeReport, now time.Time) (ControlNode, error) {
-	// A malformed/stale event must not make the whole heartbeat unprocessable.
-	// Keep the node online and drop only the offending event; core counters and
-	// valid events remain durable.
+type nodeReportCommitResult struct {
+	node              ControlNode
+	acceptedNew       []NodeRequestEvent
+	acceptedDuplicate []NodeRequestEvent
+	discardedIDs      []int64
+	discardedUIDs     []string
+}
+
+func appendNodeEventIdentity(ids *[]int64, uids *[]string, event NodeRequestEvent) {
+	if event.EventID > 0 {
+		*ids = append(*ids, event.EventID)
+	}
+	if len(event.EventUID) == 32 && isHexString(event.EventUID) {
+		*uids = append(*uids, event.EventUID)
+	}
+}
+
+func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now time.Time) (nodeReportCommitResult, error) {
+	result := nodeReportCommitResult{}
 	validEvents := make([]NodeRequestEvent, 0, len(report.Events))
 	for _, event := range report.Events {
 		if validateNodeRequestEvent(event) == nil {
 			validEvents = append(validEvents, event)
+			continue
 		}
+		appendNodeEventIdentity(&result.discardedIDs, &result.discardedUIDs, event)
 	}
 	report.Events = validEvents
 	if err := validateNodeReport(report); err != nil {
-		return ControlNode{}, err
+		return nodeReportCommitResult{}, err
 	}
 	if err := d.resetDueNodeCycles(now); err != nil {
-		return ControlNode{}, err
+		return nodeReportCommitResult{}, err
 	}
 	tx, err := d.db.Begin()
 	if err != nil {
-		return ControlNode{}, err
+		return nodeReportCommitResult{}, err
 	}
 	defer tx.Rollback()
-	acceptedEvents := make([]NodeRequestEvent, 0, len(report.Events))
+
 	var id, lastSequence, lastRX, lastTX int64
 	var lastBootID, lastSessionID string
 	err = tx.QueryRow(`SELECT id,last_sequence,last_raw_rx_bytes,last_raw_tx_bytes,last_boot_id,last_report_session_id FROM control_nodes WHERE agent_token_hash=?`, hashNodeToken(agentToken)).Scan(
 		&id, &lastSequence, &lastRX, &lastTX, &lastBootID, &lastSessionID)
 	if errors.Is(err, sql.ErrNoRows) {
-		return ControlNode{}, errInvalidAgentToken
+		return nodeReportCommitResult{}, errInvalidAgentToken
 	}
 	if err != nil {
-		return ControlNode{}, err
+		return nodeReportCommitResult{}, err
 	}
+
+	// Authorization and every report mutation use one transaction. A scheduler
+	// transition therefore resolves as either authorized-and-committed or
+	// unauthorized-and-discarded; ACKs are never inferred from a preflight.
 	allowedSites, err := authorizedNodeSitesTx(tx, id)
 	if err != nil {
-		return ControlNode{}, err
+		return nodeReportCommitResult{}, err
 	}
+
 	legacyBootID := strings.TrimSpace(report.BootID)
 	sessionID := strings.TrimSpace(report.ReportSessionID)
 	if sessionID == "" {
@@ -936,14 +1043,14 @@ func (d *DB) RecordNodeReport(agentToken string, report NodeReport, now time.Tim
 		deltaRX, deltaTX = 0, 0
 		report.RXBytes, report.TXBytes, report.Sequence = lastRX, lastTX, lastSequence
 	}
-	_, err = tx.Exec(`UPDATE control_nodes SET period_rx_bytes=period_rx_bytes+?,period_tx_bytes=period_tx_bytes+?,
+	if _, err = tx.Exec(`UPDATE control_nodes SET period_rx_bytes=period_rx_bytes+?,period_tx_bytes=period_tx_bytes+?,
 		lifetime_rx_bytes=lifetime_rx_bytes+?,lifetime_tx_bytes=lifetime_tx_bytes+?,last_raw_rx_bytes=?,last_raw_tx_bytes=?,
 		last_boot_id=?,last_report_session_id=?,last_sequence=?,interface_name=?,agent_version=?,applied_config_hash=?,agent_listener_error=?,event_spool_error=?,event_queue_depth=?,event_dropped=?,last_seen_at_ms=?,updated_at_ms=? WHERE id=?`,
 		deltaRX, deltaTX, deltaRX, deltaTX, report.RXBytes, report.TXBytes, counterEpoch, sessionID, report.Sequence,
-		strings.TrimSpace(report.InterfaceName), strings.TrimSpace(report.AgentVersion), strings.TrimSpace(report.AppliedConfigHash), strings.TrimSpace(report.ListenerError), strings.TrimSpace(report.EventSpoolError), report.EventQueueDepth, report.EventDropped, now.UnixMilli(), now.UnixMilli(), id)
-	if err != nil {
-		return ControlNode{}, err
+		strings.TrimSpace(report.InterfaceName), strings.TrimSpace(report.AgentVersion), strings.TrimSpace(report.AppliedConfigHash), strings.TrimSpace(report.ListenerError), strings.TrimSpace(report.EventSpoolError), report.EventQueueDepth, report.EventDropped, now.UnixMilli(), now.UnixMilli(), id); err != nil {
+		return nodeReportCommitResult{}, err
 	}
+
 	for _, stat := range report.SiteStats {
 		host := strings.ToLower(strings.TrimSpace(stat.Host))
 		if host == "" || len(host) > 255 || stat.RequestCount < 0 || stat.LastRequestAtMS < 0 || stat.LastStatus < 0 || stat.LastStatus > 999 {
@@ -954,10 +1061,11 @@ func (d *DB) RecordNodeReport(agentToken string, report NodeReport, now time.Tim
 		var previousCount int64
 		err := tx.QueryRow(`SELECT n.site_id,n.agent_boot_id,n.agent_request_count FROM site_node_schedules n JOIN sites s ON s.id=n.site_id WHERE n.enabled=1 AND s.enabled=1 AND (n.desired_node_id=? OR n.applied_node_id=?) AND lower(s.public_host)=?`, id, id, host).Scan(&scheduleID, &previousBoot, &previousCount)
 		if errors.Is(err, sql.ErrNoRows) {
+			d.recordAgentSecurityRejection(id, 0, "site-stats")
 			continue
 		}
 		if err != nil {
-			return ControlNode{}, err
+			return nodeReportCommitResult{}, err
 		}
 		if !authorizedNodeSiteHost(allowedSites, scheduleID, host) {
 			d.recordAgentSecurityRejection(id, scheduleID, "site-stats")
@@ -970,26 +1078,22 @@ func (d *DB) RecordNodeReport(agentToken string, report NodeReport, now time.Tim
 		if count < previousCount {
 			count = previousCount
 		}
-		_, err = tx.Exec(`UPDATE site_node_schedules SET agent_boot_id=?,agent_request_count=?,agent_last_request_at_ms=?,agent_last_status=?,updated_at_ms=? WHERE site_id=?`,
-			sessionID, count, stat.LastRequestAtMS, stat.LastStatus, now.UnixMilli(), scheduleID)
-		if err != nil {
-			return ControlNode{}, err
+		if _, err = tx.Exec(`UPDATE site_node_schedules SET agent_boot_id=?,agent_request_count=?,agent_last_request_at_ms=?,agent_last_status=?,updated_at_ms=? WHERE site_id=?`,
+			sessionID, count, stat.LastRequestAtMS, stat.LastStatus, now.UnixMilli(), scheduleID); err != nil {
+			return nodeReportCommitResult{}, err
 		}
-		// Site traffic counters are cumulative NIC counters.  Keep their epoch
-		// independent from the process/report session so an Agent restart does
-		// not discard the bytes accumulated since the previous report.
 		if err := recordNodeSiteTrafficTx(tx, id, counterEpoch, stat, now.UnixMilli(), allowedSites); err != nil {
-			return ControlNode{}, err
+			return nodeReportCommitResult{}, err
 		}
 	}
+
 	for _, count := range report.MediaCounts {
 		if _, allowed := allowedSites[count.SiteID]; !allowed {
 			d.recordAgentSecurityRejection(id, count.SiteID, "media-counts")
 			continue
 		}
-		_, err := tx.Exec(`UPDATE sites SET media_movie_count=?,media_series_count=?,media_episode_count=?,media_count_updated_at_ms=? WHERE id=? AND media_count_updated_at_ms<?`, count.MovieCount, count.SeriesCount, count.EpisodeCount, count.ObservedAtMS, count.SiteID, count.ObservedAtMS)
-		if err != nil {
-			return ControlNode{}, err
+		if _, err := tx.Exec(`UPDATE sites SET media_movie_count=?,media_series_count=?,media_episode_count=?,media_count_updated_at_ms=? WHERE id=? AND media_count_updated_at_ms<?`, count.MovieCount, count.SeriesCount, count.EpisodeCount, count.ObservedAtMS, count.SiteID, count.ObservedAtMS); err != nil {
+			return nodeReportCommitResult{}, err
 		}
 	}
 	for _, status := range report.Retention {
@@ -997,9 +1101,8 @@ func (d *DB) RecordNodeReport(agentToken string, report NodeReport, now time.Tim
 			d.recordAgentSecurityRejection(id, status.SiteID, "retention")
 			continue
 		}
-		_, err := tx.Exec(`UPDATE sites SET account_retention_started_at_ms=?,account_retention_last_completed_at_ms=?,updated_at=CURRENT_TIMESTAMP WHERE id=? AND account_retention_days>0 AND account_retention_started_at_ms=?`, status.CompletedAtMS, status.CompletedAtMS, status.SiteID, status.ExpectedStartedAtMS)
-		if err != nil {
-			return ControlNode{}, err
+		if _, err := tx.Exec(`UPDATE sites SET account_retention_started_at_ms=?,account_retention_last_completed_at_ms=?,updated_at=CURRENT_TIMESTAMP WHERE id=? AND account_retention_days>0 AND account_retention_started_at_ms=?`, status.CompletedAtMS, status.CompletedAtMS, status.SiteID, status.ExpectedStartedAtMS); err != nil {
+			return nodeReportCommitResult{}, err
 		}
 	}
 	for _, observation := range report.Observations {
@@ -1007,109 +1110,96 @@ func (d *DB) RecordNodeReport(agentToken string, report NodeReport, now time.Tim
 			d.recordAgentSecurityRejection(id, observation.SiteID, "observation")
 			continue
 		}
-		_, err := tx.Exec(`INSERT INTO dynamic_observations(site_id,canonical_authority,source,decision,reason_code,first_seen_ms,last_seen_ms,count) VALUES(?,?,?,?,?,?,?,1) ON CONFLICT(site_id,canonical_authority,source,decision,reason_code) DO UPDATE SET last_seen_ms=excluded.last_seen_ms,count=count+1`, observation.SiteID, observation.CanonicalAuthority, observation.Source, observation.Decision, observation.ReasonCode, observation.ObservedAtMS, observation.ObservedAtMS)
-		if err != nil {
-			return ControlNode{}, err
+		if _, err := tx.Exec(`INSERT INTO dynamic_observations(site_id,canonical_authority,source,decision,reason_code,first_seen_ms,last_seen_ms,count) VALUES(?,?,?,?,?,?,?,1) ON CONFLICT(site_id,canonical_authority,source,decision,reason_code) DO UPDATE SET last_seen_ms=excluded.last_seen_ms,count=count+1`, observation.SiteID, observation.CanonicalAuthority, observation.Source, observation.Decision, observation.ReasonCode, observation.ObservedAtMS, observation.ObservedAtMS); err != nil {
+			return nodeReportCommitResult{}, err
 		}
 	}
+
 	for _, event := range report.Events {
 		if !authorizedNodeSiteHost(allowedSites, event.SiteID, event.Host) {
 			d.recordAgentSecurityRejection(id, event.SiteID, "request-event")
+			appendNodeEventIdentity(&result.discardedIDs, &result.discardedUIDs, event)
 			continue
 		}
-		result, err := tx.Exec(`INSERT OR IGNORE INTO node_request_events(node_id,agent_boot_id,event_id,event_uid,received_at_ms) VALUES(?,?,?,?,?)`, id, sessionID, event.EventID, event.EventUID, now.UnixMilli())
+		inserted, err := tx.Exec(`INSERT OR IGNORE INTO node_request_events(node_id,agent_boot_id,event_id,event_uid,received_at_ms) VALUES(?,?,?,?,?)`, id, sessionID, event.EventID, event.EventUID, now.UnixMilli())
 		if err != nil {
-			return ControlNode{}, err
+			return nodeReportCommitResult{}, err
 		}
-		rows, err := result.RowsAffected()
+		rows, err := inserted.RowsAffected()
 		if err != nil {
-			return ControlNode{}, err
+			return nodeReportCommitResult{}, err
 		}
 		if rows == 0 {
-			// The event was already durably accepted (for example, the previous
-			// ACK was lost). Acknowledge it again so the Agent can retire its
-			// durable spool entry without replaying the side effect.
-			acceptedEvents = append(acceptedEvents, event)
+			var existingBoot, existingUID string
+			var existingID int64
+			lookupErr := tx.QueryRow(`SELECT agent_boot_id,event_id,event_uid FROM node_request_events WHERE node_id=? AND ((agent_boot_id=? AND event_id=?) OR (event_uid<>'' AND event_uid=?)) LIMIT 1`, id, sessionID, event.EventID, event.EventUID).Scan(&existingBoot, &existingID, &existingUID)
+			if errors.Is(lookupErr, sql.ErrNoRows) {
+				return nodeReportCommitResult{}, errors.New(`event insert was ignored without an existing identity`)
+			}
+			if lookupErr != nil {
+				return nodeReportCommitResult{}, lookupErr
+			}
+			if (event.EventUID != "" && existingUID != "" && !strings.EqualFold(event.EventUID, existingUID)) ||
+				(existingBoot != sessionID && existingUID == "") ||
+				(existingBoot == sessionID && existingID != event.EventID) {
+				appendNodeEventIdentity(&result.discardedIDs, &result.discardedUIDs, event)
+				continue
+			}
+			result.acceptedDuplicate = append(result.acceptedDuplicate, event)
 			continue
 		}
 		if !event.SkipRequestLog {
 			if err := d.recordNodeRequestEventTx(tx, id, event); err != nil {
-				return ControlNode{}, err
+				return nodeReportCommitResult{}, err
 			}
 		}
-		acceptedEvents = append(acceptedEvents, event)
+		result.acceptedNew = append(result.acceptedNew, event)
 	}
+
 	if err := tx.Commit(); err != nil {
-		return ControlNode{}, err
+		return nodeReportCommitResult{}, err
 	}
-	// Metadata responses must be replayed first. A playback sync event often
-	// arrives in the same heartbeat and relies on this cache for its title.
-	for _, event := range acceptedEvents {
+	result.node, err = d.controlNodeByID(id, now)
+	if err != nil {
+		return nodeReportCommitResult{}, err
+	}
+	// Derived in-process effects run only for newly committed events. Duplicate
+	// deliveries are acknowledged without replaying request/watch/metadata work.
+	for _, event := range result.acceptedNew {
 		if event.ResponseBody != "" {
 			d.recordNodeMetadataEvent(event)
 		}
-	}
-	for _, event := range acceptedEvents {
 		d.recordNodeWatchHistoryEvent(event)
 	}
-	node, err := d.controlNodeByID(id, now)
+	_, _ = d.NodeControlSnapshot(now)
+	return result, nil
+}
+
+func (d *DB) RecordNodeReport(agentToken string, report NodeReport, now time.Time) (ControlNode, error) {
+	result, err := d.recordNodeReportCommit(agentToken, report, now)
 	if err != nil {
 		return ControlNode{}, err
 	}
-	_, _ = d.NodeControlSnapshot(now)
-	return node, nil
+	return result.node, nil
 }
 
 // RecordNodeReportResult is the acknowledgement-safe variant used by HTTP
-// and WebSocket handlers. Invalid event payloads are explicitly retired so a
-// poison event cannot remain in an Agent spool forever.
+// and WebSocket handlers. It authenticates, snapshots authorization, commits
+// mutations, and derives ACK/discarded lists from that same transaction.
 func (d *DB) RecordNodeReportResult(agentToken string, report NodeReport, now time.Time) (NodeReportResult, error) {
-	result := NodeReportResult{}
-	validEvents := make([]NodeRequestEvent, 0, len(report.Events))
-	for _, event := range report.Events {
-		if validateNodeRequestEvent(event) == nil {
-			validEvents = append(validEvents, event)
-			continue
-		}
-		if event.EventID > 0 {
-			result.DiscardedEventIDs = append(result.DiscardedEventIDs, event.EventID)
-		}
-		if len(event.EventUID) == 32 && isHexString(event.EventUID) {
-			result.DiscardedEventUIDs = append(result.DiscardedEventUIDs, event.EventUID)
-		}
-	}
-	nodeID, allowedSites, authErr := d.authorizedNodeSitesForAgentToken(agentToken)
-	if authErr != nil {
-		return NodeReportResult{}, authErr
-	}
-	authorizedEvents := make([]NodeRequestEvent, 0, len(validEvents))
-	for _, event := range validEvents {
-		if !authorizedNodeSiteHost(allowedSites, event.SiteID, event.Host) {
-			d.recordAgentSecurityRejection(nodeID, event.SiteID, "request-event")
-			if event.EventID > 0 {
-				result.DiscardedEventIDs = append(result.DiscardedEventIDs, event.EventID)
-			}
-			if len(event.EventUID) == 32 && isHexString(event.EventUID) {
-				result.DiscardedEventUIDs = append(result.DiscardedEventUIDs, event.EventUID)
-			}
-			continue
-		}
-		authorizedEvents = append(authorizedEvents, event)
-	}
-	report.Events = authorizedEvents
-	node, err := d.RecordNodeReport(agentToken, report, now)
+	committed, err := d.recordNodeReportCommit(agentToken, report, now)
 	if err != nil {
 		return NodeReportResult{}, err
 	}
-	result.Node = node
-	for _, event := range authorizedEvents {
-		if event.EventID > 0 {
-			result.AcceptedEventIDs = append(result.AcceptedEventIDs, event.EventID)
-		}
-		if len(event.EventUID) == 32 && isHexString(event.EventUID) {
-			result.AcceptedEventUIDs = append(result.AcceptedEventUIDs, event.EventUID)
-		}
+	result := NodeReportResult{Node: committed.node}
+	for _, event := range committed.acceptedNew {
+		appendNodeEventIdentity(&result.AcceptedEventIDs, &result.AcceptedEventUIDs, event)
 	}
+	for _, event := range committed.acceptedDuplicate {
+		appendNodeEventIdentity(&result.AcceptedEventIDs, &result.AcceptedEventUIDs, event)
+	}
+	result.DiscardedEventIDs = committed.discardedIDs
+	result.DiscardedEventUIDs = committed.discardedUIDs
 	return result, nil
 }
 

--- a/panel_acme.go
+++ b/panel_acme.go
@@ -106,11 +106,15 @@ func (m *panelCertificateManager) panelPairPaths() (string, string) {
 			return filepath.Join(currentDir, "fullchain.pem"), filepath.Join(currentDir, "privkey.pem")
 		}
 	}
-	// Read the pre-TLS_STATE_DIR pointer during migration, but never create or
-	// remove anything in the operator-owned certificate directory.
-	legacyDir := filepath.Join(filepath.Dir(m.certFile), ".panel-current")
-	if _, err := os.Stat(filepath.Join(legacyDir, "fullchain.pem")); err == nil { // #nosec G703 -- legacy path is read-only migration compatibility.
-		return filepath.Join(legacyDir, "fullchain.pem"), filepath.Join(legacyDir, "privkey.pem")
+	// Managers created before TLS_STATE_DIR existed may still read the legacy
+	// pointer as a compatibility measure. New managers must never inspect a
+	// sibling of an operator-owned certificate path: that directory is outside
+	// Meridian's namespace and may belong to another service.
+	if m.stateDir == "" {
+		legacyDir := filepath.Join(filepath.Dir(m.certFile), ".panel-current")
+		if _, err := os.Stat(filepath.Join(legacyDir, "fullchain.pem")); err == nil { // #nosec G703 -- legacy path is read-only compatibility for legacy callers.
+			return filepath.Join(legacyDir, "fullchain.pem"), filepath.Join(legacyDir, "privkey.pem")
+		}
 	}
 	return m.certFile, m.keyFile
 }
@@ -184,8 +188,18 @@ func (m *panelCertificateManager) nodeEdgeTLSPaths(nodeGUID string) (string, str
 		}
 	}
 	rootBase := m.edgeStateRoot
+	// Older in-process callers and tests may construct a manager directly
+	// without filling edgeStateRoot.  Derive the private state namespace only
+	// from the manager's own state/account directory; never fall back to the
+	// operator-provided EDGE_TLS_CERT_FILE parent.
+	if rootBase == "" && strings.TrimSpace(m.stateDir) != "" {
+		rootBase = filepath.Join(m.stateDir, "edge-nodes")
+	}
+	if rootBase == "" && strings.TrimSpace(m.accountDir) != "" {
+		rootBase = filepath.Join(m.accountDir, "edge-nodes")
+	}
 	if rootBase == "" {
-		rootBase = filepath.Join(filepath.Dir(m.edgeCertFile), "edge-nodes")
+		return "", "", errors.New("edge TLS state directory is unavailable")
 	}
 	root := filepath.Join(rootBase, guid)
 	current := filepath.Join(root, "current")
@@ -365,7 +379,7 @@ func (m *panelCertificateManager) validatePanelEdgeKeySeparation() error {
 	}
 	edgeRoot := m.edgeStateRoot
 	if edgeRoot == "" {
-		edgeRoot = filepath.Join(filepath.Dir(m.edgeCertFile), "edge-nodes")
+		return errors.New("edge TLS state directory is unavailable")
 	}
 	entries, readErr := os.ReadDir(edgeRoot)
 	if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
@@ -586,9 +600,11 @@ func panelTLSBackupPaths(dbPath string) (certFile, keyFile string) {
 			return filepath.Join(currentDir, "fullchain.pem"), filepath.Join(currentDir, "privkey.pem")
 		}
 	}
-	currentDir = filepath.Join(filepath.Dir(certFile), ".panel-current")
-	if _, err := os.Stat(filepath.Join(currentDir, "fullchain.pem")); err == nil {
-		return filepath.Join(currentDir, "fullchain.pem"), filepath.Join(currentDir, "privkey.pem")
+	if stateDir == "" {
+		currentDir = filepath.Join(filepath.Dir(certFile), ".panel-current")
+		if _, err := os.Stat(filepath.Join(currentDir, "fullchain.pem")); err == nil {
+			return filepath.Join(currentDir, "fullchain.pem"), filepath.Join(currentDir, "privkey.pem")
+		}
 	}
 	return certFile, keyFile
 }
@@ -629,6 +645,34 @@ func validTLSNodeGUID(guid string) bool {
 	return true
 }
 
+const (
+	legacyEdgeCertificateMaxBytes = 4 << 20
+	legacyEdgePrivateKeyMaxBytes  = 1 << 20
+)
+
+func readLegacyTLSFile(path string, maxBytes int64) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Size() < 1 || info.Size() > maxBytes {
+		return nil, errors.New("legacy TLS file is not a bounded regular file")
+	}
+	file, err := os.Open(path) // #nosec G304 -- path is constructed from an administrator-owned legacy root and validated node GUID.
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	data, err := io.ReadAll(io.LimitReader(file, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 || int64(len(data)) > maxBytes {
+		return nil, errors.New("legacy TLS file exceeds size limit")
+	}
+	return data, nil
+}
+
 // migrateLegacyEdgeTLSState performs a one-time, allowlisted copy from the
 // pre-TLS_STATE_DIR external edge-nodes directory. It only considers GUIDs
 // present in control_nodes, validates regular files and the key pair, and
@@ -666,16 +710,16 @@ func migrateLegacyEdgeTLSState(db *DB, dbPath string) error {
 		sourceDir := filepath.Join(legacyRoot, guid, "current")
 		certSource := filepath.Join(sourceDir, "fullchain.pem")
 		keySource := filepath.Join(sourceDir, "privkey.pem")
-		certPEM, certErr := os.ReadFile(certSource) // #nosec G304 -- GUID is selected from the database and validated above.
-		keyPEM, keyErr := os.ReadFile(keySource)    // #nosec G304 -- GUID is selected from the database and validated above.
+		certPEM, certErr := readLegacyTLSFile(certSource, legacyEdgeCertificateMaxBytes)
+		keyPEM, keyErr := readLegacyTLSFile(keySource, legacyEdgePrivateKeyMaxBytes)
 		if errors.Is(certErr, os.ErrNotExist) || errors.Is(keyErr, os.ErrNotExist) {
 			continue
 		}
-		if certErr != nil {
-			return certErr
-		}
-		if keyErr != nil {
-			return keyErr
+		if certErr != nil || keyErr != nil {
+			// Legacy state is an operator-owned, low-trust input. Ignore
+			// symlinks, special files, oversized material, and unreadable entries;
+			// never activate a partially validated pair.
+			continue
 		}
 		if _, err := tls.X509KeyPair(certPEM, keyPEM); err != nil {
 			continue

--- a/security_fuzz_test.go
+++ b/security_fuzz_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"context"
 	"crypto/sha256"
+	"net/http"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -18,8 +21,14 @@ func FuzzNormalizeDynamicURL(f *testing.F) {
 	} {
 		f.Add(seed)
 	}
-	f.Fuzz(func(_ *testing.T, value string) {
-		_, _ = normalizeDynamicURL(value)
+	f.Fuzz(func(t *testing.T, value string) {
+		parsed, err := normalizeDynamicURL(value)
+		if err != nil {
+			return
+		}
+		if parsed.User != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || strings.ContainsAny(parsed.Host, "\\\r\n\t") || filepath.Clean(parsed.Path) != parsed.Path {
+			t.Fatalf("unsafe dynamic URL accepted: %q", parsed.String())
+		}
 	})
 }
 
@@ -70,8 +79,40 @@ func FuzzBackupArchiveParser(f *testing.F) {
 	} {
 		f.Add(seed)
 	}
-	f.Fuzz(func(_ *testing.T, value []byte) {
-		_, _, _ = parseBackupArchive(value)
+	f.Fuzz(func(t *testing.T, value []byte) {
+		_, entries, err := parseBackupArchive(value)
+		if err != nil {
+			return
+		}
+		if len(entries) > backupMaxFiles {
+			t.Fatalf("backup parser accepted too many entries: %d", len(entries))
+		}
+		for name := range entries {
+			if _, ok := backupEntryLimit(name); !ok || filepath.ToSlash(filepath.Clean(name)) != name || strings.HasPrefix(name, "/") {
+				t.Fatalf("backup parser accepted unsafe entry %q", name)
+			}
+		}
+	})
+}
+
+func FuzzCrossAuthorityHeaders(f *testing.F) {
+	for _, seed := range []string{"secret", "", "MediaBrowser Client=\"test\", Token=\"secret\""} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, value string) {
+		header := make(http.Header)
+		header.Set("Authorization", value)
+		header.Set("Proxy-Authorization", value)
+		header.Set("Cookie", value)
+		header.Set("X-Emby-Token", value)
+		header.Set("X-MediaBrowser-Token", value)
+		header.Set("X-Emby-Authorization", value)
+		stripSensitiveRedirectHeaders(header)
+		for _, name := range []string{"Authorization", "Proxy-Authorization", "Cookie", "X-Emby-Token", "X-MediaBrowser-Token"} {
+			if header.Get(name) != "" {
+				t.Fatalf("sensitive header survived cross-authority stripping: %s", name)
+			}
+		}
 	})
 }
 

--- a/site_node_scheduler.go
+++ b/site_node_scheduler.go
@@ -78,6 +78,7 @@ type AgentRuntimeConfig struct {
 	CertificatePEM   string           `json:"certificate_pem,omitempty"`
 	PrivateKeyPEM    string           `json:"private_key_pem,omitempty"`
 	DynamicKey       string           `json:"dynamic_key,omitempty"`
+	ProbeSecret      string           `json:"probe_secret,omitempty"`
 	AgentVersion     string           `json:"agent_version,omitempty"`
 	AgentSHA256      string           `json:"agent_sha256,omitempty"`
 	AgentDownloadURL string           `json:"agent_download_url,omitempty"`
@@ -369,6 +370,10 @@ func agentConfigHash(config AgentRuntimeConfig) (string, error) {
 func agentConfigLegacyHash(config AgentRuntimeConfig) (string, error) {
 	config.ConfigHash = ""
 	config.AgentDownloadURL = ""
+	// ProbeSecret was added after the legacy Agent contract. Older Agents ignore
+	// the field, so omit it from the compatibility hash while current Agents
+	// use the runtime hash above and authenticate their health probes with it.
+	config.ProbeSecret = ""
 	data, err := json.Marshal(config)
 	if err != nil {
 		return "", err
@@ -440,6 +445,10 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 	}
 	pending := make([]pendingRoute, 0)
 	dynamicKey := deriveNodeRuntimeKey(a.dynamicRouteKey, node.GUID, "dynamic-routes")
+	probeSecret, probeErr := dNodeProbeSecret(a.db, node)
+	if probeErr != nil {
+		return AgentRuntimeConfig{}, probeErr
+	}
 	for rows.Next() {
 		var value pendingRoute
 		if err := rows.Scan(&value.route.SiteID, &value.route.Host, &value.route.TargetURL, &value.route.PlaybackTargetURL, &value.route.PlaybackMode, &value.streamHosts, &value.storedHeaders); err != nil {
@@ -513,7 +522,7 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 	// Keep the legacy field names in the Agent wire contract during rolling
 	// upgrades. Their values now describe one HTTPS-only listener.
 	config := AgentRuntimeConfig{SchemaVersion: agentConfigSchemaVersion, NodeGUID: node.GUID, EntryMode: "direct",
-		HTTPPort: 0, HTTPSPort: node.Port, DynamicKey: encodeRuntimeKey(dynamicKey), Routes: routes}
+		HTTPPort: 0, HTTPSPort: node.Port, DynamicKey: encodeRuntimeKey(dynamicKey), ProbeSecret: encodeRuntimeKey([]byte(probeSecret)), Routes: routes}
 	// Legacy Agents do not send a platform header. Do not advertise the
 	// controller's local binary to those clients: on a cross-architecture
 	// rollout that checksum would make an old arm64 Agent download an amd64
@@ -769,7 +778,10 @@ func nodeHTTPSProbePort(node ControlNode) int {
 	return node.Port
 }
 
-func probeScheduledNode(ctx context.Context, node ControlNode, host string) error {
+func probeScheduledNode(ctx context.Context, node ControlNode, host string, probeSecret []byte) error {
+	if len(probeSecret) == 0 {
+		return errors.New("node health probe secret is unavailable")
+	}
 	address, err := nodeDialAddress(node.Address, nodeHTTPSProbePort(node))
 	if err != nil {
 		return err
@@ -789,6 +801,7 @@ func probeScheduledNode(ctx context.Context, node ControlNode, host string) erro
 	if err != nil {
 		return err
 	}
+	req.Header.Set("X-Meridian-Probe", encodeRuntimeKey(probeSecret))
 	response, err := client.Do(req)
 	if err != nil {
 		return err
@@ -839,7 +852,15 @@ func (a *App) reconcileOneSiteSchedule(ctx context.Context, schedule SiteNodeSch
 	if node.AgentListenerError != "" {
 		return readinessError(readinessListener, errors.New(node.AgentListenerError))
 	}
-	if err := probeScheduledNode(ctx, node, schedule.PublicHost); err != nil {
+	probeSecretText, err := dNodeProbeSecret(a.db, node)
+	if err != nil {
+		return readinessError(readinessProbe, err)
+	}
+	probeSecret, err := base64.RawURLEncoding.DecodeString(probeSecretText)
+	if err != nil {
+		return readinessError(readinessProbe, errors.New("node health probe secret is invalid"))
+	}
+	if err := probeScheduledNode(ctx, node, schedule.PublicHost, probeSecret); err != nil {
 		return readinessError(readinessProbe, fmt.Errorf("entry health check: %w", err))
 	}
 	if err := a.db.clearSiteNodeProbeFailure(schedule.SiteID, node.ID); err != nil {

--- a/telegram_report.go
+++ b/telegram_report.go
@@ -283,6 +283,18 @@ type telegramReportSettingsView struct {
 	Timezone     int
 }
 
+// telegramReportHTTPClient is a narrow injection point for redirect and
+// timeout regression tests. Production callers receive a fresh client with
+// redirects disabled because the bot token is embedded in the request URL.
+var telegramReportHTTPClient = func() *http.Client {
+	return &http.Client{
+		Timeout: 15 * time.Second,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
 func (d *DB) telegramReportSettingsView() (telegramReportSettingsView, telegramReportStoredSettings, error) {
 	stored, err := d.telegramReportSettings()
 	if err != nil {
@@ -560,14 +572,9 @@ func sendTelegramReport(ctx context.Context, botToken, chatID, message string) e
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	client := &http.Client{
-		Timeout: 15 * time.Second,
-		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
-			// Telegram credentials are embedded in the request URL. Never follow
-			// a redirect to another authority (or even replay them to a changed
-			// Telegram endpoint); treat every 3xx as an explicit failure.
-			return http.ErrUseLastResponse
-		},
+	client := telegramReportHTTPClient()
+	if client == nil {
+		return errors.New("telegram HTTP client is unavailable")
 	}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/telegram_report_test.go
+++ b/telegram_report_test.go
@@ -3,10 +3,46 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
 )
+
+type telegramRedirectTransport struct {
+	first  int
+	second int
+}
+
+func (t *telegramRedirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Host == "api.telegram.org" {
+		t.first++
+		return &http.Response{
+			StatusCode: http.StatusFound,
+			Header:     http.Header{"Location": []string{"https://redirect.example.test/sendMessage"}},
+			Body:       io.NopCloser(strings.NewReader(`{"ok":false,"description":"redirect"}`)),
+			Request:    req,
+		}, nil
+	}
+	t.second++
+	return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"ok":true}`)), Request: req}, nil
+}
+
+func TestTelegramReportRejectsRedirectWithoutFollowing(t *testing.T) {
+	transport := &telegramRedirectTransport{}
+	previous := telegramReportHTTPClient
+	telegramReportHTTPClient = func() *http.Client {
+		return &http.Client{Timeout: 15 * time.Second, Transport: transport, CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse }}
+	}
+	t.Cleanup(func() { telegramReportHTTPClient = previous })
+	if err := sendTelegramReport(context.Background(), "bot-token", "123", "hello"); err == nil {
+		t.Fatal("Telegram redirect was accepted")
+	}
+	if transport.first != 1 || transport.second != 0 {
+		t.Fatalf("redirect transport calls = first %d second %d, want 1/0", transport.first, transport.second)
+	}
+}
 
 func TestTelegramReportTokenRoundTrip(t *testing.T) {
 	ciphertext, err := encryptTelegramBotToken("123456:example-token")


### PR DESCRIPTION
## 问题
Agent 报告、TLS 状态迁移、备份和发布链路仍有跨模块一致性与资源边界风险。

## 变更
- 在同一 SQLite 事务中认证 Agent、校验 Node→Site 权限、写入遥测/事件并生成 ACK；非法站点事件单独丢弃并返回 discarded 列表。
- 为 HTTP 与 WebSocket 增加共享的预认证、每节点限速和并发门禁；WebSocket 在 admission 后才接收/解码帧。
- 增加独立节点健康探针密钥、TLS_STATE_DIR 迁移与外部证书路径隔离。
- 增加 MRDBKP02 分块 AEAD、磁盘空间预检、流式导出/恢复和 MRDBKP01 兼容。
- 增加安全审计指标、Telegram 重定向拒绝、fuzz 工作流和 Release 版本/build mode/已发布 Release 保护。

## 验证
- go test ./...
- go test -race ./...
- go vet ./...（含 Windows/Darwin 交叉 vet）
- govulncheck ./...
- gosec
- node --test tests/*.test.js
- 全部 web/static/js JavaScript 语法检查
- ShellCheck

Windows 本地无 Docker daemon/Bash；Docker 构建与 Bash 集成测试由 GitHub CI 执行。
