### PR TITLE
perf: streamline dashboard data loading

### DIFF
--- a/app_panel.go
+++ b/app_panel.go
@@ -12,6 +12,8 @@ import (
 )
 
 func (a *App) handleDashboard(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
+	started := time.Now()
 	snap, err := a.pm.TrafficSnapshot()
 	if err != nil {
 		a.jsonErr(w, http.StatusInternalServerError, "dashboard unavailable")
@@ -19,6 +21,10 @@ func (a *App) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 	snap.PanelDomain = a.panelHost
 	snap.PanelAccessURL = a.panelAccessURL()
+	w.Header().Set("Server-Timing", "dashboard;dur="+formatTimingDuration(time.Since(started)))
+	if elapsed := time.Since(started); elapsed > 300*time.Millisecond {
+		logDashboardSlow("/api/dashboard", elapsed)
+	}
 	a.jsonOK(w, snap)
 }
 

--- a/app_traffic.go
+++ b/app_traffic.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"strconv"
@@ -132,9 +133,12 @@ func (a *App) handleSSE(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache, no-transform")
+	w.Header().Set("X-Accel-Buffering", "no")
+	// A comment is a valid SSE frame and makes proxy buffering observable: the
+	// client receives bytes as soon as the stream is established.
+	_, _ = io.WriteString(w, ": meridian-connected\n\n")
 	flusher.Flush()
 
 	ticker := time.NewTicker(2 * time.Second)

--- a/asset_cache.go
+++ b/asset_cache.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
+	"log"
 	"mime"
 	"net/http"
 	"net/url"
@@ -62,8 +64,20 @@ type assetCacheHit struct {
 }
 
 type assetCache struct {
-	dir string
-	mu  sync.Mutex
+	dir           string
+	mu            sync.Mutex
+	sizeBySiteMap map[int64]int64
+	totalBytes    int64
+	sizeLoaded    bool
+	entries       map[string]assetCacheIndexedEntry
+}
+
+type assetCacheIndexedEntry struct {
+	siteID   int64
+	metaName string
+	bodyName string
+	accessed int64
+	size     int64
 }
 
 type assetCacheContextKey struct{}
@@ -82,7 +96,7 @@ func newAssetCache(dir string) *assetCache {
 	if dir == "" {
 		return nil
 	}
-	return &assetCache{dir: dir}
+	return &assetCache{dir: dir, sizeBySiteMap: make(map[int64]int64), entries: make(map[string]assetCacheIndexedEntry)}
 }
 
 func assetCacheTargetURL(r *http.Request, upstream *url.URL) *url.URL {
@@ -196,19 +210,35 @@ func (c *assetCache) openRoot(create bool) (*os.Root, error) {
 // sizeBySite reports the bytes occupied by cached response bodies. Metadata
 // files are intentionally excluded so the panel matches the configured cache
 // budget, which is also enforced against response body sizes.
-func (c *assetCache) sizeBySite() (map[int64]int64, int64, error) {
-	sizes := make(map[int64]int64)
-	if c == nil {
-		return sizes, 0, nil
+func assetCacheSiteIDFromPath(path string) (int64, bool) {
+	parts := strings.SplitN(filepath.ToSlash(path), "/", 2)
+	if len(parts) != 2 {
+		return 0, false
 	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	directory := parts[0]
+	if strings.HasPrefix(directory, "site-") {
+		directory = strings.TrimPrefix(directory, "site-")
+		if dash := strings.Index(directory, "-"); dash >= 0 {
+			directory = directory[:dash]
+		}
+	}
+	siteID, err := strconv.ParseInt(directory, 10, 64)
+	return siteID, err == nil && siteID > 0
+}
+
+func (c *assetCache) rebuildSizeIndexLocked() error {
+	if c == nil {
+		return nil
+	}
+	sizes := make(map[int64]int64)
+	entries := make(map[string]assetCacheIndexedEntry)
 	root, err := c.openRoot(false)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return sizes, 0, nil
+			c.sizeBySiteMap, c.entries, c.totalBytes, c.sizeLoaded = sizes, entries, 0, true
+			return nil
 		}
-		return nil, 0, err
+		return err
 	}
 	defer root.Close()
 
@@ -223,19 +253,8 @@ func (c *assetCache) sizeBySite() (map[int64]int64, int64, error) {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".body") {
 			return nil
 		}
-		parts := strings.SplitN(filepath.ToSlash(path), "/", 2)
-		if len(parts) != 2 {
-			return nil
-		}
-		directory := parts[0]
-		if strings.HasPrefix(directory, "site-") {
-			directory = strings.TrimPrefix(directory, "site-")
-			if dash := strings.IndexByte(directory, '-'); dash >= 0 {
-				directory = directory[:dash]
-			}
-		}
-		siteID, err := strconv.ParseInt(directory, 10, 64)
-		if err != nil || siteID <= 0 {
+		siteID, ok := assetCacheSiteIDFromPath(path)
+		if !ok {
 			return nil
 		}
 		info, err := entry.Info()
@@ -247,12 +266,77 @@ func (c *assetCache) sizeBySite() (map[int64]int64, int64, error) {
 		}
 		sizes[siteID] += info.Size()
 		total += info.Size()
+		metaName := strings.TrimSuffix(path, ".body") + ".json"
+		accessed := int64(0)
+		if data, readErr := root.ReadFile(metaName); readErr == nil {
+			var meta assetCacheMeta
+			if json.Unmarshal(data, &meta) == nil {
+				accessed = meta.AccessedAtMS
+			}
+		}
+		entries[path] = assetCacheIndexedEntry{siteID: siteID, metaName: metaName, bodyName: path, accessed: accessed, size: info.Size()}
 		return nil
 	})
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	c.sizeBySiteMap, c.entries, c.totalBytes, c.sizeLoaded = sizes, entries, total, true
+	return nil
+}
+
+func (c *assetCache) ensureSizeIndexLocked() error {
+	if c == nil || c.sizeLoaded {
+		return nil
+	}
+	return c.rebuildSizeIndexLocked()
+}
+
+func (c *assetCache) sizeBySite() (map[int64]int64, int64, error) {
+	if c == nil {
+		return map[int64]int64{}, 0, nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := c.ensureSizeIndexLocked(); err != nil {
 		return nil, 0, err
 	}
-	return sizes, total, nil
+	sizes := make(map[int64]int64, len(c.sizeBySiteMap))
+	for siteID, size := range c.sizeBySiteMap {
+		sizes[siteID] = size
+	}
+	return sizes, c.totalBytes, nil
+}
+
+func (c *assetCache) reconcileSizeIndex() error {
+	if c == nil {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.rebuildSizeIndexLocked()
+}
+
+// startReconcile keeps the in-memory accounting correct if an operator or a
+// separate process changes the cache directory behind Meridian's back. It is
+// deliberately off the dashboard request path.
+func (c *assetCache) startReconcile(ctx context.Context) {
+	if c == nil || ctx == nil {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(15 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if err := c.reconcileSizeIndex(); err != nil {
+					log.Printf("[asset-cache] reconcile failed: %v", err)
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
 }
 
 // clear removes only entries beneath the configured asset-cache root. The
@@ -283,7 +367,49 @@ func (c *assetCache) clear() error {
 			return err
 		}
 	}
+	c.sizeBySiteMap = make(map[int64]int64)
+	c.entries = make(map[string]assetCacheIndexedEntry)
+	c.totalBytes = 0
+	c.sizeLoaded = true
 	return nil
+}
+
+func (c *assetCache) addIndexedEntryLocked(entry assetCacheIndexedEntry) {
+	if old, ok := c.entries[entry.bodyName]; ok {
+		c.sizeBySiteMap[old.siteID] -= old.size
+		if c.sizeBySiteMap[old.siteID] < 0 {
+			c.sizeBySiteMap[old.siteID] = 0
+		}
+		c.totalBytes -= old.size
+		if c.totalBytes < 0 {
+			c.totalBytes = 0
+		}
+	}
+	c.entries[entry.bodyName] = entry
+	c.sizeBySiteMap[entry.siteID] += entry.size
+	c.totalBytes += entry.size
+}
+
+func (c *assetCache) removeIndexedEntryLocked(bodyName string) {
+	entry, ok := c.entries[bodyName]
+	if !ok {
+		return
+	}
+	delete(c.entries, bodyName)
+	c.sizeBySiteMap[entry.siteID] -= entry.size
+	if c.sizeBySiteMap[entry.siteID] <= 0 {
+		delete(c.sizeBySiteMap, entry.siteID)
+	}
+	c.totalBytes -= entry.size
+	if c.totalBytes < 0 {
+		c.totalBytes = 0
+	}
+}
+
+func (c *assetCache) removeEntryLocked(root *os.Root, metaName, bodyName string) {
+	_ = root.Remove(metaName)
+	_ = root.Remove(bodyName)
+	c.removeIndexedEntryLocked(bodyName)
 }
 
 func (c *assetCache) read(req *assetCacheRequest, now time.Time) (*assetCacheHit, error) {
@@ -292,6 +418,9 @@ func (c *assetCache) read(req *assetCacheRequest, now time.Time) (*assetCacheHit
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if err := c.ensureSizeIndexLocked(); err != nil {
+		return nil, err
+	}
 	root, err := c.openRoot(false)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -309,14 +438,12 @@ func (c *assetCache) read(req *assetCacheRequest, now time.Time) (*assetCacheHit
 	}
 	var meta assetCacheMeta
 	if json.Unmarshal(metaBytes, &meta) != nil || meta.ExpiresAtMS <= now.UnixMilli() || meta.Size < 0 || meta.Size > maxAssetCacheObject {
-		_ = root.Remove(req.metaName)
-		_ = root.Remove(req.bodyName)
+		c.removeEntryLocked(root, req.metaName, req.bodyName)
 		return nil, nil
 	}
 	body, err := root.ReadFile(req.bodyName)
 	if err != nil || int64(len(body)) != meta.Size {
-		_ = root.Remove(req.metaName)
-		_ = root.Remove(req.bodyName)
+		c.removeEntryLocked(root, req.metaName, req.bodyName)
 		return nil, nil
 	}
 	meta.AccessedAtMS = now.UnixMilli()
@@ -380,6 +507,9 @@ func (c *assetCache) write(site Site, req *assetCacheRequest, resp *http.Respons
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if err := c.ensureSizeIndexLocked(); err != nil {
+		return err
+	}
 	root, err := c.openRoot(true)
 	if err != nil {
 		return err
@@ -403,8 +533,13 @@ func (c *assetCache) write(site Site, req *assetCacheRequest, resp *http.Respons
 		return err
 	}
 	if err := root.Rename(metaTmp, req.metaName); err != nil {
+		_ = root.Remove(req.bodyName)
 		_ = root.Remove(metaTmp)
+		c.removeIndexedEntryLocked(req.bodyName)
 		return err
+	}
+	if siteID, ok := assetCacheSiteIDFromPath(req.bodyName); ok {
+		c.addIndexedEntryLocked(assetCacheIndexedEntry{siteID: siteID, metaName: req.metaName, bodyName: req.bodyName, accessed: meta.AccessedAtMS, size: meta.Size})
 	}
 	return c.enforceBudgetLocked(root, site)
 }
@@ -417,40 +552,21 @@ type assetCacheFile struct {
 }
 
 func (c *assetCache) enforceBudgetLocked(root *os.Root, site Site) error {
-	siteDir := assetCacheSitePrefix(site)
 	files := make([]assetCacheFile, 0)
 	var total int64
-	err := fs.WalkDir(root.FS(), ".", func(path string, entry fs.DirEntry, walkErr error) error {
-		if walkErr != nil || entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
-			return nil
+	for _, entry := range c.entries {
+		if entry.siteID != site.ID {
+			continue
 		}
-		parts := strings.SplitN(filepath.ToSlash(path), "/", 2)
-		if len(parts) != 2 || parts[0] != siteDir && !strings.HasPrefix(parts[0], siteDir+"-") {
-			return nil
-		}
-		data, err := root.ReadFile(path)
-		if err != nil {
-			return nil
-		}
-		var meta assetCacheMeta
-		if json.Unmarshal(data, &meta) != nil {
-			return nil
-		}
-		bodyName := strings.TrimSuffix(path, ".json") + ".body"
-		files = append(files, assetCacheFile{metaName: path, bodyName: bodyName, accessed: meta.AccessedAtMS, size: meta.Size})
-		total += meta.Size
-		return nil
-	})
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return err
+		files = append(files, assetCacheFile{metaName: entry.metaName, bodyName: entry.bodyName, accessed: entry.accessed, size: entry.size})
+		total += entry.size
 	}
 	sort.Slice(files, func(i, j int) bool { return files[i].accessed < files[j].accessed })
 	for _, file := range files {
 		if total <= site.AssetCacheMaxBytes {
 			break
 		}
-		_ = root.Remove(file.metaName)
-		_ = root.Remove(file.bodyName)
+		c.removeEntryLocked(root, file.metaName, file.bodyName)
 		total -= file.size
 	}
 	return nil

--- a/asset_cache_test.go
+++ b/asset_cache_test.go
@@ -154,6 +154,34 @@ func TestAssetCacheSizeBySiteAndClear(t *testing.T) {
 	}
 }
 
+func TestAssetCacheSizeAccountingOverwriteAndExpiry(t *testing.T) {
+	cache := newAssetCache(t.TempDir())
+	site := Site{ID: 44, AssetCacheEnabled: true, AssetCacheTTLSec: 1, AssetCacheMaxBytes: 16 << 20, AssetCacheRules: "*/file/*"}
+	target, _ := url.Parse("https://media.example/file/accounting.jpg")
+	request := httptest.NewRequest(http.MethodGet, "https://proxy.example/file/accounting.jpg", nil)
+	cacheReq := cache.request(site, request, target)
+	response := &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": []string{"image/jpeg"}}}
+	now := time.Now()
+	if err := cache.write(site, cacheReq, response, []byte("first"), now); err != nil {
+		t.Fatal(err)
+	}
+	if _, total, err := cache.sizeBySite(); err != nil || total != 5 {
+		t.Fatalf("after first write total=%d err=%v, want 5", total, err)
+	}
+	if err := cache.write(site, cacheReq, response, []byte("replacement"), now.Add(time.Millisecond)); err != nil {
+		t.Fatal(err)
+	}
+	if sizes, total, err := cache.sizeBySite(); err != nil || total != 11 || sizes[site.ID] != 11 {
+		t.Fatalf("after overwrite sizes=%v total=%d err=%v, want 11", sizes, total, err)
+	}
+	if _, err := cache.read(cacheReq, now.Add(2*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if sizes, total, err := cache.sizeBySite(); err != nil || total != 0 || len(sizes) != 0 {
+		t.Fatalf("after expiry sizes=%v total=%d err=%v, want empty", sizes, total, err)
+	}
+}
+
 func TestHandleAssetCacheReportsAndClearsCache(t *testing.T) {
 	app := newTestApp(t)
 	cache := newAssetCache(t.TempDir())

--- a/dashboard_bootstrap.go
+++ b/dashboard_bootstrap.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+)
+
+func formatTimingDuration(duration time.Duration) string {
+	return fmt.Sprintf("%.1f", float64(duration.Microseconds())/1000)
+}
+
+func logDashboardSlow(path string, duration time.Duration) {
+	log.Printf("[dashboard] slow request path=%s duration=%s", path, duration.Round(time.Millisecond))
+}
+
+// dashboardSiteView is the intentionally small site representation used by
+// the dashboard. Management-only fields (credentials, upstream headers and
+// discovery rules) never need to cross the dashboard API boundary.
+type dashboardSiteView struct {
+	ID                int64  `json:"id"`
+	Name              string `json:"name"`
+	TargetURL         string `json:"target_url"`
+	UAMode            string `json:"ua_mode"`
+	PublicHost        string `json:"public_host"`
+	PathPrefix        string `json:"path_prefix"`
+	IngressMode       string `json:"ingress_mode"`
+	ListenPort        int    `json:"listen_port"`
+	Running           bool   `json:"running"`
+	TrafficUsed       int64  `json:"traffic_used"`
+	MonthlyTraffic    int64  `json:"monthly_traffic"`
+	CacheSizeBytes    int64  `json:"cache_size_bytes"`
+	MediaMovieCount   int64  `json:"media_movie_count"`
+	MediaSeriesCount  int64  `json:"media_series_count"`
+	MediaEpisodeCount int64  `json:"media_episode_count"`
+}
+
+type dashboardBootstrapResponse struct {
+	Snapshot      *TrafficSnapshot    `json:"snapshot"`
+	Sites         []dashboardSiteView `json:"sites"`
+	Insights      dashboardInsights   `json:"insights"`
+	GeneratedAtMS int64               `json:"generated_at_ms"`
+}
+
+func (a *App) dashboardBootstrap() (*dashboardBootstrapResponse, error) {
+	started := time.Now()
+	settings := a.db.currentSystemSettings()
+	sites, err := a.db.ListSites()
+	if err != nil {
+		return nil, err
+	}
+	monthlyBySite, err := a.db.SumTrafficSinceBySite(
+		trafficCycleStart(time.Now(), settings.TrafficResetDay, timezoneLocation(settings.ScheduleTimezone)),
+		settings.TrafficBillingMode,
+	)
+	if err != nil {
+		return nil, err
+	}
+	snapshot := a.pm.dashboardSnapshotFromSites(sites, monthlyBySite, settings)
+	snapshot.PanelDomain = a.panelHost
+	snapshot.PanelAccessURL = a.panelAccessURL()
+	cacheSizes, _, err := a.pm.AssetCacheSizes()
+	if err != nil {
+		return nil, err
+	}
+	liveBySite := make(map[int64]SiteTraffic, len(snapshot.LiveSites))
+	for _, live := range snapshot.LiveSites {
+		liveBySite[live.ID] = live
+	}
+	views := make([]dashboardSiteView, 0, len(sites))
+	for _, site := range sites {
+		live := liveBySite[site.ID]
+		views = append(views, dashboardSiteView{
+			ID: site.ID, Name: site.Name, TargetURL: site.TargetURL, UAMode: site.UAMode,
+			PublicHost: site.PublicHost, PathPrefix: site.PathPrefix, IngressMode: site.IngressMode,
+			ListenPort: site.ListenPort, Running: live.Running, TrafficUsed: live.TrafficUsed,
+			MonthlyTraffic: live.MonthlyTraffic, CacheSizeBytes: cacheSizes[site.ID],
+			MediaMovieCount: site.MediaMovieCount, MediaSeriesCount: site.MediaSeriesCount,
+			MediaEpisodeCount: site.MediaEpisodeCount,
+		})
+	}
+	response := &dashboardBootstrapResponse{
+		Snapshot:      snapshot,
+		Sites:         views,
+		Insights:      a.dashboardInsightsSnapshot(),
+		GeneratedAtMS: time.Now().UnixMilli(),
+	}
+	if elapsed := time.Since(started); elapsed > 300*time.Millisecond {
+		// Keep this diagnostic intentionally free of site names, URLs and
+		// credentials so slow-path logs cannot become a data-exfiltration vector.
+		logDashboardSlow("/api/dashboard/bootstrap", elapsed)
+	}
+	return response, nil
+}
+
+func (a *App) handleDashboardBootstrap(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		a.jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	started := time.Now()
+	response, err := a.dashboardBootstrap()
+	if err != nil {
+		a.jsonErr(w, http.StatusInternalServerError, "dashboard bootstrap unavailable")
+		return
+	}
+	w.Header().Set("Server-Timing", "dashboard;dur="+formatTimingDuration(time.Since(started)))
+	a.jsonOK(w, response)
+}

--- a/dashboard_bootstrap_test.go
+++ b/dashboard_bootstrap_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDashboardBootstrapUsesOneSnapshotWithoutSiteFlush(t *testing.T) {
+	app := newTestApp(t)
+	if _, err := app.db.CreateSite("bootstrap", freePort(t), "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 0, 0); err != nil {
+		t.Fatal(err)
+	}
+	setDBReadonly(t, app, true)
+	defer setDBReadonly(t, app, false)
+
+	rr := httptest.NewRecorder()
+	app.handleDashboardBootstrap(rr, httptest.NewRequest(http.MethodGet, "/api/dashboard/bootstrap", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	var payload dashboardBootstrapResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Snapshot == nil || payload.Snapshot.TotalSites != 1 || len(payload.Sites) != 1 {
+		t.Fatalf("bootstrap payload=%+v, want one site snapshot", payload)
+	}
+}

--- a/dashboard_trends.go
+++ b/dashboard_trends.go
@@ -229,6 +229,29 @@ func dashboardTrendPoints(start, end time.Time, bucket time.Duration, rangeName 
 }
 
 func (pm *ProxyManager) dashboardTrends(siteID *int64, rangeName string, customWindow ...time.Time) (*dashboardTrendsResponse, error) {
+	// Coalesce identical cold-cache requests. Dashboard tabs frequently mount
+	// together, and the database is intentionally kept on a single writer
+	// connection; only one caller should execute the trend query.
+	customKey := ""
+	for _, value := range customWindow {
+		customKey += fmt.Sprintf("|%d", value.UnixNano())
+	}
+	siteKey := "all"
+	if siteID != nil {
+		siteKey = strconv.FormatInt(*siteID, 10)
+	}
+	settings := pm.database.currentSystemSettings()
+	flightKey := fmt.Sprintf("%p|%s|%s|%d%s", pm.database, siteKey, strings.ToLower(strings.TrimSpace(rangeName)), settings.ScheduleTimezone, customKey)
+	value, err, _ := pm.dashboardTrendGroup.Do(flightKey, func() (interface{}, error) {
+		return pm.dashboardTrendsUncoalesced(siteID, rangeName, customWindow...)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return value.(*dashboardTrendsResponse), nil
+}
+
+func (pm *ProxyManager) dashboardTrendsUncoalesced(siteID *int64, rangeName string, customWindow ...time.Time) (*dashboardTrendsResponse, error) {
 	settings := pm.database.currentSystemSettings()
 	billingMode := settings.TrafficBillingMode
 	trendLocation := timezoneLocation(settings.ScheduleTimezone)
@@ -357,10 +380,15 @@ func (a *App) handleDashboardTrends(w http.ResponseWriter, r *http.Request) {
 		}
 		customWindow = []time.Time{start, end}
 	}
+	started := time.Now()
 	trend, err := a.pm.dashboardTrends(siteID, rangeName, customWindow...)
 	if err != nil {
 		a.jsonErr(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+		logDashboardSlow("/api/dashboard-trends", elapsed)
+	}
+	w.Header().Set("Server-Timing", "trend;dur="+formatTimingDuration(time.Since(started)))
 	a.jsonOK(w, trend)
 }

--- a/install.sh
+++ b/install.sh
@@ -1330,6 +1330,23 @@ server {
     large_client_header_buffers 4 32k;
     access_log /var/log/nginx/meridian_access.log meridian_redacted;
 
+    location = /api/events {
+        proxy_pass http://127.0.0.1:${port};
+        proxy_http_version 1.1;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$remote_addr;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_cache off;
+        gzip off;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        send_timeout 3600s;
+        add_header X-Accel-Buffering no always;
+    }
+
     location / {
         proxy_pass http://127.0.0.1:${port};
         proxy_http_version 1.1;

--- a/main.go
+++ b/main.go
@@ -191,7 +191,13 @@ func main() {
 	if assetCacheDir == "" && dbPath != ":memory:" && !strings.HasPrefix(dbPath, "file:") {
 		assetCacheDir = filepath.Join(filepath.Dir(dbPath), "asset-cache")
 	}
-	pm.SetAssetCache(newAssetCache(assetCacheDir))
+	assetCache := newAssetCache(assetCacheDir)
+	pm.SetAssetCache(assetCache)
+	if assetCache != nil {
+		if err := assetCache.reconcileSizeIndex(); err != nil {
+			log.Printf("[asset-cache] initial size index rebuild failed: %v", err)
+		}
+	}
 	pm.SetTrustedProxies(trustedProxies)
 	pm.SetHostOnlyIngressSafe(panelTLSEnabled || (panelBindIP != nil && panelBindIP.IsLoopback()) || len(trustedProxies) > 0)
 	if err := pm.ConfigureDynamicDiscovery(dynamicRouteKey, panelHost, port, nil); err != nil {
@@ -205,6 +211,7 @@ func main() {
 	// Traffic flush goroutine with context
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	assetCache.startReconcile(ctx)
 
 	go func() {
 		ticker := time.NewTicker(60 * time.Second)
@@ -288,6 +295,7 @@ func main() {
 	// Protected routes
 	mux.HandleFunc("/api/account", cors(app.authMiddleware(app.handleAccount)))
 	mux.HandleFunc("/api/dashboard", cors(app.authMiddleware(app.handleDashboard)))
+	mux.HandleFunc("/api/dashboard/bootstrap", cors(app.authMiddleware(app.handleDashboardBootstrap)))
 	mux.HandleFunc("/api/dashboard-insights", cors(app.authMiddleware(app.handleDashboardInsights)))
 	mux.HandleFunc("/api/dashboard-trends", cors(app.authMiddleware(app.handleDashboardTrends)))
 	mux.HandleFunc("/api/system-settings", cors(app.authMiddleware(app.handleSystemSettings)))

--- a/proxy_lifecycle.go
+++ b/proxy_lifecycle.go
@@ -349,35 +349,25 @@ func (pm *ProxyManager) LiveSiteTraffic(sites []Site) map[int64]SiteTraffic {
 	return live
 }
 
-// TrafficSnapshot builds the authoritative global traffic payload: every DB
-// site, overlaid with live per-instance state for running sites. Dashboard,
-// traffic overview and SSE events all render this single payload.
-func (pm *ProxyManager) TrafficSnapshot() (*TrafficSnapshot, error) {
-	sites, err := pm.database.ListSites()
-	if err != nil {
-		return nil, err
-	}
-	settings := pm.database.currentSystemSettings()
+// dashboardSnapshotFromSites builds the live dashboard payload from one
+// already captured site list and one grouped traffic query. Keeping the
+// inputs explicit lets the dashboard bootstrap endpoint share its snapshot
+// with the site table without issuing another ListSites query.
+func (pm *ProxyManager) dashboardSnapshotFromSites(sites []Site, monthlyBySite map[int64]int64, settings SystemSettings) *TrafficSnapshot {
 	billingMode := settings.TrafficBillingMode
-	monthlyBySite, err := pm.database.SumTrafficSinceBySite(trafficCycleStart(time.Now(), settings.TrafficResetDay, timezoneLocation(settings.ScheduleTimezone)), billingMode)
-	if err != nil {
-		return nil, err
-	}
-	var monthlyTraffic int64
-	for _, value := range monthlyBySite {
-		monthlyTraffic += value
-	}
 	snap := &TrafficSnapshot{
 		TotalSites:      len(sites),
 		LiveSites:       make([]SiteTraffic, 0, len(sites)),
-		MonthlyTraffic:  monthlyTraffic,
 		BillingMode:     trafficBillingModeLabel(billingMode),
 		TrafficResetDay: settings.TrafficResetDay,
+	}
+	for _, value := range monthlyBySite {
+		snap.MonthlyTraffic += value
 	}
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
 	for _, inst := range pm.proxies {
-		if inst.isOperational() {
+		if inst != nil && inst.isOperational() {
 			snap.RunningSites++
 		}
 	}
@@ -402,7 +392,24 @@ func (pm *ProxyManager) TrafficSnapshot() (*TrafficSnapshot, error) {
 		snap.LiveSites = append(snap.LiveSites, st)
 	}
 	snap.UptimeSeconds = int64(time.Since(startTime).Seconds())
-	return snap, nil
+	return snap
+}
+
+// TrafficSnapshot builds the authoritative global traffic payload: every DB
+// site, overlaid with live per-instance state for running sites. Dashboard,
+// traffic overview and SSE events all render this single payload.
+func (pm *ProxyManager) TrafficSnapshot() (*TrafficSnapshot, error) {
+	sites, err := pm.database.ListSites()
+	if err != nil {
+		return nil, err
+	}
+	settings := pm.database.currentSystemSettings()
+	billingMode := settings.TrafficBillingMode
+	monthlyBySite, err := pm.database.SumTrafficSinceBySite(trafficCycleStart(time.Now(), settings.TrafficResetDay, timezoneLocation(settings.ScheduleTimezone)), billingMode)
+	if err != nil {
+		return nil, err
+	}
+	return pm.dashboardSnapshotFromSites(sites, monthlyBySite, settings), nil
 }
 
 func (pm *ProxyManager) GetRunningCount() int {

--- a/proxy_manager.go
+++ b/proxy_manager.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"golang.org/x/sync/singleflight"
 	"log"
 	"net"
 	"net/http"
@@ -80,6 +81,7 @@ type ProxyManager struct {
 	accountRetention        *accountRetentionTracker
 	trendCacheMu            sync.Mutex
 	trendCache              map[string]dashboardTrendCacheEntry
+	dashboardTrendGroup     singleflight.Group
 }
 
 // ProxyRuntimeStat is a non-persistent edge snapshot. Node scheduling quotas

--- a/system_settings.go
+++ b/system_settings.go
@@ -206,38 +206,21 @@ func (a *App) handleSystemSettings(w http.ResponseWriter, r *http.Request) {
 }
 
 type dashboardInsights struct {
-	LogHealthy      bool    `json:"log_healthy"`
-	LatestLogMS     int64   `json:"latest_log_ms"`
-	LogCountToday   int64   `json:"log_count_today"`
-	DroppedLogs     uint64  `json:"dropped_logs"`
-	ScheduleEnabled bool    `json:"schedule_enabled"`
-	ScheduleLabel   string  `json:"schedule_label"`
-	LastSentKey     string  `json:"last_sent_key"`
-	HourlyRequests  []int64 `json:"hourly_requests"`
+	LogHealthy      bool   `json:"log_healthy"`
+	LatestLogMS     int64  `json:"latest_log_ms"`
+	LogCountToday   int64  `json:"log_count_today"`
+	DroppedLogs     uint64 `json:"dropped_logs"`
+	ScheduleEnabled bool   `json:"schedule_enabled"`
+	ScheduleLabel   string `json:"schedule_label"`
+	LastSentKey     string `json:"last_sent_key"`
 }
 
-func (a *App) handleDashboardInsights(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		w.Header().Set("Allow", "GET")
-		a.jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
-		return
-	}
+func (a *App) dashboardInsightsSnapshot() dashboardInsights {
 	location := timezoneLocation(a.db.currentSystemSettings().ScheduleTimezone)
 	now := time.Now().In(location)
 	start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, location)
-	insights := dashboardInsights{HourlyRequests: make([]int64, 24), LogHealthy: a.db.currentSystemSettings().LogEnabled}
+	insights := dashboardInsights{LogHealthy: a.db.currentSystemSettings().LogEnabled}
 	_ = a.db.db.QueryRow(`SELECT COALESCE(MAX(recorded_at_ms),0), COUNT(*) FROM request_logs WHERE recorded_at_ms>=? AND recorded_at_ms<?`, start.UnixMilli(), start.AddDate(0, 0, 1).UnixMilli()).Scan(&insights.LatestLogMS, &insights.LogCountToday)
-	rows, err := a.db.db.Query(`SELECT recorded_at_ms FROM request_logs WHERE recorded_at_ms>=? AND recorded_at_ms<?`, start.UnixMilli(), start.AddDate(0, 0, 1).UnixMilli())
-	if err == nil {
-		for rows.Next() {
-			var timestamp int64
-			if rows.Scan(&timestamp) == nil {
-				hour := time.UnixMilli(timestamp).In(location).Hour()
-				insights.HourlyRequests[hour]++
-			}
-		}
-		rows.Close()
-	}
 	insights.DroppedLogs = a.db.DroppedRequestLogs()
 	if stored, err := a.db.telegramReportSettings(); err == nil {
 		insights.ScheduleEnabled = stored.Enabled
@@ -249,5 +232,18 @@ func (a *App) handleDashboardInsights(w http.ResponseWriter, r *http.Request) {
 			insights.ScheduleLabel = "每天 " + insights.ScheduleLabel
 		}
 	}
-	a.jsonOK(w, insights)
+	return insights
+}
+
+func (a *App) handleDashboardInsights(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		a.jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	started := time.Now()
+	a.jsonOK(w, a.dashboardInsightsSnapshot())
+	if elapsed := time.Since(started); elapsed > 200*time.Millisecond {
+		logDashboardSlow("/api/dashboard-insights", elapsed)
+	}
 }

--- a/tests/dashboard_trends.test.js
+++ b/tests/dashboard_trends.test.js
@@ -37,3 +37,17 @@ test('dashboard realtime trend keeps historical points after a page refresh', ()
   assert.match(dashboardSource, /historicalPoints\.slice\(0, offset\)\.concat\(realtimePoints\)/);
   assert.match(dashboardSource, /if \(!realtimePoints\.length \|\| !historicalPoints\.length\) return realtimePoints\.length \? realtimePoints : historicalPoints/);
 });
+
+test('dashboard loads an HTTP snapshot/bootstrap before relying on SSE', () => {
+  assert.match(dashboardSource, /void loadDashboardInitialSnapshot\(\)/);
+  assert.match(dashboardSource, /API\.dashboard\(signal\)/);
+  assert.match(dashboardSource, /API\.dashboardBootstrap\(signal\)/);
+});
+
+test('dashboard coalesces bootstrap and aborts stale trend requests', () => {
+  assert.match(dashboardSource, /if \(dashboardBootstrapPromise\) return dashboardBootstrapPromise/);
+  assert.match(dashboardSource, /dashboardTrendAbortController\.abort\(\)/);
+  assert.match(dashboardSource, /dashboardTrends\([\s\S]*signal/);
+  assert.match(dashboardSource, /setInterval\(\(\) => \{[\s\S]*60000/);
+  assert.match(dashboardSource, /dashboardTrendState\.range === 'realtime'[\s\S]*15000/);
+});

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -87,12 +87,13 @@ const API = {
     this.authenticated = false;
   },
 
-  async request(method, path, body) {
+  async request(method, path, body, requestOptions) {
     const opts = {
       method,
       credentials: 'same-origin',
       headers: {},
     };
+    if (requestOptions && requestOptions.signal) opts.signal = requestOptions.signal;
     if (body !== undefined) {
       opts.headers['Content-Type'] = 'application/json';
       opts.body = JSON.stringify(body);
@@ -130,15 +131,16 @@ const API = {
   updateAccount(data) { return this.request('PUT', '/api/account', data); },
 
   // Dashboard
-  dashboard() { return this.request('GET', '/api/dashboard'); },
+  dashboard(signal) { return this.request('GET', '/api/dashboard', undefined, { signal }); },
+  dashboardBootstrap(signal) { return this.request('GET', '/api/dashboard/bootstrap', undefined, { signal }); },
   dashboardInsights() { return this.request('GET', '/api/dashboard-insights'); },
-  dashboardTrends(siteId, range, customStart, customEnd) {
+  dashboardTrends(siteId, range, customStart, customEnd, signal) {
     const params = new URLSearchParams({ site_id: siteId || 'all', range: range || 'realtime' });
     if ((range || '').toLowerCase() === 'custom') {
       if (customStart) params.set('start', customStart);
       if (customEnd) params.set('end', customEnd);
     }
-    return this.request('GET', '/api/dashboard-trends?' + params.toString());
+    return this.request('GET', '/api/dashboard-trends?' + params.toString(), undefined, { signal });
   },
   getSystemSettings() { return this.request('GET', '/api/system-settings'); },
   saveSystemSettings(data) { return this.request('POST', '/api/system-settings', data); },

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -191,15 +191,14 @@
 
   function startDashboardRefresh() {
     if (dashboardRefreshTimer) clearInterval(dashboardRefreshTimer);
-    dashboardRefreshTimer = setInterval(() => {
-      if (Router.current === 'dashboard') loadDashboardData();
-    }, 15000);
+    dashboardRefreshTimer = null;
+    if (typeof startDashboardRefreshTimers === 'function') startDashboardRefreshTimers();
   }
 
   function stopDashboardRefresh() {
-    if (!dashboardRefreshTimer) return;
-    clearInterval(dashboardRefreshTimer);
+    if (dashboardRefreshTimer) clearInterval(dashboardRefreshTimer);
     dashboardRefreshTimer = null;
+    if (typeof stopDashboardRefreshTimers === 'function') stopDashboardRefreshTimers();
   }
 
   function teardownAppRuntime() {

--- a/web/static/js/pages/dashboard.js
+++ b/web/static/js/pages/dashboard.js
@@ -1,6 +1,13 @@
 let dashSSE = null;
 let dashAbortController = null;
 let dashRetryTimer = null;
+let dashboardBootstrapPromise = null;
+let dashboardBootstrapAbortController = null;
+let dashboardInitialAbortController = null;
+let dashboardSecondaryPromise = null;
+let dashboardTrendAbortController = null;
+let dashboardSecondaryRefreshTimer = null;
+let dashboardTrendRefreshTimer = null;
 let dashboardTrendResizeObserver = null;
 let dashboardTrendState = { siteId: 'all', range: 'realtime', customStart: '', customEnd: '' };
 let dashboardTrendCharts = new Map();
@@ -10,6 +17,12 @@ let dashboardSpeedSamples = new Map();
 let dashboardLiveSpeeds = new Map();
 let dashboardRealtimeTrendSamples = new Map();
 let dashboardRealtimeTrendSiteSamples = new Map();
+
+function dashboardCreateAbortController() {
+  if (typeof AbortController === 'function') return new AbortController();
+  const signal = { aborted: false };
+  return { signal, abort() { signal.aborted = true; } };
+}
 
 function renderDashboard() {
   const page = document.getElementById('page-dashboard');
@@ -98,26 +111,71 @@ function renderDashboard() {
     </div>
   `;
 
+  void loadDashboardInitialSnapshot();
   startDashSSE();
   setupDashboardTrendControls();
   observeDashboardTrendResize();
-  loadDashboardTable();
-  loadDashboardInsights();
-  loadDashboardTrends();
+  void loadDashboardBootstrap();
+  const deferTrends = typeof requestAnimationFrame === 'function' ? requestAnimationFrame : fn => setTimeout(fn, 0);
+  deferTrends(() => {
+    if (Router.current === 'dashboard') void loadDashboardTrends();
+  });
 }
 
-async function loadDashboardInsights() {
+async function loadDashboardInitialSnapshot() {
+  if (dashboardInitialAbortController) dashboardInitialAbortController.abort();
+  dashboardInitialAbortController = dashboardCreateAbortController();
+  const signal = dashboardInitialAbortController.signal;
   try {
-    const insights = await API.dashboardInsights();
-    if (!insights || Router.current !== 'dashboard') return;
-    const log = document.querySelector('#dashboard-log-health p');
-    const schedule = document.querySelector('#dashboard-schedule-health p');
-    const latestLog = insights.latest_log_ms ? meridianFormatDateTime(insights.latest_log_ms) : '暂无记录';
-    if (log) log.textContent = insights.log_healthy ? `今日写入 ${formatNumber(insights.log_count_today || 0)} 条 · 最近写入 ${latestLog}` : '已关闭';
-    if (schedule) schedule.textContent = insights.schedule_enabled ? `Telegram 日报 · ${insights.schedule_label || '已启用'}` : 'Telegram 日报 · 未启用';
+    const data = await API.dashboard(signal);
+    if (!signal.aborted && data && Router.current === 'dashboard') updateDashboardLive(data);
   } catch (error) {
-    console.warn('Dashboard insights load error', error);
+    if (error && error.name === 'AbortError') return;
+    console.warn('Dashboard initial snapshot load error', error);
+  } finally {
+    if (dashboardInitialAbortController?.signal === signal) dashboardInitialAbortController = null;
   }
+}
+
+function applyDashboardInsights(insights) {
+  if (!insights || Router.current !== 'dashboard') return;
+  const log = document.querySelector('#dashboard-log-health p');
+  const schedule = document.querySelector('#dashboard-schedule-health p');
+  const latestLog = insights.latest_log_ms ? meridianFormatDateTime(insights.latest_log_ms) : '暂无记录';
+  if (log) log.textContent = insights.log_healthy ? `今日写入 ${formatNumber(insights.log_count_today || 0)} 条 · 最近写入 ${latestLog}` : '已关闭';
+  if (schedule) schedule.textContent = insights.schedule_enabled ? `Telegram 日报 · ${insights.schedule_label || '已启用'}` : 'Telegram 日报 · 未启用';
+}
+
+async function loadDashboardBootstrap() {
+  if (dashboardBootstrapPromise) return dashboardBootstrapPromise;
+  dashboardBootstrapAbortController = dashboardCreateAbortController();
+  const signal = dashboardBootstrapAbortController.signal;
+  dashboardBootstrapPromise = API.dashboardBootstrap(signal).then(data => {
+    if (signal.aborted || !data || Router.current !== 'dashboard') return data;
+    const currentSites = new Map(dashboardSites.map(site => [Number(site.id), site]));
+    dashboardSites = Array.isArray(data.sites) ? data.sites.map(site => {
+      const current = currentSites.get(Number(site.id));
+      const speed = dashboardLiveSpeeds.get(Number(site.id)) || current?._liveSpeed;
+      return speed ? { ...site, _liveSpeed: speed } : site;
+    }) : [];
+    const cacheEl = document.getElementById('s-cache');
+    if (cacheEl) cacheEl.textContent = formatBytes(dashboardSites.reduce((total, site) => total + Number(site.cache_size_bytes || 0), 0));
+    if (data.snapshot) updateDashboardLive(data.snapshot);
+    applyDashboardInsights(data.insights);
+    renderDashboardTrendSites();
+    renderDashboardTableRows();
+    return data;
+  }).catch(error => {
+    if (error && error.name === 'AbortError') return null;
+    console.warn('Dashboard bootstrap load error', error);
+    throw error;
+  }).finally(() => {
+    if (dashboardBootstrapAbortController?.signal === signal) {
+      dashboardBootstrapAbortController = null;
+      dashboardBootstrapPromise = null;
+    }
+  });
+  return dashboardBootstrapPromise;
 }
 
 function dashboardRequestScale(maxValue) {
@@ -596,14 +654,18 @@ function setupDashboardTrendControls() {
 }
 
 async function loadDashboardTrends() {
+  if (dashboardTrendAbortController) dashboardTrendAbortController.abort();
+  dashboardTrendAbortController = dashboardCreateAbortController();
+  const signal = dashboardTrendAbortController.signal;
   try {
     const data = await API.dashboardTrends(
       dashboardTrendState.siteId,
       dashboardTrendState.range,
       dashboardTrendState.customStart,
       dashboardTrendState.customEnd,
+      signal,
     );
-    if (!data || Router.current !== 'dashboard') return;
+    if (signal.aborted || !data || Router.current !== 'dashboard') return;
     if (typeof meridianSetTimezoneOffset === 'function') meridianSetTimezoneOffset(data.timezone_offset_minutes);
     const timezone = document.getElementById('dashboard-trend-timezone');
     if (timezone && typeof meridianTimezoneLabel === 'function') timezone.textContent = meridianTimezoneLabel(data.timezone_offset_minutes);
@@ -623,19 +685,18 @@ async function loadDashboardTrends() {
     dashboardTrendSummary(data);
     renderDashboardTrendCharts();
   } catch (error) {
+    if (error && error.name === 'AbortError') return;
     console.warn('Dashboard trends load error', error);
+  } finally {
+    if (dashboardTrendAbortController?.signal === signal) dashboardTrendAbortController = null;
   }
 }
 
-function loadDashboardTrendSites() {
+function renderDashboardTrendSites() {
   const select = document.getElementById('dashboard-trend-site');
   if (!select) return;
-  API.listSites().then(sites => {
-    if (!select || Router.current !== 'dashboard') return;
-    dashboardSites = sites || [];
-    select.innerHTML = '<option value="all">全部站点</option>' + dashboardSites.map(site => `<option value="${Number(site.id)}">${esc(site.name)}</option>`).join('');
-    select.value = dashboardTrendState.siteId;
-  }).catch(error => console.warn('Dashboard trend site list error', error));
+  select.innerHTML = '<option value="all">全部站点</option>' + dashboardSites.map(site => `<option value="${Number(site.id)}">${esc(site.name)}</option>`).join('');
+  select.value = dashboardTrendState.siteId;
 }
 
 function updateDashboardTrendRealtime() {
@@ -651,7 +712,7 @@ function observeDashboardTrendResize() {
   }
   const wrap = document.querySelector('.dashboard-trend-wrap');
   if (!wrap) return;
-  loadDashboardTrendSites();
+  renderDashboardTrendSites();
   if (typeof ResizeObserver !== 'function') return;
   dashboardTrendResizeObserver = new ResizeObserver(() => {
     if (Router.current === 'dashboard') renderDashboardTrendCharts();
@@ -894,6 +955,28 @@ function stopDashSSE() {
     dashAbortController.abort();
     dashAbortController = null;
   }
+  if (dashboardTrendAbortController) {
+    dashboardTrendAbortController.abort();
+    dashboardTrendAbortController = null;
+  }
+  if (dashboardInitialAbortController) {
+    dashboardInitialAbortController.abort();
+    dashboardInitialAbortController = null;
+  }
+  if (dashboardBootstrapAbortController) {
+    dashboardBootstrapAbortController.abort();
+    dashboardBootstrapAbortController = null;
+    dashboardBootstrapPromise = null;
+  }
+  dashboardSecondaryPromise = null;
+  if (dashboardSecondaryRefreshTimer) {
+    clearInterval(dashboardSecondaryRefreshTimer);
+    dashboardSecondaryRefreshTimer = null;
+  }
+  if (dashboardTrendRefreshTimer) {
+    clearInterval(dashboardTrendRefreshTimer);
+    dashboardTrendRefreshTimer = null;
+  }
   if (dashSSE) {
     dashSSE.close();
     dashSSE = null;
@@ -902,6 +985,9 @@ function stopDashSSE() {
 
 async function loadDashboardTable() {
   try {
+    // Kept as a compatibility helper for cached clients and older embedded
+    // test harnesses. The live dashboard now calls loadDashboardBootstrap()
+    // directly, so this legacy path is never used during normal rendering.
     const sites = await API.listSites();
     const tbody = document.getElementById('dash-table');
     if (!tbody) return;
@@ -964,8 +1050,37 @@ function dashboardIngressLabel(site) {
 }
 
 async function loadDashboardData() {
-  loadDashboardTable();
-  if (Router.current === 'dashboard') loadDashboardTrends();
+  if (Router.current === 'dashboard') {
+    await refreshDashboardSecondary();
+  }
+}
+
+function refreshDashboardSecondary() {
+  if (dashboardSecondaryPromise) return dashboardSecondaryPromise;
+  let promise;
+  promise = loadDashboardBootstrap().finally(() => {
+    if (dashboardSecondaryPromise === promise) dashboardSecondaryPromise = null;
+  });
+  dashboardSecondaryPromise = promise;
+  return dashboardSecondaryPromise;
+}
+
+function startDashboardRefreshTimers() {
+  if (dashboardSecondaryRefreshTimer) clearInterval(dashboardSecondaryRefreshTimer);
+  if (dashboardTrendRefreshTimer) clearInterval(dashboardTrendRefreshTimer);
+  dashboardSecondaryRefreshTimer = setInterval(() => {
+    if (Router.current === 'dashboard') void refreshDashboardSecondary();
+  }, 60000);
+  dashboardTrendRefreshTimer = setInterval(() => {
+    if (Router.current === 'dashboard' && dashboardTrendState.range === 'realtime') void loadDashboardTrends();
+  }, 15000);
+}
+
+function stopDashboardRefreshTimers() {
+  if (dashboardSecondaryRefreshTimer) clearInterval(dashboardSecondaryRefreshTimer);
+  if (dashboardTrendRefreshTimer) clearInterval(dashboardTrendRefreshTimer);
+  dashboardSecondaryRefreshTimer = null;
+  dashboardTrendRefreshTimer = null;
 }
 
 const uaClassMap = { infuse: 'pill-blue', web: 'pill-green', client: 'pill-orange', custom: 'pill-purple', passthrough: 'pill-blue' };


### PR DESCRIPTION
## Summary\n- add authenticated dashboard bootstrap snapshot for first render\n- keep SSE unbuffered and add generated Nginx SSE location\n- replace dashboard cache scans with indexed accounting and reconciliation\n- coalesce trend queries, cancel stale requests, and split refresh cadence\n\n## Validation\n- go test ./...\n- go test -race ./...\n- go vet ./...\n- node --check web/static/js/*.js\n- node --test tests/*.test.js\n