### PR TITLE
fix: harden agent reports, probe secrets, backups, and releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
       release_tag: ${{ steps.release_tag.outputs.value }}
 
@@ -47,6 +49,18 @@ jobs:
             exit 1
           fi
           printf 'value=%s\n' "$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Refuse to mutate a published release
+        env:
+          RELEASE_TAG: ${{ steps.release_tag.outputs.value }}
+        run: |
+          set -euo pipefail
+          existing_release="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+            --jq '.[] | select(.tag_name == env.RELEASE_TAG) | select(.draft == false) | .id' | head -n1)"
+          if [ -n "$existing_release" ]; then
+            echo "Release ${RELEASE_TAG} is already published and cannot be mutated." >&2
+            exit 1
+          fi
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -178,21 +192,6 @@ jobs:
             meridian-*
             SHA256SUMS
 
-      - name: Refuse to mutate a published release
-        env:
-          RELEASE_TAG: ${{ needs.verify.outputs.release_tag }}
-        run: |
-          set -euo pipefail
-          # A published release is immutable from Meridian's workflow. This
-          # also protects manual reruns of an older tag from replacing assets
-          # that agents may already trust.
-          existing_draft="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
-            --jq '.[] | select(.tag_name == env.RELEASE_TAG) | select(.draft == false) | .id' | head -n1)"
-          if [ -n "$existing_draft" ]; then
-            echo "Release ${RELEASE_TAG} is already published and cannot be mutated." >&2
-            exit 1
-          fi
-
       - name: Create Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
@@ -251,6 +250,14 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Refuse to overwrite an existing versioned image tag
+        run: |
+          set -euo pipefail
+          if docker buildx imagetools inspect "$IMAGE_NAME:$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Container tag $IMAGE_NAME:$RELEASE_TAG already exists and is immutable." >&2
+            exit 1
+          fi
 
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.6-alpine AS builder
+FROM golang:1.26.6-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83 AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./
@@ -10,7 +10,7 @@ ARG VERSION=dev
 RUN CGO_ENABLED=0 go build -trimpath -buildvcs=false -ldflags="-s -w -X main.appVersion=${VERSION} -X main.buildMode=controller" -o meridian .
 
 # Runtime stage
-FROM alpine:3.24
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
 RUN apk add --no-cache ca-certificates libcap su-exec tzdata
 

--- a/agent_e2e_test.go
+++ b/agent_e2e_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestControllerAgentHTTPConfigApplyAndReportE2E exercises the production
+// HTTP contract end to end: enrollment, config serialization, Agent envelope
+// validation/application, and a report containing both authorized and
+// unauthorized site telemetry. It uses SQLite and real HTTP handlers while
+// keeping DNS/Cloudflare outside the test.
+func TestControllerAgentHTTPConfigApplyAndReportE2E(t *testing.T) {
+	app := newTestApp(t)
+	app.dynamicRouteKey = bytes.Repeat([]byte{0x31}, 32)
+	installReviewCertificate(t, app)
+	now := time.Now().UTC()
+	nodeA, enrollmentA, err := app.db.CreateControlNode(NodeCreateInput{Name: "e2e-a", Address: "203.0.113.80", Port: 19090}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nodeB, enrollmentB, err := app.db.CreateControlNode(NodeCreateInput{Name: "e2e-b", Address: "203.0.113.81", Port: 19091}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, tokenA, err := app.db.EnrollControlNode(enrollmentA, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := app.db.EnrollControlNode(enrollmentB, now); err != nil {
+		t.Fatal(err)
+	}
+	installReviewCertificateForNode(t, app, nodeA.GUID)
+	installReviewCertificateForNode(t, app, nodeB.GUID)
+	siteAPort := freePort(t)
+	releasePort(siteAPort)
+	siteA, err := app.db.CreateSiteRecord(Site{Name: "e2e-a-site", ListenPort: siteAPort, PublicHost: "a.e2e.example", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:1", PlaybackMode: "direct", MainVideoStreamMode: "proxy", StreamHosts: "[]", UAMode: passthroughUAMode})
+	if err != nil {
+		t.Fatal(err)
+	}
+	siteBPort := freePort(t)
+	releasePort(siteBPort)
+	siteB, err := app.db.CreateSiteRecord(Site{Name: "e2e-b-site", ListenPort: siteBPort, PublicHost: "b.e2e.example", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:1", PlaybackMode: "direct", MainVideoStreamMode: "proxy", StreamHosts: "[]", UAMode: passthroughUAMode})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.SaveSiteNodeSchedule(siteA.ID, true, "fixed", nodeA.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.SaveSiteNodeSchedule(siteB.ID, true, "fixed", nodeB.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.RecordNodeReport(tokenA, NodeReport{BootID: "e2e-bootstrap", ReportSessionID: "e2e-bootstrap", CounterEpoch: "e2e-kernel:eth0", Sequence: 1, InterfaceName: "eth0", AgentVersion: "test"}, now); err != nil {
+		t.Fatal(err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/agent/config", app.withAgentPreAuth(app.handleAgentConfig))
+	mux.HandleFunc("/api/agent/report", app.withAgentPreAuth(app.handleAgentReport))
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	request, err := http.NewRequest(http.MethodGet, server.URL+"/api/agent/config", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Authorization", "Bearer "+tokenA)
+	response, err := server.Client().Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("config status=%d", response.StatusCode)
+	}
+	var config AgentRuntimeConfig
+	if err := json.NewDecoder(response.Body).Decode(&config); err != nil {
+		t.Fatal(err)
+	}
+	if len(config.Routes) != 1 || config.Routes[0].SiteID != siteA.ID {
+		t.Fatalf("Agent received unauthorized routes: %#v", config.Routes)
+	}
+	port := freePort(t)
+	releasePort(port)
+	config.HTTPSPort = port
+	config.ConfigHash, err = agentConfigLegacyHash(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := &edgeAgentRuntime{stateDir: t.TempDir()}
+	if err := runtime.apply(config); err != nil {
+		t.Fatalf("Agent failed to apply Controller config: %v", err)
+	}
+	runtime.close()
+	unauthorizedUID := strings.Repeat("b", 32)
+	report := NodeReport{BootID: "e2e-session", ReportSessionID: "e2e-session", CounterEpoch: "e2e-kernel:eth0", Sequence: 1, InterfaceName: "eth0", AppliedConfigHash: config.ConfigHash,
+		Events: []NodeRequestEvent{{EventID: 1, EventUID: strings.Repeat("a", 32), SiteID: siteA.ID, Host: siteA.PublicHost, Method: http.MethodGet, Path: "/ok", StatusCode: 200, RecordedAtMS: now.UnixMilli()}, {EventID: 2, EventUID: unauthorizedUID, SiteID: siteB.ID, Host: siteB.PublicHost, Method: http.MethodGet, Path: "/no", StatusCode: 200, RecordedAtMS: now.UnixMilli()}}}
+	body, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reportRequest, err := http.NewRequest(http.MethodPost, server.URL+"/api/agent/report", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	reportRequest.Header.Set("Authorization", "Bearer "+tokenA)
+	reportRequest.Header.Set("Content-Type", "application/json")
+	reportResponse, err := server.Client().Do(reportRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reportResponse.Body.Close()
+	if reportResponse.StatusCode != http.StatusOK {
+		t.Fatalf("report status=%d", reportResponse.StatusCode)
+	}
+	var acknowledgement struct {
+		AcceptedEventIDs   []int64  `json:"accepted_event_ids"`
+		DiscardedEventIDs  []int64  `json:"discarded_event_ids"`
+		DiscardedEventUIDs []string `json:"discarded_event_uids"`
+	}
+	if err := json.NewDecoder(reportResponse.Body).Decode(&acknowledgement); err != nil {
+		t.Fatal(err)
+	}
+	if len(acknowledgement.AcceptedEventIDs) != 1 || acknowledgement.AcceptedEventIDs[0] != 1 || len(acknowledgement.DiscardedEventIDs) != 1 || acknowledgement.DiscardedEventIDs[0] != 2 || len(acknowledgement.DiscardedEventUIDs) != 1 || acknowledgement.DiscardedEventUIDs[0] != unauthorizedUID {
+		t.Fatalf("unexpected report acknowledgement: %#v", acknowledgement)
+	}
+	var logs int
+	if err := app.db.db.QueryRow("SELECT COUNT(*) FROM request_logs WHERE site_id=?", siteB.ID).Scan(&logs); err != nil {
+		t.Fatal(err)
+	}
+	if logs != 0 {
+		t.Fatalf("unauthorized Site B event created %d request logs", logs)
+	}
+}

--- a/agent_report_guard.go
+++ b/agent_report_guard.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"container/list"
+	"math"
+	"net/http"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -27,16 +31,20 @@ type nodeReportAdmission struct {
 }
 
 const (
-	agentPreAuthRatePerSecond = 10.0
-	agentPreAuthBurst         = 20.0
-	agentPreAuthEntryTTL      = 15 * time.Minute
-	agentPreAuthConcurrency   = 32
+	agentPreAuthRatePerSecond     = 10.0
+	agentPreAuthBurst             = 20.0
+	agentPreAuthEntryTTL          = 15 * time.Minute
+	agentPreAuthConcurrency       = 32
+	maxTrackedAgentPreAuthClients = 4096
+	agentPreAuthPruneInterval     = time.Minute
 )
 
 type agentPreAuthEntry struct {
-	tokens   float64
-	last     time.Time
-	lastSeen time.Time
+	tokens         float64
+	last           time.Time
+	lastSeen       time.Time
+	active         int
+	inactiveHandle *list.Element
 }
 
 // agentPreAuthAdmission is deliberately keyed by the trusted-proxy-aware
@@ -44,20 +52,77 @@ type agentPreAuthEntry struct {
 // lookup so a stream of invalid credentials cannot monopolize the sole DB
 // connection.
 type agentPreAuthAdmission struct {
-	mu      sync.Mutex
-	entries map[string]*agentPreAuthEntry
-	active  int
+	mu         sync.Mutex
+	entries    map[string]*agentPreAuthEntry
+	inactive   *list.List
+	active     int
+	maxEntries int
+	lastPrune  time.Time
 }
 
 func newAgentPreAuthAdmission() *agentPreAuthAdmission {
-	return &agentPreAuthAdmission{entries: make(map[string]*agentPreAuthEntry)}
+	return &agentPreAuthAdmission{entries: make(map[string]*agentPreAuthEntry), inactive: list.New(), maxEntries: maxTrackedAgentPreAuthClients}
+}
+
+func (a *agentPreAuthAdmission) addInactive(key string, entry *agentPreAuthEntry) {
+	if entry == nil || entry.active > 0 {
+		return
+	}
+	if a.inactive == nil {
+		a.inactive = list.New()
+	}
+	if entry.inactiveHandle != nil {
+		a.inactive.MoveToBack(entry.inactiveHandle)
+		return
+	}
+	entry.inactiveHandle = a.inactive.PushBack(key)
+}
+
+func (a *agentPreAuthAdmission) removeInactive(entry *agentPreAuthEntry) {
+	if entry == nil || entry.inactiveHandle == nil || a.inactive == nil {
+		return
+	}
+	a.inactive.Remove(entry.inactiveHandle)
+	entry.inactiveHandle = nil
 }
 
 func (a *agentPreAuthAdmission) prune(now time.Time) {
 	for key, entry := range a.entries {
-		if now.Sub(entry.lastSeen) > agentPreAuthEntryTTL {
+		if entry.active == 0 && now.Sub(entry.lastSeen) > agentPreAuthEntryTTL {
+			a.removeInactive(entry)
 			delete(a.entries, key)
 		}
+	}
+}
+
+func (a *agentPreAuthAdmission) maybePrune(now time.Time) {
+	if !a.lastPrune.IsZero() && now.Sub(a.lastPrune) < agentPreAuthPruneInterval {
+		return
+	}
+	a.prune(now)
+	a.lastPrune = now
+}
+
+func (a *agentPreAuthAdmission) evictOne() {
+	if a.inactive == nil {
+		return
+	}
+	for element := a.inactive.Front(); element != nil; element = a.inactive.Front() {
+		key, ok := element.Value.(string)
+		a.inactive.Remove(element)
+		if !ok {
+			continue
+		}
+		entry := a.entries[key]
+		if entry == nil || entry.active > 0 {
+			if entry != nil {
+				entry.inactiveHandle = nil
+			}
+			continue
+		}
+		entry.inactiveHandle = nil
+		delete(a.entries, key)
+		return
 	}
 }
 
@@ -67,14 +132,26 @@ func (a *agentPreAuthAdmission) admit(key string, now time.Time) (func(), time.D
 	if key == "" {
 		key = "unknown"
 	}
-	a.prune(now)
+	a.maybePrune(now)
 	if a.active >= agentPreAuthConcurrency {
 		return func() {}, time.Second, false
 	}
 	entry := a.entries[key]
 	if entry == nil {
+		if a.maxEntries <= 0 {
+			a.maxEntries = maxTrackedAgentPreAuthClients
+		}
+		if len(a.entries) >= a.maxEntries {
+			a.evictOne()
+			if len(a.entries) >= a.maxEntries {
+				return func() {}, time.Second, false
+			}
+		}
 		entry = &agentPreAuthEntry{tokens: agentPreAuthBurst, last: now, lastSeen: now}
 		a.entries[key] = entry
+		a.addInactive(key, entry)
+	} else if entry.active == 0 {
+		a.removeInactive(entry)
 	}
 	if entry.last.IsZero() {
 		entry.last = now
@@ -88,6 +165,7 @@ func (a *agentPreAuthAdmission) admit(key string, now time.Time) (func(), time.D
 	}
 	entry.lastSeen = now
 	if entry.tokens < 1 {
+		a.addInactive(key, entry)
 		wait := time.Duration((1 - entry.tokens) / agentPreAuthRatePerSecond * float64(time.Second))
 		if wait < time.Millisecond {
 			wait = time.Millisecond
@@ -95,11 +173,18 @@ func (a *agentPreAuthAdmission) admit(key string, now time.Time) (func(), time.D
 		return func() {}, wait, false
 	}
 	entry.tokens--
+	entry.active++
 	a.active++
 	return func() {
 		a.mu.Lock()
 		if a.active > 0 {
 			a.active--
+		}
+		if entry.active > 0 {
+			entry.active--
+		}
+		if entry.active == 0 {
+			a.addInactive(key, entry)
 		}
 		if current := a.entries[key]; current != nil {
 			current.lastSeen = time.Now()
@@ -192,4 +277,24 @@ func (a *App) agentPreAuthAdmission() *agentPreAuthAdmission {
 		a.agentPreAuth = newAgentPreAuthAdmission()
 	}
 	return a.agentPreAuth
+}
+
+// withAgentPreAuth is shared by every credential-bearing Agent endpoint. It
+// runs before endpoint-specific parsing or SQLite authentication so invalid
+// credentials cannot rotate between URLs to evade the admission budget.
+func (a *App) withAgentPreAuth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		release, retryAfter, admitted := a.agentPreAuthAdmission().admit(requestClientKey(r, a.trustedProxies), time.Now())
+		if !admitted {
+			seconds := int(math.Ceil(retryAfter.Seconds()))
+			if seconds < 1 {
+				seconds = 1
+			}
+			w.Header().Set("Retry-After", strconv.Itoa(seconds))
+			a.jsonErr(w, http.StatusTooManyRequests, "agent authentication rate limit exceeded")
+			return
+		}
+		defer release()
+		next(w, r)
+	}
 }

--- a/agent_report_guard_test.go
+++ b/agent_report_guard_test.go
@@ -1,9 +1,34 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 )
+
+func TestAgentPreAuthCannotBeBypassedByEndpointRotation(t *testing.T) {
+	app := &App{}
+	handler := app.withAgentPreAuth(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	paths := []string{"/api/agent/enroll", "/api/agent/config", "/api/agent/manifest", "/api/agent/binary", "/api/agent/report"}
+	for i := 0; i < agentPreAuthBurst; i++ {
+		req := httptest.NewRequest(http.MethodGet, paths[i%len(paths)], nil)
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, req)
+		if response.Code != http.StatusNoContent {
+			t.Fatalf("request %d was rejected before burst exhausted: %d", i, response.Code)
+		}
+	}
+	req := httptest.NewRequest(http.MethodGet, paths[0], nil)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, req)
+	if response.Code != http.StatusTooManyRequests {
+		t.Fatalf("rotated endpoint bypassed shared pre-auth limiter: %d", response.Code)
+	}
+}
 
 func TestAgentSecurityAuditStateIsBoundedByNodeAndCategory(t *testing.T) {
 	db := &DB{}
@@ -71,5 +96,58 @@ func TestNodeReportAdmissionReclaimsIdleEntries(t *testing.T) {
 	admission.mu.Unlock()
 	if exists {
 		t.Fatal("idle node report limiter entry was not reclaimed")
+	}
+}
+
+func TestAgentPreAuthAdmissionHasHardEntryLimit(t *testing.T) {
+	admission := newAgentPreAuthAdmission()
+	now := time.Now()
+	for i := 0; i < maxTrackedAgentPreAuthClients+100000; i++ {
+		release, _, ok := admission.admit("client-"+strconv.Itoa(i), now)
+		if ok {
+			release()
+		}
+	}
+	admission.mu.Lock()
+	entries := len(admission.entries)
+	admission.mu.Unlock()
+	if entries > maxTrackedAgentPreAuthClients {
+		t.Fatalf("pre-auth entries=%d, want <=%d", entries, maxTrackedAgentPreAuthClients)
+	}
+}
+
+func TestAgentPreAuthAdmissionDoesNotEvictActiveEntries(t *testing.T) {
+	admission := newAgentPreAuthAdmission()
+	now := time.Now()
+	release, _, ok := admission.admit("active", now)
+	if !ok {
+		t.Fatal("active client was rejected")
+	}
+	t.Cleanup(release)
+	admission.mu.Lock()
+	admission.maxEntries = 1
+	admission.mu.Unlock()
+	if _, _, ok := admission.admit("new-client", now); ok {
+		t.Fatal("new client admitted while the only tracked entry was active")
+	}
+	admission.mu.Lock()
+	_, exists := admission.entries["active"]
+	admission.mu.Unlock()
+	if !exists {
+		t.Fatal("active pre-auth entry was evicted")
+	}
+}
+
+func BenchmarkAgentPreAuthAdmissionLargeMap(b *testing.B) {
+	admission := newAgentPreAuthAdmission()
+	now := time.Now()
+	for i := 0; i < maxTrackedAgentPreAuthClients; i++ {
+		admission.entries[strconv.Itoa(i)] = &agentPreAuthEntry{tokens: agentPreAuthBurst, last: now, lastSeen: now}
+	}
+	for i := 0; i < b.N; i++ {
+		release, _, ok := admission.admit("steady-client", now.Add(time.Duration(i)*time.Millisecond))
+		if ok {
+			release()
+		}
 	}
 }

--- a/app_nodes.go
+++ b/app_nodes.go
@@ -256,6 +256,8 @@ func writeNodeAPIError(a *App, w http.ResponseWriter, err error) {
 		a.jsonErr(w, http.StatusConflict, "node name already exists")
 	case errors.Is(err, errManualNodeUnavailable):
 		a.jsonErr(w, http.StatusConflict, err.Error())
+	case errors.Is(err, errPersistentJWTRequired):
+		a.jsonErr(w, http.StatusConflict, "请先配置持久 JWT_SECRET，再创建或注册 Agent 节点")
 	default:
 		a.jsonErr(w, http.StatusBadRequest, err.Error())
 	}
@@ -624,6 +626,10 @@ func (a *App) handleAgentEnroll(w http.ResponseWriter, r *http.Request) {
 	}
 	node, agentToken, err := a.db.EnrollControlNode(requestBearerToken(r), time.Now())
 	if err != nil {
+		if errors.Is(err, errPersistentJWTRequired) {
+			a.jsonErr(w, http.StatusConflict, "请先配置持久 JWT_SECRET，再注册 Agent 节点")
+			return
+		}
 		a.jsonErr(w, http.StatusUnauthorized, "invalid enrollment token")
 		return
 	}
@@ -648,19 +654,8 @@ func (a *App) handleAgentReport(w http.ResponseWriter, r *http.Request) {
 		a.jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
-	preRelease, retryAfter, preAdmitted := a.agentPreAuthAdmission().admit(requestClientKey(r, a.trustedProxies), time.Now())
-	if !preAdmitted {
-		seconds := int(retryAfter.Seconds())
-		if seconds < 1 {
-			seconds = 1
-		}
-		w.Header().Set("Retry-After", strconv.Itoa(seconds))
-		a.jsonErr(w, http.StatusTooManyRequests, "agent authentication rate limit exceeded")
-		return
-	}
 	token := requestBearerToken(r)
 	node, authErr := a.db.nodeByAgentToken(token, time.Now())
-	preRelease()
 	if authErr != nil {
 		a.jsonErr(w, http.StatusUnauthorized, "invalid agent token")
 		return

--- a/backup_restore.go
+++ b/backup_restore.go
@@ -853,11 +853,127 @@ func parseBackupArchiveFile(path string) (backupManifest, map[string][]byte, err
 	return parseBackupZipReader(reader)
 }
 
+// backupArchiveInspection performs all central-directory checks before any
+// archive entry is extracted. This gives restore a disk-space decision point
+// while the target filesystem is still untouched.
+type backupArchiveInspection struct {
+	Manifest      backupManifest
+	Entries       []*zip.File
+	EntryCount    int
+	ExpandedBytes int64
+	DatabaseBytes int64
+	TLSBytes      int64
+}
+
+func inspectBackupArchiveFile(path string) (backupArchiveInspection, error) {
+	var result backupArchiveInspection
+	file, err := os.Open(path) // #nosec G304 -- path is an internal restore staging file.
+	if err != nil {
+		return result, err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return result, err
+	}
+	reader, err := zip.NewReader(file, info.Size())
+	if err != nil {
+		return result, errors.New("备份压缩包损坏")
+	}
+	if len(reader.File) < 2 || len(reader.File) > backupMaxFiles {
+		return result, errors.New("备份文件数量无效")
+	}
+	seen := make(map[string]struct{}, len(reader.File))
+	result.Entries = append([]*zip.File(nil), reader.File...)
+	var manifestFile *zip.File
+	for _, archiveEntry := range reader.File {
+		limit, allowed := backupEntryLimit(archiveEntry.Name)
+		if !allowed || filepath.ToSlash(filepath.Clean(archiveEntry.Name)) != archiveEntry.Name || strings.HasPrefix(archiveEntry.Name, "/") {
+			return result, fmt.Errorf("备份包含不允许的文件: %s", archiveEntry.Name)
+		}
+		if _, duplicate := seen[archiveEntry.Name]; duplicate {
+			return result, fmt.Errorf("备份包含重复文件: %s", archiveEntry.Name)
+		}
+		seen[archiveEntry.Name] = struct{}{}
+		if archiveEntry.UncompressedSize64 > uint64(limit) || archiveEntry.UncompressedSize64 > uint64(backupMaxExpandedBytes) { // #nosec G115 -- fixed positive limits.
+			return result, fmt.Errorf("%s 解压后过大", archiveEntry.Name)
+		}
+		if archiveEntry.CompressedSize64 > uint64(backupMaxUploadBytes) { // #nosec G115 -- fixed positive limits.
+			return result, fmt.Errorf("%s 压缩数据过大", archiveEntry.Name)
+		}
+		if archiveEntry.UncompressedSize64 > uint64(backupMaxExpandedBytes)-uint64(result.ExpandedBytes) { // #nosec G115 -- fixed positive limits.
+			return result, errors.New("备份解压后总大小超出限制")
+		}
+		result.ExpandedBytes += int64(archiveEntry.UncompressedSize64)
+		if archiveEntry.Name == backupDatabaseEntry {
+			result.DatabaseBytes = int64(archiveEntry.UncompressedSize64)
+		}
+		if strings.HasPrefix(archiveEntry.Name, "tls/") {
+			result.TLSBytes += int64(archiveEntry.UncompressedSize64)
+		}
+		if archiveEntry.Name == backupManifestEntry {
+			manifestFile = archiveEntry
+		}
+	}
+	if manifestFile == nil {
+		return result, errors.New("备份缺少清单")
+	}
+	manifestData, err := readZipEntry(manifestFile, 1<<20)
+	if err != nil {
+		return result, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(manifestData))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&result.Manifest); err != nil {
+		return result, errors.New("备份清单无效")
+	}
+	if result.Manifest.Format != "meridian-backup" || (result.Manifest.FormatVersion != backupFormatVersion && result.Manifest.FormatVersion != backupLegacyFormatVersion) {
+		return result, errors.New("不支持的备份格式版本")
+	}
+	if result.Manifest.DatabaseSchemaVersion > databaseSchemaVersion {
+		return result, errors.New("该备份由更高数据库版本的 Meridian 创建，请先升级 Meridian 后再恢复")
+	}
+	if result.DatabaseBytes <= 0 {
+		return result, errors.New("备份缺少数据库")
+	}
+	if !manifestIncludesTLS(result.Manifest) {
+		for name := range seen {
+			if strings.HasPrefix(name, "tls/") {
+				return result, errors.New("备份清单声明不包含 TLS，但压缩包中存在 TLS 文件")
+			}
+		}
+	}
+	declared := make(map[string]struct{}, len(result.Manifest.Files)+1)
+	declared[backupManifestEntry] = struct{}{}
+	for _, name := range result.Manifest.Files {
+		if _, allowed := backupEntryLimit(name); !allowed || name == backupManifestEntry {
+			return result, errors.New("备份清单文件列表无效")
+		}
+		if _, duplicate := declared[name]; duplicate {
+			return result, errors.New("备份清单文件列表无效")
+		}
+		declared[name] = struct{}{}
+	}
+	if len(declared) != len(seen) {
+		return result, errors.New("备份清单与文件内容不一致")
+	}
+	for name := range seen {
+		if _, ok := declared[name]; !ok {
+			return result, errors.New("备份清单与文件内容不一致")
+		}
+	}
+	result.EntryCount = len(reader.File)
+	return result, nil
+}
+
 // parseBackupArchiveFileToPaths validates a decrypted archive while keeping
 // each entry on disk. The restore path uses this variant so a legal large
 // backup never becomes an in-memory map[string][]byte.
 func parseBackupArchiveFileToPaths(path, entriesDir string) (backupManifest, map[string]string, error) {
 	var manifest backupManifest
+	if _, err := inspectBackupArchiveFile(path); err != nil {
+		return manifest, nil, err
+	}
 	file, err := os.Open(path) // #nosec G304 -- path is an internal restore staging file.
 	if err != nil {
 		return manifest, nil, err
@@ -898,6 +1014,15 @@ func parseBackupArchiveFileToPaths(path, entriesDir string) (backupManifest, map
 		if err := copyZipEntryToFile(archiveEntry, limit, entryPath); err != nil {
 			return manifest, nil, err
 		}
+		actualInfo, statErr := os.Stat(entryPath)
+		if statErr != nil {
+			return manifest, nil, statErr
+		}
+		expandedBefore := expanded - int64(archiveEntry.UncompressedSize64)
+		if actualInfo.Size() > limit || actualInfo.Size() > backupMaxExpandedBytes-expandedBefore {
+			return manifest, nil, errors.New("备份解压后总大小超出限制")
+		}
+		expanded = expandedBefore + actualInfo.Size()
 		entries[archiveEntry.Name] = entryPath
 	}
 	manifestPath, ok := entries[backupManifestEntry]
@@ -1017,6 +1142,30 @@ func ensureRestoreDiskSpace(dbPath string, entries map[string]string) error {
 	// state is similarly copied into pending and rollback namespaces. Keep a
 	// generous fixed margin for SQLite journals and directory metadata.
 	required := incomingDB*2 + currentDB + incomingTLS*2 + (64 << 20)
+	return ensureDiskSpace(filepath.Dir(dbPath), required)
+}
+
+func ensureRestoreDiskSpaceInspection(dbPath string, inspection backupArchiveInspection, encryptedBytes, plainBytes int64) error {
+	if strings.TrimSpace(dbPath) == "" {
+		return nil
+	}
+	if inspection.DatabaseBytes <= 0 {
+		return errors.New("备份缺少数据库")
+	}
+	var currentDB int64
+	if info, err := os.Stat(dbPath); err == nil {
+		currentDB = info.Size()
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	// Before extraction, account for the encrypted upload, decrypted ZIP,
+	// extracted entries, staged database/TLS tree, and rollback copies. This is
+	// intentionally conservative: failing closed is preferable to filling the
+	// filesystem halfway through a restore.
+	if encryptedBytes < 0 || plainBytes < 0 {
+		return errors.New("备份大小无效")
+	}
+	required := inspection.DatabaseBytes*2 + currentDB + inspection.TLSBytes*2 + encryptedBytes + plainBytes + (64 << 20)
 	return ensureDiskSpace(filepath.Dir(dbPath), required)
 }
 
@@ -2357,25 +2506,11 @@ func (a *App) handleBackupRestore(w http.ResponseWriter, r *http.Request) {
 		a.jsonErr(w, http.StatusConflict, "当前数据库模式不支持恢复")
 		return
 	}
-	r.Body = http.MaxBytesReader(w, r.Body, backupMaxUploadBytes+(1<<20))
-	if err := r.ParseMultipartForm(1 << 20); err != nil {
-		a.jsonErr(w, http.StatusBadRequest, "上传文件过大或表单无效")
-		return
-	}
-	if r.MultipartForm != nil {
-		defer r.MultipartForm.RemoveAll()
-	}
-	password := r.FormValue("password")
-	if r.FormValue("confirm") != "恢复" {
-		a.jsonErr(w, http.StatusBadRequest, "请输入“恢复”确认操作")
-		return
-	}
-	file, _, err := r.FormFile("backup")
-	if err != nil {
-		a.jsonErr(w, http.StatusBadRequest, "请选择 Meridian 备份文件")
-		return
-	}
-	defer file.Close()
+	// Parse multipart parts directly into the private restore directory. Using
+	// ParseMultipartForm would spill large file parts to the system temp
+	// directory and retain form metadata in memory before we can perform a disk
+	// preflight.
+	r.Body = http.MaxBytesReader(w, r.Body, backupMaxUploadBytes+(4<<20))
 	restoreTemp, err := os.MkdirTemp(filepath.Dir(a.dbPath), ".meridian-restore-upload-*")
 	if err != nil {
 		a.jsonErr(w, http.StatusInternalServerError, "恢复暂存目录创建失败")
@@ -2383,15 +2518,71 @@ func (a *App) handleBackupRestore(w http.ResponseWriter, r *http.Request) {
 	}
 	defer os.RemoveAll(restoreTemp)
 	encryptedPath := filepath.Join(restoreTemp, "backup.mrbak")
-	encrypted, err := os.OpenFile(encryptedPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600) // #nosec G304 -- encryptedPath is inside a private restore directory.
+	reader, err := r.MultipartReader()
 	if err != nil {
-		a.jsonErr(w, http.StatusInternalServerError, "恢复暂存文件创建失败")
+		a.jsonErr(w, http.StatusBadRequest, "上传文件过大或表单无效")
 		return
 	}
-	readBytes, copyErr := io.Copy(encrypted, io.LimitReader(file, backupMaxUploadBytes+1))
-	closeErr := encrypted.Close()
-	if copyErr != nil || closeErr != nil || readBytes > backupMaxUploadBytes {
-		a.jsonErr(w, http.StatusBadRequest, "备份文件读取失败或超过 256 MiB")
+	var password, confirmation string
+	var readBytes int64
+	var havePassword, haveConfirmation, haveBackup bool
+	var encrypted *os.File
+	for {
+		part, nextErr := reader.NextPart()
+		if errors.Is(nextErr, io.EOF) {
+			break
+		}
+		if nextErr != nil {
+			a.jsonErr(w, http.StatusBadRequest, "上传文件过大或表单无效")
+			return
+		}
+		name := part.FormName()
+		if name == "password" || name == "confirm" {
+			if (name == "password" && havePassword) || (name == "confirm" && haveConfirmation) {
+				_ = part.Close()
+				a.jsonErr(w, http.StatusBadRequest, "表单字段重复")
+				return
+			}
+			value, valueErr := io.ReadAll(io.LimitReader(part, backupMaxPasswordBytes+1))
+			_ = part.Close()
+			if valueErr != nil || len(value) > backupMaxPasswordBytes {
+				a.jsonErr(w, http.StatusBadRequest, "备份密码或确认信息无效")
+				return
+			}
+			if name == "password" {
+				password, havePassword = string(value), true
+			} else {
+				confirmation, haveConfirmation = string(value), true
+			}
+			continue
+		}
+		if name != "backup" || haveBackup {
+			_ = part.Close()
+			a.jsonErr(w, http.StatusBadRequest, "表单字段无效")
+			return
+		}
+		haveBackup = true
+		var openErr error
+		encrypted, openErr = os.OpenFile(encryptedPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) // #nosec G304 -- encryptedPath is inside a private restore directory.
+		if openErr != nil {
+			_ = part.Close()
+			a.jsonErr(w, http.StatusInternalServerError, "恢复暂存文件创建失败")
+			return
+		}
+		readBytes, err = io.Copy(encrypted, io.LimitReader(part, backupMaxUploadBytes+1))
+		closeErr := encrypted.Close()
+		_ = part.Close()
+		if err != nil || closeErr != nil || readBytes > backupMaxUploadBytes {
+			a.jsonErr(w, http.StatusBadRequest, "备份文件读取失败或超过 256 MiB")
+			return
+		}
+	}
+	if !havePassword || !haveConfirmation || confirmation != "恢复" {
+		a.jsonErr(w, http.StatusBadRequest, "请输入“恢复”确认操作")
+		return
+	}
+	if !haveBackup {
+		a.jsonErr(w, http.StatusBadRequest, "请选择 Meridian 备份文件")
 		return
 	}
 	if err := ensureDiskSpace(restoreTemp, readBytes*3+64<<20); err != nil {
@@ -2443,6 +2634,20 @@ func (a *App) handleBackupRestore(w http.ResponseWriter, r *http.Request) {
 	}
 	if decryptErr != nil {
 		a.jsonErr(w, http.StatusBadRequest, decryptErr.Error())
+		return
+	}
+	plainInfo, statErr := os.Stat(plainPath)
+	if statErr != nil {
+		a.jsonErr(w, http.StatusInternalServerError, "恢复解密文件检查失败")
+		return
+	}
+	inspection, inspectErr := inspectBackupArchiveFile(plainPath)
+	if inspectErr != nil {
+		a.jsonErr(w, http.StatusBadRequest, inspectErr.Error())
+		return
+	}
+	if err := ensureRestoreDiskSpaceInspection(a.dbPath, inspection, readBytes, plainInfo.Size()); err != nil {
+		a.jsonErr(w, http.StatusInsufficientStorage, err.Error())
 		return
 	}
 	a.backupMu.Lock()

--- a/disk_space.go
+++ b/disk_space.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +10,8 @@ import (
 // diskSpaceProvider is replaceable by tests so low-space behavior can be
 // verified without filling the host filesystem.
 var diskSpaceProvider = diskAvailableBytes
+
+var errDiskSpaceUnsupported = errors.New("disk space check unsupported")
 
 // ensureDiskSpace fails before a backup/restore transaction starts when the
 // filesystem cannot hold its temporary copies. Platforms without a portable
@@ -19,8 +22,14 @@ func ensureDiskSpace(path string, required int64) error {
 		return nil
 	}
 	available, err := diskSpaceProvider(path)
-	if err != nil || available <= 0 {
+	if errors.Is(err, errDiskSpaceUnsupported) {
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("检查磁盘剩余空间失败: %w", err)
+	}
+	if available <= 0 {
+		return errors.New("无法确定磁盘剩余空间")
 	}
 	if available < required {
 		return fmt.Errorf("磁盘剩余空间不足：需要至少 %d MiB，可用 %d MiB", required>>20, available>>20)

--- a/disk_space_test.go
+++ b/disk_space_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -16,9 +17,18 @@ func TestEnsureDiskSpaceRejectsInsufficientCapacity(t *testing.T) {
 
 func TestEnsureDiskSpaceAllowsUnknownPlatformCapacity(t *testing.T) {
 	previous := diskSpaceProvider
-	diskSpaceProvider = func(string) (int64, error) { return 0, nil }
+	diskSpaceProvider = func(string) (int64, error) { return 0, errDiskSpaceUnsupported }
 	t.Cleanup(func() { diskSpaceProvider = previous })
 	if err := ensureDiskSpace(t.TempDir(), 1<<30); err != nil {
 		t.Fatalf("unknown disk capacity should retain bounded-size fallback: %v", err)
+	}
+}
+
+func TestEnsureDiskSpaceFailsClosedOnProviderError(t *testing.T) {
+	previous := diskSpaceProvider
+	diskSpaceProvider = func(string) (int64, error) { return 0, errors.New("statfs failed") }
+	t.Cleanup(func() { diskSpaceProvider = previous })
+	if err := ensureDiskSpace(t.TempDir(), 1<<20); err == nil || !strings.Contains(err.Error(), "检查磁盘剩余空间失败") {
+		t.Fatalf("disk space provider error was accepted: %v", err)
 	}
 }

--- a/disk_space_windows.go
+++ b/disk_space_windows.go
@@ -3,5 +3,5 @@
 package main
 
 func diskAvailableBytes(string) (int64, error) {
-	return 0, nil
+	return 0, errDiskSpaceUnsupported
 }

--- a/edge_agent_test.go
+++ b/edge_agent_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
@@ -12,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -126,6 +128,63 @@ func TestEdgeAgentHealthProbeRequiresSecret(t *testing.T) {
 	handler.ServeHTTP(response, request)
 	if response.Code != http.StatusNotFound {
 		t.Fatalf("health probe status = %d, want %d", response.Code, http.StatusNotFound)
+	}
+}
+
+func TestScheduledProbeUsesWireProbeSecret(t *testing.T) {
+	probeSecret := make([]byte, sha256.Size)
+	if _, err := rand.Read(probeSecret); err != nil {
+		t.Fatal(err)
+	}
+	const nodeGUID = "scheduled-probe-node"
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Header.Get("X-Meridian-Probe"), encodeRuntimeKey(probeSecret); got != want {
+			t.Fatalf("probe header=%q, want %q", got, want)
+		}
+		w.Header().Set("X-Meridian-Node", nodeGUID)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	certificate, err := x509.ParseCertificate(server.TLS.Certificates[0].Certificate[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	host := "127.0.0.1"
+	if len(certificate.DNSNames) > 0 {
+		host = certificate.DNSNames[0]
+	}
+	address, portText, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	node := ControlNode{GUID: nodeGUID, Address: address, Port: port}
+	roots := x509.NewCertPool()
+	roots.AddCert(certificate)
+	if err := probeScheduledNodeWithRoots(context.Background(), node, host, probeSecret, roots); err != nil {
+		t.Fatalf("scheduled probe failed: %v", err)
+	}
+}
+
+func TestNodeProbeSecretWireRoundTrip(t *testing.T) {
+	plaintext, err := newNodeProbeSecret()
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := decodeNodeProbeSecret(plaintext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw) != sha256.Size {
+		t.Fatalf("decoded probe secret length=%d, want %d", len(raw), sha256.Size)
+	}
+	wire := encodeRuntimeKey(raw)
+	decoded, err := edgeDecodeKey(wire)
+	if err != nil || len(decoded) != sha256.Size || string(decoded) != string(raw) {
+		t.Fatalf("probe secret wire round trip failed: len=%d err=%v", len(decoded), err)
 	}
 }
 
@@ -367,6 +426,26 @@ func TestBuildAgentConfigCarriesCompleteDynamicSiteWithoutNestedQueryDeadlock(t 
 		if len(config.Routes) != 1 || !config.Routes[0].Site.DynamicDiscoveryEnabled || config.DynamicKey == "" {
 			t.Fatalf("incomplete runtime config: %#v", config)
 		}
+		decodedProbe, decodeErr := edgeDecodeKey(config.ProbeSecret)
+		if decodeErr != nil || len(decodedProbe) != sha256.Size {
+			t.Fatalf("Agent config probe secret is not a 32-byte wire key: len=%d err=%v", len(decodedProbe), decodeErr)
+		}
+		// Exercise the same wire envelope through the production Agent runtime,
+		// rather than only decoding a hand-built value. A free listener port keeps
+		// this Controller -> Config -> Agent regression test hermetic.
+		port := freePort(t)
+		releasePort(port)
+		config.HTTPSPort = port
+		config.ConfigHash, err = agentConfigLegacyHash(config)
+		if err != nil {
+			t.Fatalf("recompute test config hash: %v", err)
+		}
+		runtime := &edgeAgentRuntime{stateDir: t.TempDir()}
+		if err := runtime.apply(config); err != nil {
+			runtime.close()
+			t.Fatalf("current Agent rejected Controller config: %v", err)
+		}
+		runtime.close()
 	case <-time.After(3 * time.Second):
 		t.Fatal("buildAgentConfig deadlocked while expanding routes")
 	}

--- a/main.go
+++ b/main.go
@@ -257,12 +257,12 @@ func main() {
 	mux.HandleFunc("/api/auth/login", cors(app.csrfMiddleware(app.handleLogin)))
 	mux.HandleFunc("/api/auth/logout", cors(app.csrfMiddleware(app.handleLogout)))
 	mux.HandleFunc("/api/auth/check", cors(app.handleAuthCheck))
-	mux.HandleFunc("/api/agent/binary", app.handleAgentBinary)
-	mux.HandleFunc("/api/agent/manifest", app.handleAgentManifest)
+	mux.HandleFunc("/api/agent/binary", app.withAgentPreAuth(app.handleAgentBinary))
+	mux.HandleFunc("/api/agent/manifest", app.withAgentPreAuth(app.handleAgentManifest))
 	mux.HandleFunc("/api/agent/install.sh", app.handleAgentInstallScript)
-	mux.HandleFunc("/api/agent/enroll", app.handleAgentEnroll)
-	mux.HandleFunc("/api/agent/report", app.handleAgentReport)
-	mux.HandleFunc("/api/agent/config", app.handleAgentConfig)
+	mux.HandleFunc("/api/agent/enroll", app.withAgentPreAuth(app.handleAgentEnroll))
+	mux.HandleFunc("/api/agent/report", app.withAgentPreAuth(app.handleAgentReport))
+	mux.HandleFunc("/api/agent/config", app.withAgentPreAuth(app.handleAgentConfig))
 	mux.Handle("/api/agent/ws", websocket.Server{
 		Handshake: func(config *websocket.Config, request *http.Request) error {
 			preRelease, retryAfter, admitted := app.agentPreAuthAdmission().admit(requestClientKey(request, app.trustedProxies), time.Now())

--- a/node_probe_secret.go
+++ b/node_probe_secret.go
@@ -77,6 +77,19 @@ func newNodeProbeSecret() (string, error) {
 	return newNodeToken()
 }
 
+// decodeNodeProbeSecret converts the encrypted-at-rest plaintext representation
+// (a base64url token) into the raw 32-byte secret used on the wire. Keeping this
+// conversion in one place prevents accidentally base64-encoding the textual
+// token a second time when building Agent configs or scheduler probes.
+func decodeNodeProbeSecret(value string) ([]byte, error) {
+	value = strings.TrimSpace(value)
+	decoded, err := base64.RawURLEncoding.Strict().DecodeString(value)
+	if err != nil || len(decoded) != sha256.Size {
+		return nil, errors.New("invalid node probe secret")
+	}
+	return decoded, nil
+}
+
 // dNodeProbeSecret returns the plaintext only at the two places that need it:
 // the Agent config response and the Controller's private readiness probe. The
 // database stores only JWT-secret-encrypted material; the in-memory ControlNode
@@ -86,7 +99,14 @@ func dNodeProbeSecret(db *DB, node ControlNode) (string, error) {
 		return "", errors.New("node probe secret is unavailable")
 	}
 	if strings.TrimSpace(node.probeSecretCiphertext) != "" {
-		return decryptNodeProbeSecretWithSecret(node.probeSecretCiphertext, jwtSecret)
+		secret, err := decryptNodeProbeSecretWithSecret(node.probeSecretCiphertext, jwtSecret)
+		if err == nil {
+			return secret, nil
+		}
+		if jwtSecretEphemeral {
+			return "", err
+		}
+		return rotateNodeProbeSecret(db, node)
 	}
 	secret, err := newNodeProbeSecret()
 	if err != nil {
@@ -110,4 +130,39 @@ func dNodeProbeSecret(db *DB, node ControlNode) (string, error) {
 		return decryptNodeProbeSecretWithSecret(existing, jwtSecret)
 	}
 	return secret, nil
+}
+
+// rotateNodeProbeSecret repairs a ciphertext written with an old signing key
+// without touching the node identity, enrollment token, or traffic counters.
+// The conditional update makes concurrent config requests converge on one
+// secret while preserving a successfully rotated value.
+func rotateNodeProbeSecret(db *DB, node ControlNode) (string, error) {
+	if db == nil || db.db == nil || node.ID <= 0 {
+		return "", errors.New("node probe secret is unavailable")
+	}
+	if jwtSecretEphemeral || len(jwtSecret) < 32 {
+		return "", errors.New("persistent JWT_SECRET is required to rotate node probe secret")
+	}
+	secret, err := newNodeProbeSecret()
+	if err != nil {
+		return "", err
+	}
+	ciphertext, err := encryptNodeProbeSecretWithSecret(secret, jwtSecret)
+	if err != nil {
+		return "", err
+	}
+	result, err := db.db.Exec("UPDATE control_nodes SET probe_secret_ciphertext=?,updated_at_ms=? WHERE id=? AND probe_secret_ciphertext=?", ciphertext, time.Now().UnixMilli(), node.ID, node.probeSecretCiphertext)
+	if err != nil {
+		return "", err
+	}
+	if affected, rowsErr := result.RowsAffected(); rowsErr != nil {
+		return "", rowsErr
+	} else if affected == 1 {
+		return secret, nil
+	}
+	var existing string
+	if err := db.db.QueryRow("SELECT probe_secret_ciphertext FROM control_nodes WHERE id=?", node.ID).Scan(&existing); err != nil {
+		return "", err
+	}
+	return decryptNodeProbeSecretWithSecret(existing, jwtSecret)
 }

--- a/node_repository.go
+++ b/node_repository.go
@@ -28,6 +28,7 @@ var (
 	errInvalidNodeToken      = errors.New("invalid or expired node token")
 	errInvalidAgentToken     = errors.New("invalid agent token")
 	errManualNodeUnavailable = errors.New("manual node is unavailable")
+	errPersistentJWTRequired = errors.New("Agent nodes require a persistent JWT_SECRET")
 )
 
 type ControlNode struct {
@@ -338,6 +339,9 @@ func (d *DB) resetDueNodeCycles(now time.Time) error {
 }
 
 func (d *DB) CreateControlNode(input NodeCreateInput, now time.Time) (ControlNode, string, error) {
+	if jwtSecretEphemeral {
+		return ControlNode{}, "", errPersistentJWTRequired
+	}
 	input, err := normalizeNodeInput(input)
 	if err != nil {
 		return ControlNode{}, "", err
@@ -646,6 +650,9 @@ func (d *DB) AuthorizeEnrollmentToken(token string, now time.Time) error {
 }
 
 func (d *DB) EnrollControlNode(token string, now time.Time) (ControlNode, string, error) {
+	if jwtSecretEphemeral {
+		return ControlNode{}, "", errPersistentJWTRequired
+	}
 	agentToken, err := newNodeToken()
 	if err != nil {
 		return ControlNode{}, "", err

--- a/node_repository_test.go
+++ b/node_repository_test.go
@@ -130,6 +130,56 @@ func TestRefreshNodeEnrollmentKeepsOldAgentUntilReplacement(t *testing.T) {
 	}
 }
 
+func TestNodeCredentialsRejectEphemeralJWTSecret(t *testing.T) {
+	app := newTestApp(t)
+	previousSecret, previousEphemeral := jwtSecret, jwtSecretEphemeral
+	t.Cleanup(func() { jwtSecret, jwtSecretEphemeral = previousSecret, previousEphemeral })
+	jwtSecret = nil
+	jwtSecretEphemeral = true
+	if _, _, err := app.db.CreateControlNode(NodeCreateInput{Name: "ephemeral", Address: "203.0.113.70"}, time.Now()); err == nil {
+		t.Fatal("node creation succeeded with an ephemeral JWT secret")
+	}
+	// Enrollment is checked before token lookup so a pending token can never
+	// create a ciphertext that will be undecryptable after restart.
+	if _, _, err := app.db.EnrollControlNode("invalid", time.Now()); err == nil || !strings.Contains(err.Error(), "persistent JWT_SECRET") {
+		t.Fatalf("ephemeral enrollment error = %v", err)
+	}
+}
+
+func TestBrokenProbeSecretCanBeRotatedWithStableJWT(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now()
+	node, enrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "probe-rotate", Address: "203.0.113.71"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, agentToken, err := app.db.EnrollControlNode(enrollment, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalGUID := node.GUID
+	if _, err := app.db.db.Exec("UPDATE control_nodes SET probe_secret_ciphertext=? WHERE id=?", "v1:broken", node.ID); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := app.db.controlNodeByID(node.ID, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rotated, err := dNodeProbeSecret(app.db, loaded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := decodeNodeProbeSecret(rotated); err != nil {
+		t.Fatalf("rotated probe secret is invalid: %v", err)
+	}
+	if loaded.GUID != originalGUID {
+		t.Fatalf("node GUID changed during probe rotation: %q", loaded.GUID)
+	}
+	if _, err := app.db.nodeByAgentToken(agentToken, now); err != nil {
+		t.Fatalf("agent token changed during probe rotation: %v", err)
+	}
+}
+
 func TestRefreshNodeEnrollmentPreservesRuntimeStateAndTrafficBaseline(t *testing.T) {
 	app := newTestApp(t)
 	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)

--- a/panel_acme.go
+++ b/panel_acme.go
@@ -625,8 +625,11 @@ func legacyEdgeNodeTLSRoot(dbPath string) string {
 	if configured == "" {
 		return ""
 	}
-	certFile := cleanConfiguredTLSPath(configured)
-	if certFile == "" {
+	// Preserve the operator's lexical path here. Migration must be able to
+	// detect and reject symlinked ancestors rather than canonicalizing them
+	// away before the safety check.
+	certFile, err := filepath.Abs(filepath.Clean(configured))
+	if err != nil || certFile == "" {
 		return ""
 	}
 	return filepath.Join(filepath.Dir(certFile), "edge-nodes")
@@ -673,6 +676,50 @@ func readLegacyTLSFile(path string, maxBytes int64) ([]byte, error) {
 	return data, nil
 }
 
+// validateLegacyTLSPathComponents rejects symlinked ancestors before a legacy
+// certificate is copied into TLS_STATE_DIR. Lexical filepath.Clean checks are
+// insufficient here because an operator-owned legacy directory may contain a
+// link that escapes the allowlisted node namespace.
+func validateLegacyTLSPathComponents(root, path string) error {
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+	// Inspect ancestors individually. Lstat on a nested path follows a
+	// symlinked parent, so checking only the final path is not sufficient.
+	for ancestor := path; ; ancestor = filepath.Dir(ancestor) {
+		info, statErr := os.Lstat(ancestor)
+		if statErr == nil {
+			if info.Mode()&os.ModeSymlink != 0 {
+				return errors.New("legacy TLS path contains a symlinked ancestor")
+			}
+		} else if !errors.Is(statErr, os.ErrNotExist) {
+			return statErr
+		}
+		parent := filepath.Dir(ancestor)
+		if parent == ancestor {
+			break
+		}
+	}
+	relative, err := filepath.Rel(root, path)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(os.PathSeparator)) {
+		return errors.New("legacy TLS path escapes its root")
+	}
+	current := root
+	for _, part := range strings.Split(relative, string(os.PathSeparator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		current = filepath.Join(current, part)
+		info, statErr := os.Lstat(current)
+		if statErr != nil {
+			return statErr
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return errors.New("legacy TLS path contains a symlink")
+		}
+	}
+	return nil
+}
+
 // migrateLegacyEdgeTLSState performs a one-time, allowlisted copy from the
 // pre-TLS_STATE_DIR external edge-nodes directory. It only considers GUIDs
 // present in control_nodes, validates regular files and the key pair, and
@@ -710,6 +757,14 @@ func migrateLegacyEdgeTLSState(db *DB, dbPath string) error {
 		sourceDir := filepath.Join(legacyRoot, guid, "current")
 		certSource := filepath.Join(sourceDir, "fullchain.pem")
 		keySource := filepath.Join(sourceDir, "privkey.pem")
+		// Validate every ancestor, including the GUID/current directories, so
+		// the allowlisted copy can never follow an operator-created symlink.
+		if err := validateLegacyTLSPathComponents(legacyRoot, certSource); err != nil {
+			continue
+		}
+		if err := validateLegacyTLSPathComponents(legacyRoot, keySource); err != nil {
+			continue
+		}
 		certPEM, certErr := readLegacyTLSFile(certSource, legacyEdgeCertificateMaxBytes)
 		keyPEM, keyErr := readLegacyTLSFile(keySource, legacyEdgePrivateKeyMaxBytes)
 		if errors.Is(certErr, os.ErrNotExist) || errors.Is(keyErr, os.ErrNotExist) {

--- a/review_regression_test.go
+++ b/review_regression_test.go
@@ -521,6 +521,70 @@ func TestReviewLegacyEdgeTLSMigratesOnlyKnownNodesIntoStateDir(t *testing.T) {
 	}
 }
 
+func TestLegacyTLSMigrationRejectsIntermediateSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "meridian.db")
+	db, err := openDB(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	t.Setenv("PANEL_TLS_CERT_FILE", "")
+	t.Setenv("PANEL_TLS_KEY_FILE", "")
+	t.Setenv("EDGE_TLS_CERT_FILE", filepath.Join(dir, "external", "edge.pem"))
+	t.Setenv("EDGE_TLS_KEY_FILE", filepath.Join(dir, "external", "edge.key"))
+	stateDir := filepath.Join(dir, "owned-tls")
+	t.Setenv("TLS_STATE_DIR", stateDir)
+	node, _, err := db.CreateControlNode(NodeCreateInput{Name: "symlink-edge", Address: "203.0.113.72"}, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyRoot := filepath.Join(dir, "external", "edge-nodes")
+	if err := os.MkdirAll(legacyRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	certPEM, keyPEM := reviewCertificatePEM(t)
+	outside := filepath.Join(dir, "outside", "current")
+	if err := os.MkdirAll(outside, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "fullchain.pem"), []byte(certPEM), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "privkey.pem"), []byte(keyPEM), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Dir(outside), filepath.Join(legacyRoot, node.GUID)); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := migrateLegacyEdgeTLSState(db, dbPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "edge-nodes", node.GUID)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("symlinked GUID directory was migrated: %v", err)
+	}
+	// Replace the GUID link with a real directory and make only current a link.
+	if err := os.Remove(filepath.Join(legacyRoot, node.GUID)); err != nil {
+		t.Fatal(err)
+	}
+	currentLinkRoot := filepath.Join(legacyRoot, node.GUID, "current")
+	if err := os.MkdirAll(filepath.Dir(currentLinkRoot), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, currentLinkRoot); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := migrateLegacyEdgeTLSState(db, dbPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "edge-nodes", node.GUID)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("symlinked current directory was migrated: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "fullchain.pem")); err != nil {
+		t.Fatalf("outside TLS file was modified or removed: %v", err)
+	}
+}
+
 func TestReviewEventSpoolEncryptsAndReportsPersistenceFailure(t *testing.T) {
 	dir := t.TempDir()
 	var store edgeEventStore

--- a/site_node_scheduler.go
+++ b/site_node_scheduler.go
@@ -6,6 +6,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"crypto/tls"
+	"crypto/x509"
 	"database/sql"
 	"encoding/base64"
 	"encoding/hex"
@@ -445,7 +446,11 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 	}
 	pending := make([]pendingRoute, 0)
 	dynamicKey := deriveNodeRuntimeKey(a.dynamicRouteKey, node.GUID, "dynamic-routes")
-	probeSecret, probeErr := dNodeProbeSecret(a.db, node)
+	probeSecretText, probeErr := dNodeProbeSecret(a.db, node)
+	if probeErr != nil {
+		return AgentRuntimeConfig{}, probeErr
+	}
+	probeSecret, probeErr := decodeNodeProbeSecret(probeSecretText)
 	if probeErr != nil {
 		return AgentRuntimeConfig{}, probeErr
 	}
@@ -522,7 +527,7 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 	// Keep the legacy field names in the Agent wire contract during rolling
 	// upgrades. Their values now describe one HTTPS-only listener.
 	config := AgentRuntimeConfig{SchemaVersion: agentConfigSchemaVersion, NodeGUID: node.GUID, EntryMode: "direct",
-		HTTPPort: 0, HTTPSPort: node.Port, DynamicKey: encodeRuntimeKey(dynamicKey), ProbeSecret: encodeRuntimeKey([]byte(probeSecret)), Routes: routes}
+		HTTPPort: 0, HTTPSPort: node.Port, DynamicKey: encodeRuntimeKey(dynamicKey), ProbeSecret: encodeRuntimeKey(probeSecret), Routes: routes}
 	// Legacy Agents do not send a platform header. Do not advertise the
 	// controller's local binary to those clients: on a cross-architecture
 	// rollout that checksum would make an old arm64 Agent download an amd64
@@ -779,6 +784,10 @@ func nodeHTTPSProbePort(node ControlNode) int {
 }
 
 func probeScheduledNode(ctx context.Context, node ControlNode, host string, probeSecret []byte) error {
+	return probeScheduledNodeWithRoots(ctx, node, host, probeSecret, nil)
+}
+
+func probeScheduledNodeWithRoots(ctx context.Context, node ControlNode, host string, probeSecret []byte, roots *x509.CertPool) error {
 	if len(probeSecret) == 0 {
 		return errors.New("node health probe secret is unavailable")
 	}
@@ -792,7 +801,7 @@ func probeScheduledNode(ctx context.Context, node ControlNode, host string, prob
 		DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
 			return dialer.DialContext(ctx, network, address)
 		},
-		TLSClientConfig:   &tls.Config{MinVersion: tls.VersionTLS12, ServerName: host},
+		TLSClientConfig:   &tls.Config{MinVersion: tls.VersionTLS12, ServerName: host, RootCAs: roots},
 		DisableKeepAlives: true,
 	}
 	defer transport.CloseIdleConnections()
@@ -856,7 +865,7 @@ func (a *App) reconcileOneSiteSchedule(ctx context.Context, schedule SiteNodeSch
 	if err != nil {
 		return readinessError(readinessProbe, err)
 	}
-	probeSecret, err := base64.RawURLEncoding.DecodeString(probeSecretText)
+	probeSecret, err := decodeNodeProbeSecret(probeSecretText)
 	if err != nil {
 		return readinessError(readinessProbe, errors.New("node health probe secret is invalid"))
 	}

--- a/test_main_test.go
+++ b/test_main_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// Agent node tests need a stable signing key because production deliberately
+// rejects persistent node credentials when JWT_SECRET is ephemeral. Individual
+// tests that exercise ephemeral behavior still override the globals explicitly.
+func TestMain(m *testing.M) {
+	jwtSecret = []byte(strings.Repeat("test-jwt-secret-", 3))
+	jwtSecretEphemeral = false
+	os.Exit(m.Run())
+}

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -7168,6 +7168,7 @@ html[data-theme="light"] .page:not(#page-watch-history) .account-session-card h2
 .node-site-card .node-site-status { min-height: 58px; padding: 11px 12px; border: 1px solid var(--glass-border); border-radius: 9px; background: var(--surface); }
 .node-site-dirty { color: var(--orange); }
 .node-site-card-actions { justify-content: flex-end; }
+.node-site-card.is-schedule-pending { transition: opacity .18s ease; opacity: .78; }
 @media (max-width: 900px) { .node-site-card-controls { grid-template-columns: 1fr 1fr; }.node-site-card-controls .node-check { grid-column: 1 / -1; } }
 @media (max-width: 680px) {
   .node-site-list { grid-template-columns: minmax(0, 1fr); gap: 12px; }

--- a/web/static/js/pages/nodes.js
+++ b/web/static/js/pages/nodes.js
@@ -5,10 +5,14 @@ let siteSchedulesSnapshot = { sites: [] };
 // replaces the server snapshot. Drafts are cleared after a successful save or
 // when the page is recreated.
 let siteScheduleDrafts = new Map();
+const siteScheduleReactionDelay = 280;
+const siteScheduleReactionTimers = new Map();
 
 function stopNodesRefresh() {
   if (nodesRefreshTimer) clearInterval(nodesRefreshTimer);
   nodesRefreshTimer = null;
+  siteScheduleReactionTimers.forEach(timer => clearTimeout(timer));
+  siteScheduleReactionTimers.clear();
 }
 
 function nodeBytes(value) {
@@ -219,15 +223,32 @@ function syncSiteScheduleRow(row) {
   refreshSiteScheduleRowState(row);
 }
 
+// Keep checkbox/select state changes just behind the pointer event. The small
+// debounce prevents a fast five-second refresh or double tap from making the
+// controls jump while the unsaved draft is being captured.
+function queueSiteScheduleRowSync(row) {
+  const siteID = Number(row?.dataset?.siteId);
+  if (!Number.isFinite(siteID) || siteID <= 0) return;
+  const previous = siteScheduleReactionTimers.get(siteID);
+  if (previous) clearTimeout(previous);
+  row.classList.add('is-schedule-pending');
+  const timer = setTimeout(() => {
+    siteScheduleReactionTimers.delete(siteID);
+    row.classList.remove('is-schedule-pending');
+    syncSiteScheduleRow(row);
+  }, siteScheduleReactionDelay);
+  siteScheduleReactionTimers.set(siteID, timer);
+}
+
 async function handleSiteScheduleAction(event) {
   const row = event.target.closest('.node-site-row');
   if (!row) return;
   if (event.target.matches('[data-field="enabled"]')) {
-    syncSiteScheduleRow(row);
+    queueSiteScheduleRowSync(row);
     return;
   }
   if (event.target.matches('[data-field="mode"]')) {
-    syncSiteScheduleRow(row);
+    queueSiteScheduleRowSync(row);
     return;
   }
   if (event.target.matches('[data-field="fixed-node"]')) {


### PR DESCRIPTION
## 变更
- 修复 Probe Secret 二次 Base64，增加 Controller → Agent 配置/健康探针回归测试。
- 统一 Agent credential API 的预认证限流，增加节点级速率、并发、容量上限与回收。
- 在同一事务内校验 Agent 的 Node → Site 授权，隔离越权遥测和事件，并返回可重试 ACK。
- 将 Legacy Edge TLS 状态迁移到 TLS_STATE_DIR，阻止符号链接逃逸并保护外部证书路径。
- 增加 Backup v2 分块 AEAD、流式上传/恢复、ZIP 预检和磁盘空间 fail-closed 检查。
- 加固 Telegram 重定向、Docker 基础镜像 digest、GHCR 版本标签保护与 Release 预检查。
- 保留站点调度未保存状态，修复 Cloudflare 删除幂等性，并让勾选/取消勾选反馈延迟一小段时间以避免自动刷新跳变。

## 验证
- go test ./...
- go test -race ./...
- go vet ./...
- node --test tests/*.test.js
- 所有 web/static/js 文件 node --check

CI 环境还会执行 shellcheck、govulncheck、gosec、Docker 构建和安装器测试。