### PR TITLE
fix: decouple Agent updates from runtime config

### DIFF
--- a/agent_report_guard.go
+++ b/agent_report_guard.go
@@ -2,12 +2,42 @@ package main
 
 import (
 	"container/list"
+	"context"
 	"math"
 	"net/http"
 	"strconv"
 	"sync"
 	"time"
 )
+
+// agentCredentialIdentity is attached to a request after the short pre-auth
+// admission window has authenticated its bearer credential. Keeping the
+// result in context avoids repeating the SQLite lookup in each handler while
+// ensuring the global admission slot is released before any slow work such as
+// a GitHub binary proxy begins.
+type agentCredentialIdentity struct {
+	Token      string
+	Node       ControlNode
+	HasNode    bool
+	Enrollment bool
+}
+
+type agentCredentialContextKey struct{}
+
+func withAgentCredential(r *http.Request, identity agentCredentialIdentity) *http.Request {
+	if r == nil {
+		return r
+	}
+	return r.WithContext(context.WithValue(r.Context(), agentCredentialContextKey{}, identity))
+}
+
+func agentCredentialFromContext(ctx context.Context) (agentCredentialIdentity, bool) {
+	if ctx == nil {
+		return agentCredentialIdentity{}, false
+	}
+	identity, ok := ctx.Value(agentCredentialContextKey{}).(agentCredentialIdentity)
+	return identity, ok && identity.Token != ""
+}
 
 const (
 	nodeReportRatePerSecond = 1.0
@@ -294,7 +324,57 @@ func (a *App) withAgentPreAuth(next http.HandlerFunc) http.HandlerFunc {
 			a.jsonErr(w, http.StatusTooManyRequests, "agent authentication rate limit exceeded")
 			return
 		}
-		defer release()
-		next(w, r)
+		// A few unit-test embedders use this admission helper without a DB. Keep
+		// that lightweight behavior, while the production router always has a DB
+		// and authenticates before handing control to the endpoint.
+		if a == nil || a.db == nil || a.db.db == nil {
+			release()
+			next(w, r)
+			return
+		}
+		identity, err := a.authenticateAgentRequest(r)
+		release()
+		if err != nil {
+			a.jsonErr(w, http.StatusUnauthorized, "invalid agent token")
+			return
+		}
+		next(w, withAgentCredential(r, identity))
 	}
+}
+
+// authenticateAgentRequest performs the only credential lookups protected by
+// the global pre-auth concurrency budget. Enrollment credentials are retained
+// because the binary, manifest, and enroll endpoints intentionally accept the
+// one-time enrollment token.
+func (a *App) authenticateAgentRequest(r *http.Request) (agentCredentialIdentity, error) {
+	if a == nil || a.db == nil || a.db.db == nil {
+		return agentCredentialIdentity{}, errInvalidAgentToken
+	}
+	token := requestBearerToken(r)
+	if token == "" {
+		return agentCredentialIdentity{}, errInvalidAgentToken
+	}
+	now := time.Now()
+	if node, err := a.db.nodeByAgentToken(token, now); err == nil {
+		return agentCredentialIdentity{Token: token, Node: node, HasNode: true}, nil
+	}
+	if err := a.db.AuthorizeEnrollmentToken(token, now); err == nil {
+		return agentCredentialIdentity{Token: token, Enrollment: true}, nil
+	}
+	return agentCredentialIdentity{}, errInvalidAgentToken
+}
+
+func agentIdentityForRequest(a *App, r *http.Request) (agentCredentialIdentity, error) {
+	if identity, ok := agentCredentialFromContext(r.Context()); ok {
+		return identity, nil
+	}
+	return a.authenticateAgentRequest(r)
+}
+
+func agentNodeIdentityForRequest(a *App, r *http.Request) (agentCredentialIdentity, error) {
+	identity, err := agentIdentityForRequest(a, r)
+	if err != nil || !identity.HasNode || identity.Enrollment {
+		return agentCredentialIdentity{}, errInvalidAgentToken
+	}
+	return identity, nil
 }

--- a/agent_report_guard.go
+++ b/agent_report_guard.go
@@ -310,8 +310,9 @@ func (a *App) agentPreAuthAdmission() *agentPreAuthAdmission {
 }
 
 // withAgentPreAuth is shared by every credential-bearing Agent endpoint. It
-// runs before endpoint-specific parsing or SQLite authentication so invalid
-// credentials cannot rotate between URLs to evade the admission budget.
+// runs before endpoint-specific parsing and covers the credential lookup so
+// invalid credentials cannot rotate between URLs to evade the admission
+// budget. The slot is released before endpoint work begins.
 func (a *App) withAgentPreAuth(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		release, retryAfter, admitted := a.agentPreAuthAdmission().admit(requestClientKey(r, a.trustedProxies), time.Now())

--- a/agent_report_guard_test.go
+++ b/agent_report_guard_test.go
@@ -8,6 +8,55 @@ import (
 	"time"
 )
 
+type panicBody struct{}
+
+func (panicBody) Read([]byte) (int, error) { panic("request body was decoded before authentication") }
+func (panicBody) Close() error             { return nil }
+
+func TestAgentPreAuthAuthenticatesBeforeBodyDecode(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now()
+	node, enrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "preauth", Address: "203.0.113.80"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, agentToken, err := app.db.EnrollControlNode(enrollment, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	called := false
+	handler := app.withAgentPreAuth(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		identity, ok := agentCredentialFromContext(r.Context())
+		if !ok || !identity.HasNode || identity.Node.ID != node.ID || identity.Token != agentToken {
+			t.Errorf("missing authenticated Agent identity: %#v, %v", identity, ok)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	request := httptest.NewRequest(http.MethodPost, "/api/agent/report", panicBody{})
+	request.Header.Set("Authorization", "Bearer "+agentToken)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusNoContent || !called {
+		t.Fatalf("authenticated request = status %d called=%v", response.Code, called)
+	}
+
+	invalid := httptest.NewRequest(http.MethodPost, "/api/agent/report", panicBody{})
+	invalid.Header.Set("Authorization", "Bearer invalid")
+	invalidResponse := httptest.NewRecorder()
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				t.Fatalf("invalid credentials caused body decode: %v", recovered)
+			}
+		}()
+		handler.ServeHTTP(invalidResponse, invalid)
+	}()
+	if invalidResponse.Code != http.StatusUnauthorized {
+		t.Fatalf("invalid credentials status = %d, want 401", invalidResponse.Code)
+	}
+}
+
 func TestAgentPreAuthCannotBeBypassedByEndpointRotation(t *testing.T) {
 	app := &App{}
 	handler := app.withAgentPreAuth(func(w http.ResponseWriter, _ *http.Request) {

--- a/app_nodes.go
+++ b/app_nodes.go
@@ -419,12 +419,10 @@ func (a *App) handleAgentBinary(w http.ResponseWriter, r *http.Request) {
 		a.jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
-	token := requestBearerToken(r)
-	if err := a.db.AuthorizeEnrollmentToken(token, time.Now()); err != nil {
-		if _, agentErr := a.db.nodeByAgentToken(token, time.Now()); agentErr != nil {
-			a.jsonErr(w, http.StatusUnauthorized, "invalid agent token")
-			return
-		}
+	identity, authErr := agentIdentityForRequest(a, r)
+	if authErr != nil || (!identity.HasNode && !identity.Enrollment) {
+		a.jsonErr(w, http.StatusUnauthorized, "invalid agent token")
+		return
 	}
 	platform, err := requestedAgentPlatform(r)
 	if err != nil {
@@ -575,12 +573,10 @@ func (a *App) handleAgentManifest(w http.ResponseWriter, r *http.Request) {
 		a.jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
-	token := requestBearerToken(r)
-	if err := a.db.AuthorizeEnrollmentToken(token, time.Now()); err != nil {
-		if _, agentErr := a.db.nodeByAgentToken(token, time.Now()); agentErr != nil {
-			a.jsonErr(w, http.StatusUnauthorized, "invalid agent token")
-			return
-		}
+	identity, authErr := agentIdentityForRequest(a, r)
+	if authErr != nil || (!identity.HasNode && !identity.Enrollment) {
+		a.jsonErr(w, http.StatusUnauthorized, "invalid agent token")
+		return
 	}
 	platform, err := requestedAgentPlatform(r)
 	if err != nil {
@@ -624,7 +620,12 @@ func (a *App) handleAgentEnroll(w http.ResponseWriter, r *http.Request) {
 		a.jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
-	node, agentToken, err := a.db.EnrollControlNode(requestBearerToken(r), time.Now())
+	identity, authErr := agentIdentityForRequest(a, r)
+	if authErr != nil || !identity.Enrollment {
+		a.jsonErr(w, http.StatusUnauthorized, "invalid enrollment token")
+		return
+	}
+	node, agentToken, err := a.db.EnrollControlNode(identity.Token, time.Now())
 	if err != nil {
 		if errors.Is(err, errPersistentJWTRequired) {
 			a.jsonErr(w, http.StatusConflict, "请先配置持久 JWT_SECRET，再注册 Agent 节点")
@@ -654,12 +655,13 @@ func (a *App) handleAgentReport(w http.ResponseWriter, r *http.Request) {
 		a.jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
-	token := requestBearerToken(r)
-	node, authErr := a.db.nodeByAgentToken(token, time.Now())
+	identity, authErr := agentNodeIdentityForRequest(a, r)
 	if authErr != nil {
 		a.jsonErr(w, http.StatusUnauthorized, "invalid agent token")
 		return
 	}
+	token := identity.Token
+	node := identity.Node
 	release, retryAfter, admitted := a.agentReports().admit(node.ID, time.Now())
 	if !admitted {
 		seconds := int(retryAfter.Seconds())

--- a/backup_restore.go
+++ b/backup_restore.go
@@ -2684,26 +2684,25 @@ func (a *App) handleBackupRestore(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if len(oldHeaderKey) == 32 {
-			tempDir, tempErr := os.MkdirTemp("", ".meridian-header-check-*")
-			if tempErr != nil {
-				a.jsonErr(w, http.StatusInternalServerError, "恢复校验失败")
-				return
-			}
-			tempDB := filepath.Join(tempDir, backupDatabaseEntry)
-			writeErr := copyPrivateFile(entries[backupDatabaseEntry], tempDB)
+			// The database entry is already a private, fully staged file on the
+			// restore filesystem. Open it directly for the header-presence check;
+			// copying the whole database into the system temp directory wastes
+			// space and can make otherwise valid restores fail on small /tmp or
+			// tmpfs filesystems.
+			tempDB := entries[backupDatabaseEntry]
+			var writeErr error
 			hasHeaders := false
-			if writeErr == nil {
-				checkDB, openErr := sql.Open("sqlite", "file:"+filepath.ToSlash(tempDB)+"?mode=ro&_pragma=query_only(1)")
-				if openErr == nil {
-					var count int
-					writeErr = checkDB.QueryRow("SELECT COUNT(*) FROM sites WHERE upstream_headers <> '' AND upstream_headers <> '[]'").Scan(&count)
-					hasHeaders = count > 0
-					_ = checkDB.Close()
-				} else {
-					writeErr = openErr
+			checkDB, openErr := sql.Open("sqlite", "file:"+filepath.ToSlash(tempDB)+"?mode=ro&_pragma=query_only(1)")
+			if openErr == nil {
+				var count int
+				writeErr = checkDB.QueryRow("SELECT COUNT(*) FROM sites WHERE upstream_headers <> '' AND upstream_headers <> '[]'").Scan(&count)
+				hasHeaders = count > 0
+				if closeErr := checkDB.Close(); writeErr == nil {
+					writeErr = closeErr
 				}
+			} else {
+				writeErr = openErr
 			}
-			_ = os.RemoveAll(tempDir)
 			if writeErr != nil {
 				a.jsonErr(w, http.StatusBadRequest, "恢复校验失败：无法检查自定义上游请求头")
 				return

--- a/edge_agent.go
+++ b/edge_agent.go
@@ -1609,7 +1609,9 @@ func runEdgeAgent() error {
 	bootID := edgeBootID()
 	sequence := int64(0)
 	const configRefreshInterval = 60 * time.Second
+	const agentUpdateRetryInterval = 5 * time.Minute
 	lastConfigAt := time.Time{}
+	lastUpdateAttempt := time.Time{}
 	for {
 		if lastConfigAt.IsZero() || time.Since(lastConfigAt) >= configRefreshInterval {
 			var config AgentRuntimeConfig
@@ -1620,19 +1622,28 @@ func runEdgeAgent() error {
 				fmt.Fprintf(os.Stderr, "Meridian Agent config fetch failed: %v\n", err)
 			} else if configErr := validateAgentConfigEnvelope(config); configErr != nil {
 				fmt.Fprintf(os.Stderr, "Meridian Agent rejected config: %v\n", configErr)
-			} else if updateErr := edgeMaybeUpdate(ctx, client, controller, state.Token, config); updateErr != nil {
-				if errors.Is(updateErr, errEdgeAgentUpdated) {
-					return updateErr
-				}
-				fmt.Fprintf(os.Stderr, "Meridian Agent update failed: %v\n", updateErr)
 			} else {
+				// Applying a valid runtime configuration must not depend on the
+				// availability of the optional Agent release service. A GitHub
+				// outage should leave the current proxy converged while update
+				// retries happen independently in the background.
+				now := time.Now()
+				if lastUpdateAttempt.IsZero() || now.Sub(lastUpdateAttempt) >= agentUpdateRetryInterval {
+					lastUpdateAttempt = now
+					if updateErr := edgeMaybeUpdate(ctx, client, controller, state.Token, config); updateErr != nil {
+						if errors.Is(updateErr, errEdgeAgentUpdated) {
+							return updateErr
+						}
+						fmt.Fprintf(os.Stderr, "Meridian Agent update failed: %v\n", updateErr)
+					}
+				}
 				applied, _ := runtime.status()
 				if config.ConfigHash != applied {
 					if err := runtime.apply(config); err != nil {
 						fmt.Fprintf(os.Stderr, "Meridian Agent config apply failed: %v\n", err)
 					}
 				}
-				lastConfigAt = time.Now()
+				lastConfigAt = now
 			}
 		}
 		sequence++

--- a/main.go
+++ b/main.go
@@ -269,15 +269,15 @@ func main() {
 			if !admitted {
 				return fmt.Errorf("agent authentication rate limit exceeded; retry after %s", retryAfter.Round(time.Millisecond))
 			}
-			node, err := app.db.nodeByAgentToken(requestBearerToken(request), time.Now())
+			identity, err := app.authenticateAgentRequest(request)
 			preRelease()
-			if err != nil {
+			if err != nil || !identity.HasNode || identity.Enrollment {
 				return errors.New("invalid agent token")
 			}
 			// x/net/websocket passes the same request pointer to the handler. Carry
 			// the authenticated node through its context so the handler never
 			// performs a second SQLite token lookup for this connection.
-			*request = *withAgentWebSocketNode(request, node)
+			*request = *withAgentCredential(withAgentWebSocketNode(request, identity.Node), identity)
 			// Agent clients are not browsers; token authentication is the origin
 			// boundary, so do not apply the package's browser Origin check.
 			return nil

--- a/node_probe_secret.go
+++ b/node_probe_secret.go
@@ -108,6 +108,9 @@ func dNodeProbeSecret(db *DB, node ControlNode) (string, error) {
 		}
 		return rotateNodeProbeSecret(db, node)
 	}
+	if jwtSecretEphemeral {
+		return "", errPersistentJWTRequired
+	}
 	secret, err := newNodeProbeSecret()
 	if err != nil {
 		return "", err

--- a/node_repository_test.go
+++ b/node_repository_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -143,6 +145,39 @@ func TestNodeCredentialsRejectEphemeralJWTSecret(t *testing.T) {
 	// create a ciphertext that will be undecryptable after restart.
 	if _, _, err := app.db.EnrollControlNode("invalid", time.Now()); err == nil || !strings.Contains(err.Error(), "persistent JWT_SECRET") {
 		t.Fatalf("ephemeral enrollment error = %v", err)
+	}
+}
+
+func TestLegacyNodeProbeSecretDoesNotPersistWithEphemeralJWT(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now()
+	node, enrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "legacy-probe", Address: "203.0.113.72"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := app.db.EnrollControlNode(enrollment, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec("UPDATE control_nodes SET probe_secret_ciphertext='' WHERE id=?", node.ID); err != nil {
+		t.Fatal(err)
+	}
+	previousSecret, previousEphemeral := jwtSecret, jwtSecretEphemeral
+	t.Cleanup(func() { jwtSecret, jwtSecretEphemeral = previousSecret, previousEphemeral })
+	jwtSecret = nil
+	jwtSecretEphemeral = true
+	loaded, err := app.db.controlNodeByID(node.ID, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := dNodeProbeSecret(app.db, loaded); !errors.Is(err, errPersistentJWTRequired) {
+		t.Fatalf("legacy probe secret with ephemeral JWT error = %v", err)
+	}
+	var ciphertext string
+	if err := app.db.db.QueryRow("SELECT probe_secret_ciphertext FROM control_nodes WHERE id=?", node.ID).Scan(&ciphertext); err != nil {
+		t.Fatal(err)
+	}
+	if ciphertext != "" {
+		t.Fatalf("ephemeral JWT persisted probe secret ciphertext %q", ciphertext)
 	}
 }
 
@@ -616,6 +651,7 @@ func TestAgentConfigHashSeparatesReleaseMetadata(t *testing.T) {
 		AgentVersion:     "v1.9.30",
 		AgentSHA256:      strings.Repeat("a", 64),
 		AgentDownloadURL: "https://github.com/chanhui800/Meridian/releases/download/v1.9.30/meridian-agent-linux-amd64",
+		ProbeSecret:      encodeRuntimeKey(bytes.Repeat([]byte{0x42}, 32)),
 		Routes:           []AgentSiteRoute{},
 	}
 	runtimeHash, err := agentConfigHash(config)
@@ -656,6 +692,49 @@ func TestAgentConfigHashSeparatesReleaseMetadata(t *testing.T) {
 	}
 	if got, err := agentConfigHashForVersion(config, "v1.9.43"); err != nil || got != runtimeHash {
 		t.Fatalf("v1.9.43 config hash changed unexpectedly: got=%q want=%q err=%v", got, runtimeHash, err)
+	}
+	if runtimeHash == preProbeHash {
+		t.Fatal("probe secret did not change the current runtime hash")
+	}
+	// Freeze the v1.9.42 wire shape rather than comparing two current structs.
+	// This catches future fields that JSON-unmarshal would silently discard on
+	// an old Agent and ensures the compatibility hash is calculated over what
+	// that Agent actually understood.
+	type agentRuntimeConfigV1942 struct {
+		SchemaVersion  int              `json:"schema_version"`
+		ConfigHash     string           `json:"config_hash"`
+		NodeGUID       string           `json:"node_guid"`
+		EntryMode      string           `json:"entry_mode"`
+		HTTPPort       int              `json:"http_port"`
+		HTTPSPort      int              `json:"https_port"`
+		CertificatePEM string           `json:"certificate_pem,omitempty"`
+		PrivateKeyPEM  string           `json:"private_key_pem,omitempty"`
+		DynamicKey     string           `json:"dynamic_key,omitempty"`
+		AgentVersion   string           `json:"agent_version,omitempty"`
+		AgentSHA256    string           `json:"agent_sha256,omitempty"`
+		Routes         []AgentSiteRoute `json:"routes"`
+	}
+	wire, err := json.Marshal(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var frozen agentRuntimeConfigV1942
+	if err := json.Unmarshal(wire, &frozen); err != nil {
+		t.Fatal(err)
+	}
+	frozenHash, err := agentConfigHash(AgentRuntimeConfig{
+		SchemaVersion: frozen.SchemaVersion, ConfigHash: frozen.ConfigHash,
+		NodeGUID: frozen.NodeGUID, EntryMode: frozen.EntryMode,
+		HTTPPort: frozen.HTTPPort, HTTPSPort: frozen.HTTPSPort,
+		CertificatePEM: frozen.CertificatePEM, PrivateKeyPEM: frozen.PrivateKeyPEM,
+		DynamicKey: frozen.DynamicKey, AgentVersion: frozen.AgentVersion,
+		AgentSHA256: frozen.AgentSHA256, Routes: frozen.Routes,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, err := agentConfigHashForVersion(config, "v1.9.42"); err != nil || got != frozenHash {
+		t.Fatalf("v1.9.42 frozen wire hash mismatch: got=%q want=%q err=%v", got, frozenHash, err)
 	}
 }
 

--- a/site_node_scheduler.go
+++ b/site_node_scheduler.go
@@ -464,9 +464,15 @@ func (a *App) buildAgentConfigForPlatform(token string, now time.Time, platform 
 }
 
 func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now time.Time, platform, clientVersion string) (AgentRuntimeConfig, error) {
-	node, err := a.db.nodeByAgentToken(token, now)
-	if err != nil {
-		return AgentRuntimeConfig{}, err
+	var node ControlNode
+	var err error
+	if identity, ok := agentCredentialFromContext(ctx); ok && identity.HasNode && identity.Token == token {
+		node = identity.Node
+	} else {
+		node, err = a.db.nodeByAgentToken(token, now)
+		if err != nil {
+			return AgentRuntimeConfig{}, err
+		}
 	}
 	if err := a.refreshSiteAssignments(now); err != nil {
 		return AgentRuntimeConfig{}, err


### PR DESCRIPTION
## Summary
- apply valid Agent runtime configuration even when release update metadata/download is temporarily unavailable
- bound Agent pre-auth concurrency to credential lookup and carry authenticated identity through request context
- inspect staged restore databases in place instead of copying them into system temp
- reject Probe Secret persistence when only an ephemeral JWT secret is available
- add a frozen v1.9.42 wire/hash compatibility regression test

## Validation
- go test ./...
- go test -race ./...
- go vet ./...