### PR TITLE
fix: harden agent telemetry and dashboard runtime state

### DIFF
--- a/agent_report_guard_test.go
+++ b/agent_report_guard_test.go
@@ -148,6 +148,37 @@ func TestNodeReportAdmissionReclaimsIdleEntries(t *testing.T) {
 	}
 }
 
+func TestAgentReportCannotAcknowledgeFutureCacheGeneration(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now()
+	node, enrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "cache-generation-guard", Address: "203.0.113.90"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, token, err := app.db.EnrollControlNode(enrollment, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec("UPDATE control_nodes SET cache_clear_generation=3 WHERE id=?", node.ID); err != nil {
+		t.Fatal(err)
+	}
+	for sequence, generation := range []int64{4, 3} {
+		if _, err := app.db.RecordNodeReportResult(token, NodeReport{
+			BootID: "cache-guard", ReportSessionID: "cache-guard", CounterEpoch: "kernel:eth0", Sequence: int64(sequence + 1),
+			InterfaceName: "eth0", CacheClearGeneration: generation,
+		}, now.Add(time.Duration(sequence)*time.Second)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var applied int64
+	if err := app.db.db.QueryRow("SELECT cache_clear_applied_generation FROM control_nodes WHERE id=?", node.ID).Scan(&applied); err != nil {
+		t.Fatal(err)
+	}
+	if applied != 3 {
+		t.Fatalf("cache clear applied generation=%d, want only the controller-issued generation 3", applied)
+	}
+}
+
 func TestAgentPreAuthAdmissionHasHardEntryLimit(t *testing.T) {
 	admission := newAgentPreAuthAdmission()
 	now := time.Now()

--- a/app_sites.go
+++ b/app_sites.go
@@ -79,7 +79,11 @@ func (a *App) handleSites(w http.ResponseWriter, r *http.Request) {
 		result := make([]SiteWithStatus, len(sites))
 		for i, s := range sites {
 			st := live[s.ID]
-			result[i] = SiteWithStatus{Site: s, Running: st.Running, CacheSizeBytes: cacheSizes[s.ID], MonthlyTraffic: st.MonthlyTraffic}
+			cacheSize := cacheSizes[s.ID]
+			if st.AgentRuntime {
+				cacheSize = st.CacheSizeBytes
+			}
+			result[i] = SiteWithStatus{Site: s, Running: st.Running, CacheSizeBytes: cacheSize, MonthlyTraffic: st.MonthlyTraffic}
 			result[i].TrafficUsed = st.TrafficUsed
 		}
 		a.jsonOK(w, result)

--- a/app_traffic.go
+++ b/app_traffic.go
@@ -87,13 +87,48 @@ func (a *App) handleAssetCache(w http.ResponseWriter, r *http.Request) {
 			a.jsonErr(w, http.StatusInternalServerError, "cache statistics unavailable")
 			return
 		}
-		a.jsonOK(w, map[string]interface{}{"total_bytes": total, "sites": sites})
+		nodes := make([]map[string]any, 0)
+		if controlNodes, nodeErr := a.db.listControlNodes(time.Now()); nodeErr == nil {
+			for _, node := range controlNodes {
+				state := "applied"
+				if node.CacheClearGeneration > node.CacheClearAppliedGeneration {
+					state = "pending"
+					if node.Status != "online" {
+						state = "offline"
+					}
+				}
+				nodes = append(nodes, map[string]any{
+					"node_id":            node.ID,
+					"status":             state,
+					"generation":         node.CacheClearGeneration,
+					"applied_generation": node.CacheClearAppliedGeneration,
+				})
+			}
+		}
+		a.jsonOK(w, map[string]interface{}{"total_bytes": total, "sites": sites, "nodes": nodes})
 	case http.MethodDelete:
 		if err := a.pm.ClearAssetCache(); err != nil {
 			a.jsonErr(w, http.StatusInternalServerError, "clear asset cache failed")
 			return
 		}
-		a.jsonOK(w, map[string]string{"status": "cleared"})
+		nowMS := time.Now().UnixMilli()
+		result, err := a.db.db.Exec(`UPDATE control_nodes
+			SET cache_clear_generation=cache_clear_generation+1,updated_at_ms=?
+			WHERE enabled=1 AND agent_token_hash<>''`, nowMS)
+		if err != nil {
+			a.jsonErr(w, http.StatusInternalServerError, "schedule agent cache clear failed")
+			return
+		}
+		pending, _ := result.RowsAffected()
+		status := "cleared"
+		if pending > 0 {
+			status = "pending"
+		}
+		a.jsonOK(w, map[string]any{
+			"status":        status,
+			"local_cleared": true,
+			"nodes_pending": pending,
+		})
 	default:
 		a.jsonErr(w, http.StatusMethodNotAllowed, "method not allowed")
 	}

--- a/asset_cache.go
+++ b/asset_cache.go
@@ -73,11 +73,12 @@ type assetCache struct {
 }
 
 type assetCacheIndexedEntry struct {
-	siteID   int64
-	metaName string
-	bodyName string
-	accessed int64
-	size     int64
+	siteID    int64
+	namespace string
+	metaName  string
+	bodyName  string
+	accessed  int64
+	size      int64
 }
 
 type assetCacheContextKey struct{}
@@ -150,8 +151,8 @@ func assetCacheNamespace(site Site) string {
 	return namespace
 }
 
-func assetCacheSitePrefix(site Site) string {
-	namespace := assetCacheNamespace(site)
+func assetCacheNamespacePrefix(namespace string) string {
+	namespace = strings.TrimSpace(namespace)
 	if strings.HasPrefix(namespace, "site-") {
 		if index := strings.Index(namespace, "-config-"); index > 0 {
 			return namespace[:index]
@@ -160,12 +161,20 @@ func assetCacheSitePrefix(site Site) string {
 	return namespace
 }
 
+func assetCacheSitePrefix(site Site) string {
+	return assetCacheNamespacePrefix(assetCacheNamespace(site))
+}
+
 func (c *assetCache) request(site Site, r *http.Request, target *url.URL) *assetCacheRequest {
 	if c == nil || !assetCacheRequestEligible(site, r, target) {
 		return nil
 	}
 	raw := strings.Join([]string{
-		strconv.FormatInt(site.ID, 10),
+		// The cache namespace is supplied by the Controller and remains stable
+		// across the Agent's in-memory SQLite rebuilds. Do not include the local
+		// SQLite row ID in the cache key: it is ephemeral and can change when a
+		// route is added, removed, or reordered.
+		assetCacheNamespace(site),
 		target.String(),
 		r.Header.Get("Accept"),
 		r.Header.Get("Accept-Encoding"),
@@ -226,6 +235,18 @@ func assetCacheSiteIDFromPath(path string) (int64, bool) {
 	return siteID, err == nil && siteID > 0
 }
 
+// assetCacheNamespaceFromPath returns the stable central-site namespace
+// prefix (for example site-100) rather than an Agent's ephemeral SQLite row
+// ID. Generation suffixes are intentionally ignored for budget accounting so
+// old generations remain part of the same site's quota.
+func assetCacheNamespaceFromPath(path string) string {
+	parts := strings.SplitN(filepath.ToSlash(path), "/", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	return assetCacheNamespacePrefix(parts[0])
+}
+
 func (c *assetCache) rebuildSizeIndexLocked() error {
 	if c == nil {
 		return nil
@@ -274,7 +295,7 @@ func (c *assetCache) rebuildSizeIndexLocked() error {
 				accessed = meta.AccessedAtMS
 			}
 		}
-		entries[path] = assetCacheIndexedEntry{siteID: siteID, metaName: metaName, bodyName: path, accessed: accessed, size: info.Size()}
+		entries[path] = assetCacheIndexedEntry{siteID: siteID, namespace: assetCacheNamespaceFromPath(path), metaName: metaName, bodyName: path, accessed: accessed, size: info.Size()}
 		return nil
 	})
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -372,6 +393,43 @@ func (c *assetCache) clear() error {
 	c.totalBytes = 0
 	c.sizeLoaded = true
 	return nil
+}
+
+// gcSiteGenerations removes cache generations for one stable central site
+// after a new configuration generation has been successfully materialized.
+// It never uses the Agent's local SQLite ID and never touches another site's
+// namespace.
+func (c *assetCache) gcSiteGenerations(sitePrefix, keepNamespace string) error {
+	if c == nil || strings.TrimSpace(sitePrefix) == "" {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	root, err := c.openRoot(false)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+	entries, err := fs.ReadDir(root.FS(), ".")
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	prefix := strings.TrimSuffix(sitePrefix, "-") + "-"
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), prefix) || entry.Name() == keepNamespace {
+			continue
+		}
+		if err := root.RemoveAll(entry.Name()); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	return c.rebuildSizeIndexLocked()
 }
 
 func (c *assetCache) addIndexedEntryLocked(entry assetCacheIndexedEntry) {
@@ -539,7 +597,7 @@ func (c *assetCache) write(site Site, req *assetCacheRequest, resp *http.Respons
 		return err
 	}
 	if siteID, ok := assetCacheSiteIDFromPath(req.bodyName); ok {
-		c.addIndexedEntryLocked(assetCacheIndexedEntry{siteID: siteID, metaName: req.metaName, bodyName: req.bodyName, accessed: meta.AccessedAtMS, size: meta.Size})
+		c.addIndexedEntryLocked(assetCacheIndexedEntry{siteID: siteID, namespace: assetCacheNamespaceFromPath(req.bodyName), metaName: req.metaName, bodyName: req.bodyName, accessed: meta.AccessedAtMS, size: meta.Size})
 	}
 	return c.enforceBudgetLocked(root, site)
 }
@@ -554,8 +612,9 @@ type assetCacheFile struct {
 func (c *assetCache) enforceBudgetLocked(root *os.Root, site Site) error {
 	files := make([]assetCacheFile, 0)
 	var total int64
+	targetNamespace := assetCacheNamespacePrefix(assetCacheNamespace(site))
 	for _, entry := range c.entries {
-		if entry.siteID != site.ID {
+		if entry.namespace != targetNamespace {
 			continue
 		}
 		files = append(files, assetCacheFile{metaName: entry.metaName, bodyName: entry.bodyName, accessed: entry.accessed, size: entry.size})

--- a/asset_cache_test.go
+++ b/asset_cache_test.go
@@ -182,6 +182,24 @@ func TestAssetCacheSizeAccountingOverwriteAndExpiry(t *testing.T) {
 	}
 }
 
+func TestAssetCacheKeyUsesStableControllerNamespace(t *testing.T) {
+	cache := newAssetCache(t.TempDir())
+	target, _ := url.Parse("https://media.example/file/accounting.jpg")
+	request := httptest.NewRequest(http.MethodGet, "https://proxy.example/file/accounting.jpg", nil)
+	first := Site{ID: 1, AssetCacheNamespace: "site-100-config-a", AssetCacheEnabled: true, AssetCacheTTLSec: 3600, AssetCacheMaxBytes: 16 << 20, AssetCacheRules: "*/file/*"}
+	second := first
+	second.ID = 7
+	second.AssetCacheNamespace = "site-100-config-a"
+	firstRequest := cache.request(first, request, target)
+	secondRequest := cache.request(second, request, target)
+	if firstRequest == nil || secondRequest == nil {
+		t.Fatal("stable namespace requests were not cache eligible")
+	}
+	if firstRequest.key != secondRequest.key || firstRequest.bodyPath != secondRequest.bodyPath {
+		t.Fatalf("cache identity changed with local row ID: first=%+v second=%+v", firstRequest, secondRequest)
+	}
+}
+
 func TestHandleAssetCacheReportsAndClearsCache(t *testing.T) {
 	app := newTestApp(t)
 	cache := newAssetCache(t.TempDir())

--- a/dashboard_bootstrap.go
+++ b/dashboard_bootstrap.go
@@ -72,11 +72,15 @@ func (a *App) dashboardBootstrap() (*dashboardBootstrapResponse, error) {
 	views := make([]dashboardSiteView, 0, len(sites))
 	for _, site := range sites {
 		live := liveBySite[site.ID]
+		cacheSize := cacheSizes[site.ID]
+		if live.AgentRuntime {
+			cacheSize = live.CacheSizeBytes
+		}
 		views = append(views, dashboardSiteView{
 			ID: site.ID, Name: site.Name, TargetURL: site.TargetURL, UAMode: site.UAMode,
 			PublicHost: site.PublicHost, PathPrefix: site.PathPrefix, IngressMode: site.IngressMode,
 			ListenPort: site.ListenPort, Running: live.Running, TrafficUsed: live.TrafficUsed,
-			MonthlyTraffic: live.MonthlyTraffic, CacheSizeBytes: cacheSizes[site.ID],
+			MonthlyTraffic: live.MonthlyTraffic, CacheSizeBytes: cacheSize,
 			MediaMovieCount: site.MediaMovieCount, MediaSeriesCount: site.MediaSeriesCount,
 			MediaEpisodeCount: site.MediaEpisodeCount,
 		})

--- a/dashboard_trends.go
+++ b/dashboard_trends.go
@@ -181,7 +181,7 @@ func (pm *ProxyManager) pendingDashboardTraffic(siteID *int64) map[int64]dashboa
 	return result
 }
 
-func dashboardTrendPoints(start, end time.Time, bucket time.Duration, rangeName string, billingMode string, logs []TrafficLog, pending dashboardPendingTraffic) []dashboardTrendPoint {
+func dashboardTrendPoints(start, end time.Time, bucket time.Duration, rangeName string, billingMode string, logs []TrafficLog, pending dashboardPendingTraffic, now ...time.Time) []dashboardTrendPoint {
 	count := int((end.Sub(start) + bucket - time.Nanosecond) / bucket)
 	if count < 1 {
 		count = 1
@@ -203,11 +203,21 @@ func dashboardTrendPoints(start, end time.Time, bucket time.Duration, rangeName 
 		points[index].BytesOut += logRow.BytesOut
 		points[index].Requests += logRow.Requests
 	}
-	if len(points) > 0 {
-		last := &points[len(points)-1]
-		last.BytesIn += pending.BytesIn
-		last.BytesOut += pending.BytesOut
-		last.Requests += pending.Requests
+	// Pending controller-local counters belong to the current wall-clock
+	// bucket only. Historical windows must remain immutable, and a window that
+	// ends in the future must not receive today's pending bytes at its final
+	// (future) bucket.
+	current := time.Now()
+	if len(now) > 0 && !now[0].IsZero() {
+		current = now[0]
+	}
+	if !current.Before(start) && current.Before(end) {
+		index := int((current.UnixMilli() - start.UnixMilli()) / bucketMS)
+		if index >= 0 && index < len(points) {
+			points[index].BytesIn += pending.BytesIn
+			points[index].BytesOut += pending.BytesOut
+			points[index].Requests += pending.Requests
+		}
 	}
 	for i := range points {
 		points[i].Traffic = trafficBillableBytes(billingMode, points[i].BytesIn, points[i].BytesOut)
@@ -241,7 +251,7 @@ func (pm *ProxyManager) dashboardTrends(siteID *int64, rangeName string, customW
 		siteKey = strconv.FormatInt(*siteID, 10)
 	}
 	settings := pm.database.currentSystemSettings()
-	flightKey := fmt.Sprintf("%p|%s|%s|%d%s", pm.database, siteKey, strings.ToLower(strings.TrimSpace(rangeName)), settings.ScheduleTimezone, customKey)
+	flightKey := fmt.Sprintf("%p|%s|%s|%s|%d%s", pm.database, siteKey, strings.ToLower(strings.TrimSpace(rangeName)), trafficBillingModeLabel(settings.TrafficBillingMode), settings.ScheduleTimezone, customKey)
 	value, err, _ := pm.dashboardTrendGroup.Do(flightKey, func() (interface{}, error) {
 		return pm.dashboardTrendsUncoalesced(siteID, rangeName, customWindow...)
 	})
@@ -271,7 +281,7 @@ func (pm *ProxyManager) dashboardTrendsUncoalesced(siteID *int64, rangeName stri
 	if siteID != nil {
 		siteKey = strconv.FormatInt(*siteID, 10)
 	}
-	cacheKey := fmt.Sprintf("%p|%s|%s|%d|%d|%d|%d", pm.database, siteKey, name, start.UnixMilli(), end.UnixMilli(), bucket/time.Second, settings.ScheduleTimezone)
+	cacheKey := fmt.Sprintf("%p|%s|%s|%s|%d|%d|%d|%d", pm.database, siteKey, name, trafficBillingModeLabel(billingMode), start.UnixMilli(), end.UnixMilli(), bucket/time.Second, settings.ScheduleTimezone)
 	cacheTTL := 30 * time.Second
 	if strings.EqualFold(name, "realtime") {
 		cacheTTL = 3 * time.Second
@@ -304,13 +314,13 @@ func (pm *ProxyManager) dashboardTrendsUncoalesced(siteID *int64, rangeName stri
 		aggregatePending.BytesOut += value.BytesOut
 		aggregatePending.Requests += value.Requests
 	}
-	points := dashboardTrendPoints(start, end, bucket, name, billingMode, logs, aggregatePending)
+	points := dashboardTrendPoints(start, end, bucket, name, billingMode, logs, aggregatePending, now)
 	siteSeries := make([]dashboardTrendSite, 0, len(selectedSites))
 	for _, site := range selectedSites {
 		siteSeries = append(siteSeries, dashboardTrendSite{
 			SiteID:   site.ID,
 			SiteName: site.Name,
-			Points:   dashboardTrendPoints(start, end, bucket, name, billingMode, logsBySite[site.ID], pendingBySite[site.ID]),
+			Points:   dashboardTrendPoints(start, end, bucket, name, billingMode, logsBySite[site.ID], pendingBySite[site.ID], now),
 		})
 	}
 	response := &dashboardTrendsResponse{

--- a/database_migrations.go
+++ b/database_migrations.go
@@ -371,6 +371,8 @@ func (d *DB) migrateOnce() error {
 		event_spool_error TEXT NOT NULL DEFAULT '',
 		event_queue_depth INTEGER NOT NULL DEFAULT 0,
 		event_dropped BIGINT NOT NULL DEFAULT 0,
+		cache_clear_generation BIGINT NOT NULL DEFAULT 0,
+		cache_clear_applied_generation BIGINT NOT NULL DEFAULT 0,
 		enrollment_token_hash TEXT NOT NULL DEFAULT '',
 		enrollment_expires_at_ms INTEGER NOT NULL DEFAULT 0,
 		probe_secret_ciphertext TEXT NOT NULL DEFAULT '',
@@ -446,6 +448,8 @@ func (d *DB) migrateOnce() error {
 		}
 	}
 	for _, migration := range []struct{ column, sql string }{
+		{"cache_clear_generation", "ALTER TABLE control_nodes ADD COLUMN cache_clear_generation BIGINT NOT NULL DEFAULT 0"},
+		{"cache_clear_applied_generation", "ALTER TABLE control_nodes ADD COLUMN cache_clear_applied_generation BIGINT NOT NULL DEFAULT 0"},
 		{"entry_mode", "ALTER TABLE control_nodes ADD COLUMN entry_mode TEXT NOT NULL DEFAULT 'direct'"},
 		{"http_port", "ALTER TABLE control_nodes ADD COLUMN http_port INTEGER NOT NULL DEFAULT 0"},
 		{"https_port", "ALTER TABLE control_nodes ADD COLUMN https_port INTEGER NOT NULL DEFAULT 443"},
@@ -746,6 +750,15 @@ func (d *DB) migrateOnce() error {
 	CREATE INDEX IF NOT EXISTS idx_node_site_traffic_site_time ON node_site_traffic_logs(site_id, recorded_at_ms);
 	CREATE INDEX IF NOT EXISTS idx_node_site_traffic_node_time ON node_site_traffic_logs(node_id, recorded_at_ms);`); err != nil {
 		return err
+	}
+	var cacheSizeColumn int
+	if err := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM pragma_table_info('node_site_counters') WHERE name='cache_size_bytes'").Scan(&cacheSizeColumn); err != nil {
+		return err
+	}
+	if cacheSizeColumn == 0 {
+		if _, err := conn.ExecContext(ctx, "ALTER TABLE node_site_counters ADD COLUMN cache_size_bytes BIGINT NOT NULL DEFAULT 0"); err != nil {
+			return err
+		}
 	}
 	if _, err := conn.ExecContext(ctx, "UPDATE sites SET traffic_used_in=traffic_used/2, traffic_used_out=traffic_used-(traffic_used/2) WHERE traffic_used_in<0 OR traffic_used_out<0"); err != nil {
 		return err

--- a/edge_agent.go
+++ b/edge_agent.go
@@ -497,26 +497,28 @@ func (b *edgeProxyBundle) drain(grace time.Duration) {
 }
 
 type edgeAgentRuntime struct {
-	mu              sync.RWMutex
-	stateDir        string
-	nodeGUID        string
-	port            int
-	handler         http.Handler
-	certificate     *tls.Certificate
-	server          *http.Server
-	bundle          *edgeProxyBundle
-	appliedHash     string
-	listenerError   string
-	eventSpoolError string
-	events          edgeEventStore
-	stats           edgeSiteStats
-	telemetryMu     sync.Mutex
-	mediaCounts     map[int64]NodeMediaCount
-	retention       map[int64]NodeRetentionStatus
-	observations    []NodeDynamicObservation
-	siteReported    map[int64]ProxyRuntimeStat
-	resolver        dynamicIPResolver
-	transport       dynamicTransportFactory
+	mu                   sync.RWMutex
+	stateDir             string
+	nodeGUID             string
+	port                 int
+	handler              http.Handler
+	certificate          *tls.Certificate
+	server               *http.Server
+	bundle               *edgeProxyBundle
+	appliedHash          string
+	siteCounterEpoch     uint64
+	cacheClearGeneration int64
+	listenerError        string
+	eventSpoolError      string
+	events               edgeEventStore
+	stats                edgeSiteStats
+	telemetryMu          sync.Mutex
+	mediaCounts          map[int64]NodeMediaCount
+	retention            map[int64]NodeRetentionStatus
+	observations         []NodeDynamicObservation
+	siteReported         map[int64]ProxyRuntimeStat
+	resolver             dynamicIPResolver
+	transport            dynamicTransportFactory
 }
 
 func (runtime *edgeAgentRuntime) queueEvent(event NodeRequestEvent) {
@@ -660,6 +662,7 @@ func (runtime *edgeAgentRuntime) prepareSiteStats() edgeSiteStatsPending {
 		return pending
 	}
 	current := bundle.manager.ProxyRuntimeStats()
+	cacheSizes, _, _ := bundle.manager.AssetCacheSizes()
 	// Baselines are keyed by the Controller's stable SiteID. The in-memory
 	// Edge database is rebuilt whenever configuration changes, so its local
 	// auto-increment IDs must never be used as long-lived identities.
@@ -696,6 +699,7 @@ func (runtime *edgeAgentRuntime) prepareSiteStats() edgeSiteStatsPending {
 		observed.RequestCount = value.Requests
 		observed.BytesIn, observed.BytesOut = inDelta, outDelta
 		observed.CumulativeBytesIn, observed.CumulativeBytesOut = value.CumulativeBytesIn, value.CumulativeBytesOut
+		observed.CacheSizeBytes = cacheSizes[value.SiteID]
 		pending.stats = append(pending.stats, observed)
 	}
 	return pending
@@ -827,6 +831,33 @@ type edgeReplayBody struct {
 	io.Closer
 }
 
+// edgeAssetCacheGeneration is deliberately scoped to one route. A change to
+// another site (or to the surrounding Agent config envelope) must not cold
+// start this site's cache. Only values that affect the upstream response or
+// cache policy participate in the generation fingerprint.
+func edgeAssetCacheGeneration(site Site, route AgentSiteRoute) string {
+	payload := struct {
+		TargetURL         string
+		PlaybackTargetURL string
+		PlaybackMode      string
+		StreamHosts       []string
+		Headers           map[string][]string
+		CacheEnabled      bool
+		CacheTTLSec       int
+		CacheMaxBytes     int64
+		CacheRules        string
+		UpstreamHeaders   string
+	}{
+		TargetURL: site.TargetURL, PlaybackTargetURL: site.PlaybackTargetURL, PlaybackMode: site.PlaybackMode,
+		StreamHosts: route.StreamHosts, Headers: route.Headers, CacheEnabled: site.AssetCacheEnabled,
+		CacheTTLSec: site.AssetCacheTTLSec, CacheMaxBytes: site.AssetCacheMaxBytes, CacheRules: site.AssetCacheRules,
+		UpstreamHeaders: site.StoredUpstreamHeaders,
+	}
+	data, _ := json.Marshal(payload)
+	digest := sha256.Sum256(data)
+	return hex.EncodeToString(digest[:8])
+}
+
 func buildEdgeProxy(config AgentRuntimeConfig, runtime *edgeAgentRuntime) (*edgeProxyBundle, error) {
 	dynamicKey, err := edgeDecodeKey(config.DynamicKey)
 	if err != nil {
@@ -853,9 +884,6 @@ func buildEdgeProxy(config AgentRuntimeConfig, runtime *edgeAgentRuntime) (*edge
 	for _, route := range config.Routes {
 		site := route.Site
 		site.ID = 0
-		if route.SiteID > 0 {
-			site.AssetCacheNamespace = fmt.Sprintf("site-%d-config-%s", route.SiteID, config.ConfigHash)
-		}
 		site.PublicHost = strings.ToLower(strings.TrimSpace(route.Host))
 		site.IngressMode = ingressModeHost
 		site.PathPrefix = ""
@@ -872,6 +900,9 @@ func buildEdgeProxy(config AgentRuntimeConfig, runtime *edgeAgentRuntime) (*edge
 		// Node-level scheduling owns quota exhaustion. A stale local site counter
 		// must never block traffic after a DNS assignment changes nodes.
 		site.TrafficQuota = 0
+		if route.SiteID > 0 {
+			site.AssetCacheNamespace = fmt.Sprintf("site-%d-config-%s", route.SiteID, edgeAssetCacheGeneration(site, route))
+		}
 		created, createErr := database.CreateSiteRecord(site)
 		if createErr != nil {
 			return fail(fmt.Errorf("site %d runtime config: %w", route.SiteID, createErr))
@@ -905,7 +936,16 @@ func buildEdgeProxy(config AgentRuntimeConfig, runtime *edgeAgentRuntime) (*edge
 	}
 	manager.dynamicTransportFactory = runtime.transport
 	manager.SetHostOnlyIngressSafe(true)
-	manager.SetAssetCache(newAssetCache(filepath.Join(runtime.stateDir, "asset-cache")))
+	cache := newAssetCache(filepath.Join(runtime.stateDir, "asset-cache"))
+	manager.SetAssetCache(cache)
+	for _, site := range runtimeSites {
+		if site.AssetCacheNamespace == "" {
+			continue
+		}
+		if err := cache.gcSiteGenerations(assetCacheNamespacePrefix(site.AssetCacheNamespace), site.AssetCacheNamespace); err != nil {
+			return fail(fmt.Errorf("gc site %s asset cache generations: %w", site.AssetCacheNamespace, err))
+		}
+	}
 	if err := manager.ConfigureDynamicDiscovery(dynamicKey, "", config.HTTPSPort, nil); err != nil {
 		return fail(err)
 	}
@@ -1013,6 +1053,12 @@ func (runtime *edgeAgentRuntime) apply(config AgentRuntimeConfig) error {
 	runtime.mu.RLock()
 	oldPort, oldServer, oldBundle := runtime.port, runtime.server, runtime.bundle
 	oldNodeGUID, oldCertificate, oldHandler := runtime.nodeGUID, runtime.certificate, runtime.handler
+	oldCacheClearGeneration := runtime.cacheClearGeneration
+	oldSiteCounterEpoch := runtime.siteCounterEpoch
+	oldSiteReported := make(map[int64]ProxyRuntimeStat, len(runtime.siteReported))
+	for siteID, value := range runtime.siteReported {
+		oldSiteReported[siteID] = value
+	}
 	runtime.mu.RUnlock()
 	needsListener := len(config.Routes) > 0
 	listenerChanged := oldPort != config.HTTPSPort || (oldServer == nil) != !needsListener
@@ -1025,6 +1071,11 @@ func (runtime *edgeAgentRuntime) apply(config AgentRuntimeConfig) error {
 	runtime.certificate = certificate
 	runtime.handler = bundle.handler
 	runtime.bundle = bundle
+	// The in-memory Edge database and proxy counters are rebuilt on every
+	// configuration apply. Drop per-site report baselines as well; the
+	// Controller binds site traffic to AppliedConfigHash, so the next report
+	// must describe the new runtime epoch from zero.
+	runtime.siteReported = make(map[int64]ProxyRuntimeStat)
 	runtime.mu.Unlock()
 	if listenerChanged && needsListener {
 		if err := runtime.startServer(config.HTTPSPort); err != nil {
@@ -1035,6 +1086,8 @@ func (runtime *edgeAgentRuntime) apply(config AgentRuntimeConfig) error {
 			runtime.certificate = oldCertificate
 			runtime.handler = oldHandler
 			runtime.bundle = oldBundle
+			runtime.siteCounterEpoch = oldSiteCounterEpoch
+			runtime.siteReported = oldSiteReported
 			runtime.listenerError = err.Error()
 			runtime.mu.Unlock()
 			if oldServer != nil {
@@ -1043,8 +1096,32 @@ func (runtime *edgeAgentRuntime) apply(config AgentRuntimeConfig) error {
 			return err
 		}
 	}
+	if config.CacheClearGeneration > oldCacheClearGeneration {
+		if err := bundle.manager.ClearAssetCache(); err != nil {
+			bundle.close()
+			runtime.mu.Lock()
+			runtime.nodeGUID = oldNodeGUID
+			runtime.port = oldPort
+			runtime.certificate = oldCertificate
+			runtime.handler = oldHandler
+			runtime.bundle = oldBundle
+			runtime.siteCounterEpoch = oldSiteCounterEpoch
+			runtime.siteReported = oldSiteReported
+			runtime.mu.Unlock()
+			if listenerChanged && needsListener {
+				if oldServer != nil {
+					_ = runtime.startServer(oldPort)
+				}
+			}
+			return err
+		}
+	}
 	runtime.mu.Lock()
 	runtime.appliedHash = config.ConfigHash
+	runtime.siteCounterEpoch++
+	if config.CacheClearGeneration > runtime.cacheClearGeneration {
+		runtime.cacheClearGeneration = config.CacheClearGeneration
+	}
 	runtime.listenerError = ""
 	runtime.mu.Unlock()
 	if oldBundle != nil {
@@ -1652,6 +1729,10 @@ func runEdgeAgent() error {
 			fmt.Fprintf(os.Stderr, "Meridian Agent traffic collection failed: %v\n", collectErr)
 		} else {
 			report.AppliedConfigHash, report.ListenerError = runtime.status()
+			runtime.mu.RLock()
+			report.CacheClearGeneration = runtime.cacheClearGeneration
+			report.SiteCounterEpoch = strconv.FormatUint(runtime.siteCounterEpoch, 10)
+			runtime.mu.RUnlock()
 			report.EventSpoolError, report.EventQueueDepth = runtime.eventSpoolStatus()
 			report.EventDropped = runtime.events.droppedCount()
 			pendingStats := runtime.prepareSiteStats()

--- a/node_repository.go
+++ b/node_repository.go
@@ -32,40 +32,42 @@ var (
 )
 
 type ControlNode struct {
-	ID                  int64  `json:"id"`
-	GUID                string `json:"guid"`
-	Name                string `json:"name"`
-	Address             string `json:"address"`
-	Port                int    `json:"port"`
-	Enabled             bool   `json:"enabled"`
-	Priority            int    `json:"priority"`
-	TrafficQuota        int64  `json:"traffic_quota"`
-	TrafficManualOffset int64  `json:"traffic_manual_offset_bytes"`
-	BillingMode         string `json:"billing_mode"`
-	ResetDay            int    `json:"reset_day"`
-	CycleStartedAtMS    int64  `json:"cycle_started_at_ms"`
-	PeriodRXBytes       int64  `json:"period_rx_bytes"`
-	PeriodTXBytes       int64  `json:"period_tx_bytes"`
-	LifetimeRXBytes     int64  `json:"lifetime_rx_bytes"`
-	LifetimeTXBytes     int64  `json:"lifetime_tx_bytes"`
-	InterfaceName       string `json:"interface_name"`
-	AgentVersion        string `json:"agent_version"`
-	DesiredConfigHash   string `json:"desired_config_hash"`
-	AppliedConfigHash   string `json:"applied_config_hash"`
-	AgentListenerError  string `json:"agent_listener_error"`
-	EventSpoolError     string `json:"event_spool_error"`
-	EventQueueDepth     int    `json:"event_queue_depth"`
-	EventDropped        int64  `json:"event_dropped"`
-	EnrolledAtMS        int64  `json:"enrolled_at_ms"`
-	LastSeenAtMS        int64  `json:"last_seen_at_ms"`
-	CreatedAtMS         int64  `json:"created_at_ms"`
-	UpdatedAtMS         int64  `json:"updated_at_ms"`
-	Status              string `json:"status"`
-	TrafficUsed         int64  `json:"traffic_used"`
-	TrafficRemaining    int64  `json:"traffic_remaining"`
-	EnrollmentAvailable bool   `json:"enrollment_available"`
-	Depleted            bool   `json:"depleted"`
-	Active              bool   `json:"active"`
+	ID                          int64  `json:"id"`
+	GUID                        string `json:"guid"`
+	Name                        string `json:"name"`
+	Address                     string `json:"address"`
+	Port                        int    `json:"port"`
+	Enabled                     bool   `json:"enabled"`
+	Priority                    int    `json:"priority"`
+	TrafficQuota                int64  `json:"traffic_quota"`
+	TrafficManualOffset         int64  `json:"traffic_manual_offset_bytes"`
+	BillingMode                 string `json:"billing_mode"`
+	ResetDay                    int    `json:"reset_day"`
+	CycleStartedAtMS            int64  `json:"cycle_started_at_ms"`
+	PeriodRXBytes               int64  `json:"period_rx_bytes"`
+	PeriodTXBytes               int64  `json:"period_tx_bytes"`
+	LifetimeRXBytes             int64  `json:"lifetime_rx_bytes"`
+	LifetimeTXBytes             int64  `json:"lifetime_tx_bytes"`
+	InterfaceName               string `json:"interface_name"`
+	AgentVersion                string `json:"agent_version"`
+	DesiredConfigHash           string `json:"desired_config_hash"`
+	AppliedConfigHash           string `json:"applied_config_hash"`
+	AgentListenerError          string `json:"agent_listener_error"`
+	EventSpoolError             string `json:"event_spool_error"`
+	EventQueueDepth             int    `json:"event_queue_depth"`
+	EventDropped                int64  `json:"event_dropped"`
+	CacheClearGeneration        int64  `json:"cache_clear_generation"`
+	CacheClearAppliedGeneration int64  `json:"cache_clear_applied_generation"`
+	EnrolledAtMS                int64  `json:"enrolled_at_ms"`
+	LastSeenAtMS                int64  `json:"last_seen_at_ms"`
+	CreatedAtMS                 int64  `json:"created_at_ms"`
+	UpdatedAtMS                 int64  `json:"updated_at_ms"`
+	Status                      string `json:"status"`
+	TrafficUsed                 int64  `json:"traffic_used"`
+	TrafficRemaining            int64  `json:"traffic_remaining"`
+	EnrollmentAvailable         bool   `json:"enrollment_available"`
+	Depleted                    bool   `json:"depleted"`
+	Active                      bool   `json:"active"`
 
 	lastRawRXBytes        int64
 	lastRawTXBytes        int64
@@ -116,24 +118,26 @@ type NodeCreateInput struct {
 }
 
 type NodeReport struct {
-	BootID            string                   `json:"boot_id"`
-	ReportSessionID   string                   `json:"report_session_id,omitempty"`
-	CounterEpoch      string                   `json:"counter_epoch,omitempty"`
-	Sequence          int64                    `json:"sequence"`
-	InterfaceName     string                   `json:"interface_name"`
-	RXBytes           int64                    `json:"rx_bytes"`
-	TXBytes           int64                    `json:"tx_bytes"`
-	AgentVersion      string                   `json:"agent_version"`
-	AppliedConfigHash string                   `json:"applied_config_hash"`
-	ListenerError     string                   `json:"listener_error"`
-	EventSpoolError   string                   `json:"event_spool_error,omitempty"`
-	EventQueueDepth   int                      `json:"event_queue_depth,omitempty"`
-	EventDropped      int64                    `json:"event_dropped,omitempty"`
-	SiteStats         []NodeSiteStat           `json:"site_stats,omitempty"`
-	MediaCounts       []NodeMediaCount         `json:"media_counts,omitempty"`
-	Retention         []NodeRetentionStatus    `json:"retention,omitempty"`
-	Observations      []NodeDynamicObservation `json:"observations,omitempty"`
-	Events            []NodeRequestEvent       `json:"events,omitempty"`
+	BootID               string                   `json:"boot_id"`
+	ReportSessionID      string                   `json:"report_session_id,omitempty"`
+	CounterEpoch         string                   `json:"counter_epoch,omitempty"`
+	SiteCounterEpoch     string                   `json:"site_counter_epoch,omitempty"`
+	Sequence             int64                    `json:"sequence"`
+	InterfaceName        string                   `json:"interface_name"`
+	RXBytes              int64                    `json:"rx_bytes"`
+	TXBytes              int64                    `json:"tx_bytes"`
+	AgentVersion         string                   `json:"agent_version"`
+	AppliedConfigHash    string                   `json:"applied_config_hash"`
+	ListenerError        string                   `json:"listener_error"`
+	EventSpoolError      string                   `json:"event_spool_error,omitempty"`
+	EventQueueDepth      int                      `json:"event_queue_depth,omitempty"`
+	EventDropped         int64                    `json:"event_dropped,omitempty"`
+	CacheClearGeneration int64                    `json:"cache_clear_generation,omitempty"`
+	SiteStats            []NodeSiteStat           `json:"site_stats,omitempty"`
+	MediaCounts          []NodeMediaCount         `json:"media_counts,omitempty"`
+	Retention            []NodeRetentionStatus    `json:"retention,omitempty"`
+	Observations         []NodeDynamicObservation `json:"observations,omitempty"`
+	Events               []NodeRequestEvent       `json:"events,omitempty"`
 }
 
 // NodeReportResult keeps the protocol acknowledgement tied to the exact
@@ -156,6 +160,7 @@ type NodeSiteStat struct {
 	BytesOut           int64  `json:"bytes_out"`
 	CumulativeBytesIn  int64  `json:"cumulative_bytes_in"`
 	CumulativeBytesOut int64  `json:"cumulative_bytes_out"`
+	CacheSizeBytes     int64  `json:"cache_size_bytes,omitempty"`
 }
 
 type NodeMediaCount struct {
@@ -388,7 +393,7 @@ type rowScanner interface{ Scan(...interface{}) error }
 const controlNodeSelect = `SELECT id,guid,name,address,https_port,enabled,priority,traffic_quota,billing_mode,reset_day,
 	cycle_started_at_ms,period_rx_bytes,period_tx_bytes,lifetime_rx_bytes,lifetime_tx_bytes,traffic_manual_offset_bytes,
 	last_raw_rx_bytes,last_raw_tx_bytes,last_boot_id,last_report_session_id,last_sequence,interface_name,agent_version,desired_config_hash,applied_config_hash,agent_listener_error,event_spool_error,event_queue_depth,event_dropped,
-	enrollment_token_hash,enrollment_expires_at_ms,probe_secret_ciphertext,agent_token_hash,enrolled_at_ms,last_seen_at_ms,created_at_ms,updated_at_ms
+	enrollment_token_hash,enrollment_expires_at_ms,probe_secret_ciphertext,agent_token_hash,cache_clear_generation,cache_clear_applied_generation,enrolled_at_ms,last_seen_at_ms,created_at_ms,updated_at_ms
 	FROM control_nodes`
 
 func scanControlNode(scanner rowScanner, now time.Time) (ControlNode, error) {
@@ -398,7 +403,7 @@ func scanControlNode(scanner rowScanner, now time.Time) (ControlNode, error) {
 		&node.BillingMode, &node.ResetDay, &node.CycleStartedAtMS, &node.PeriodRXBytes, &node.PeriodTXBytes,
 		&node.LifetimeRXBytes, &node.LifetimeTXBytes, &node.TrafficManualOffset, &node.lastRawRXBytes, &node.lastRawTXBytes, &node.lastBootID, &node.lastReportSessionID,
 		&node.lastSequence, &node.InterfaceName, &node.AgentVersion, &node.DesiredConfigHash, &node.AppliedConfigHash, &node.AgentListenerError, &node.EventSpoolError, &node.EventQueueDepth, &node.EventDropped, &node.enrollmentTokenHash, &node.enrollmentExpiresMS, &node.probeSecretCiphertext,
-		&node.agentTokenHash, &node.EnrolledAtMS, &node.LastSeenAtMS, &node.CreatedAtMS, &node.UpdatedAtMS)
+		&node.agentTokenHash, &node.CacheClearGeneration, &node.CacheClearAppliedGeneration, &node.EnrolledAtMS, &node.LastSeenAtMS, &node.CreatedAtMS, &node.UpdatedAtMS)
 	if err != nil {
 		return ControlNode{}, err
 	}
@@ -699,10 +704,10 @@ func validateNodeReport(report NodeReport) error {
 	report.ReportSessionID = strings.TrimSpace(report.ReportSessionID)
 	report.CounterEpoch = strings.TrimSpace(report.CounterEpoch)
 	report.InterfaceName = strings.TrimSpace(report.InterfaceName)
-	if report.BootID == "" || len(report.BootID) > 128 || len(report.ReportSessionID) > 128 || len(report.CounterEpoch) > 128 {
+	if report.BootID == "" || len(report.BootID) > 128 || len(report.ReportSessionID) > 128 || len(report.CounterEpoch) > 128 || len(report.SiteCounterEpoch) > 128 {
 		return errors.New("invalid boot_id")
 	}
-	if report.Sequence <= 0 || report.RXBytes < 0 || report.TXBytes < 0 {
+	if report.Sequence <= 0 || report.RXBytes < 0 || report.TXBytes < 0 || report.CacheClearGeneration < 0 {
 		return errors.New("invalid traffic counters")
 	}
 	if report.InterfaceName == "" || len(report.InterfaceName) > 64 || len(report.AgentVersion) > 128 || len(report.AppliedConfigHash) > 128 || len(report.ListenerError) > 1024 || len(report.EventSpoolError) > 1024 || report.EventQueueDepth < 0 || report.EventQueueDepth > edgeEventQueueLimit || report.EventDropped < 0 {
@@ -723,7 +728,7 @@ func validateNodeReport(report NodeReport) error {
 		}
 	}
 	for _, stat := range report.SiteStats {
-		if strings.TrimSpace(stat.Host) == "" || len(stat.Host) > 255 || stat.RequestCount < 0 || stat.LastRequestAtMS < 0 || stat.LastStatus < 0 || stat.LastStatus > 999 || stat.BytesIn < 0 || stat.BytesOut < 0 || stat.CumulativeBytesIn < 0 || stat.CumulativeBytesOut < 0 {
+		if strings.TrimSpace(stat.Host) == "" || len(stat.Host) > 255 || stat.RequestCount < 0 || stat.LastRequestAtMS < 0 || stat.LastStatus < 0 || stat.LastStatus > 999 || stat.BytesIn < 0 || stat.BytesOut < 0 || stat.CumulativeBytesIn < 0 || stat.CumulativeBytesOut < 0 || stat.CacheSizeBytes < 0 {
 			return errors.New("invalid site stats")
 		}
 	}
@@ -929,7 +934,7 @@ func (d *DB) recordNodeRequestEventTx(tx *sql.Tx, nodeID int64, event NodeReques
 	return err
 }
 
-func recordNodeSiteTrafficTx(tx *sql.Tx, nodeID int64, bootID string, stat NodeSiteStat, nowMS int64, allowedSites map[int64]authorizedNodeSite) error {
+func recordNodeSiteTrafficTx(tx *sql.Tx, nodeID int64, counterEpoch string, stat NodeSiteStat, nowMS int64, allowedSites map[int64]authorizedNodeSite) error {
 	var siteID int64
 	host := requestPublicHost(strings.TrimSpace(stat.Host))
 	for id, site := range allowedSites {
@@ -950,32 +955,51 @@ func recordNodeSiteTrafficTx(tx *sql.Tx, nodeID int64, bootID string, stat NodeS
 	}
 	var previousBoot string
 	var previousIn, previousOut, previousRequests int64
-	err := tx.QueryRow(`SELECT boot_id,last_bytes_in,last_bytes_out,last_request_count FROM node_site_counters WHERE node_id=? AND site_id=?`, nodeID, siteID).Scan(&previousBoot, &previousIn, &previousOut, &previousRequests)
+	err := tx.QueryRow(`SELECT boot_id,last_bytes_in,last_bytes_out,last_request_count,cache_size_bytes FROM node_site_counters WHERE node_id=? AND site_id=?`, nodeID, siteID).Scan(&previousBoot, &previousIn, &previousOut, &previousRequests, new(int64))
 	if errors.Is(err, sql.ErrNoRows) {
 		// The first sample is the delta from the Agent runtime's initial zero
 		// state, rather than merely a counter baseline. Persist it immediately
 		// so the first report is visible in history and lifetime site totals.
 		initialIn, initialOut := stat.BytesIn, stat.BytesOut
-		// RequestCount is a cumulative counter, unlike BytesIn/BytesOut which
-		// are report deltas. There is no request baseline in the traffic log on
-		// the first sample, so defer request persistence until the next sample.
-		if initialIn > 0 || initialOut > 0 {
+		// RequestCount is the cumulative count for this Agent runtime epoch. The
+		// first report is the segment from zero, so persist it together with the
+		// first byte deltas instead of silently dropping the first batch.
+		initialRequests := stat.RequestCount
+		if initialIn > 0 || initialOut > 0 || initialRequests > 0 {
 			bucket := (nowMS / 60000) * 60000
-			if _, err = tx.Exec(`INSERT INTO node_site_traffic_logs(node_id,site_id,bytes_in,bytes_out,requests,recorded_at_ms) VALUES(?,?,?,?,?,?) ON CONFLICT(node_id,site_id,recorded_at_ms) DO UPDATE SET bytes_in=bytes_in+excluded.bytes_in,bytes_out=bytes_out+excluded.bytes_out,requests=requests+excluded.requests`, nodeID, siteID, initialIn, initialOut, 0, bucket); err != nil {
+			if _, err = tx.Exec(`INSERT INTO node_site_traffic_logs(node_id,site_id,bytes_in,bytes_out,requests,recorded_at_ms) VALUES(?,?,?,?,?,?) ON CONFLICT(node_id,site_id,recorded_at_ms) DO UPDATE SET bytes_in=bytes_in+excluded.bytes_in,bytes_out=bytes_out+excluded.bytes_out,requests=requests+excluded.requests`, nodeID, siteID, initialIn, initialOut, initialRequests, bucket); err != nil {
 				return err
 			}
 			if _, err = tx.Exec(`UPDATE sites SET traffic_used=traffic_used+?+?,traffic_used_in=traffic_used_in+?,traffic_used_out=traffic_used_out+?,updated_at=CURRENT_TIMESTAMP WHERE id=?`, initialIn, initialOut, initialIn, initialOut, siteID); err != nil {
 				return err
 			}
 		}
-		_, err = tx.Exec(`INSERT INTO node_site_counters(node_id,site_id,boot_id,last_bytes_in,last_bytes_out,last_request_count,updated_at_ms) VALUES(?,?,?,?,?,?,?)`, nodeID, siteID, bootID, currentIn, currentOut, stat.RequestCount, nowMS)
+		_, err = tx.Exec(`INSERT INTO node_site_counters(node_id,site_id,boot_id,last_bytes_in,last_bytes_out,last_request_count,cache_size_bytes,updated_at_ms) VALUES(?,?,?,?,?,?,?,?)`, nodeID, siteID, counterEpoch, currentIn, currentOut, stat.RequestCount, stat.CacheSizeBytes, nowMS)
 		return err
 	}
 	if err != nil {
 		return err
 	}
 	var deltaIn, deltaOut, deltaRequests int64
-	if previousBoot == bootID && currentIn >= previousIn && currentOut >= previousOut && stat.RequestCount >= previousRequests {
+	if previousBoot != counterEpoch {
+		// A process restart, config apply, or route transition starts a new
+		// Agent-side counter epoch. BytesIn/BytesOut are already report deltas;
+		// RequestCount is cumulative from zero for the same epoch.
+		deltaIn, deltaOut, deltaRequests = stat.BytesIn, stat.BytesOut, stat.RequestCount
+		// Older Agents only reported cumulative site counters. Preserve their
+		// upgrade compatibility when the cumulative value is still monotonic;
+		// a reset (the normal new-runtime case) falls back to the explicit
+		// per-report delta above.
+		if currentIn >= previousIn && stat.BytesIn == 0 {
+			deltaIn = currentIn - previousIn
+		}
+		if currentOut >= previousOut && stat.BytesOut == 0 {
+			deltaOut = currentOut - previousOut
+		}
+		if stat.RequestCount >= previousRequests {
+			deltaRequests = stat.RequestCount - previousRequests
+		}
+	} else if currentIn >= previousIn && currentOut >= previousOut && stat.RequestCount >= previousRequests {
 		deltaIn, deltaOut, deltaRequests = currentIn-previousIn, currentOut-previousOut, stat.RequestCount-previousRequests
 	}
 	if deltaIn > 0 || deltaOut > 0 || deltaRequests > 0 {
@@ -990,7 +1014,7 @@ func recordNodeSiteTrafficTx(tx *sql.Tx, nodeID int64, bootID string, stat NodeS
 			}
 		}
 	}
-	_, err = tx.Exec(`UPDATE node_site_counters SET boot_id=?,last_bytes_in=?,last_bytes_out=?,last_request_count=?,updated_at_ms=? WHERE node_id=? AND site_id=?`, bootID, currentIn, currentOut, stat.RequestCount, nowMS, nodeID, siteID)
+	_, err = tx.Exec(`UPDATE node_site_counters SET boot_id=?,last_bytes_in=?,last_bytes_out=?,last_request_count=?,cache_size_bytes=?,updated_at_ms=? WHERE node_id=? AND site_id=?`, counterEpoch, currentIn, currentOut, stat.RequestCount, stat.CacheSizeBytes, nowMS, nodeID, siteID)
 	return err
 }
 
@@ -1035,9 +1059,10 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 	defer tx.Rollback()
 
 	var id, lastSequence, lastRX, lastTX int64
+	var cacheClearGeneration int64
 	var lastBootID, lastSessionID string
-	err = tx.QueryRow(`SELECT id,last_sequence,last_raw_rx_bytes,last_raw_tx_bytes,last_boot_id,last_report_session_id FROM control_nodes WHERE agent_token_hash=?`, hashNodeToken(agentToken)).Scan(
-		&id, &lastSequence, &lastRX, &lastTX, &lastBootID, &lastSessionID)
+	err = tx.QueryRow(`SELECT id,last_sequence,last_raw_rx_bytes,last_raw_tx_bytes,last_boot_id,last_report_session_id,cache_clear_generation FROM control_nodes WHERE agent_token_hash=?`, hashNodeToken(agentToken)).Scan(
+		&id, &lastSequence, &lastRX, &lastTX, &lastBootID, &lastSessionID, &cacheClearGeneration)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nodeReportCommitResult{}, errInvalidAgentToken
 	}
@@ -1058,9 +1083,28 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 	if sessionID == "" {
 		sessionID = legacyBootID
 	}
+	siteEpoch := strings.TrimSpace(report.SiteCounterEpoch)
 	counterEpoch := strings.TrimSpace(report.CounterEpoch)
 	if counterEpoch == "" {
 		counterEpoch = legacyBootID
+	}
+	// Site proxy counters are independent from the host network interface
+	// counters above. Bind them to the Agent report session and the applied
+	// runtime configuration so a process restart or hot apply starts a fresh
+	// epoch even when the kernel boot/interface epoch is unchanged.
+	siteCounterEpoch := sessionID
+	if siteCounterEpoch == "" {
+		siteCounterEpoch = legacyBootID
+	}
+	if siteEpoch != "" {
+		// A monotonic Agent-side apply epoch distinguishes A→B→A route
+		// transitions even when the configuration hash returns to an earlier
+		// value within the same process session.
+		siteCounterEpoch += ":" + siteEpoch
+	} else if appliedHash := strings.TrimSpace(report.AppliedConfigHash); appliedHash != "" {
+		siteCounterEpoch += ":" + appliedHash
+	} else if counterEpoch != "" {
+		siteCounterEpoch += ":" + counterEpoch
 	}
 	deltaRX, deltaTX := int64(0), int64(0)
 	if counterEpoch == lastBootID && report.RXBytes >= lastRX && report.TXBytes >= lastTX && (sessionID != lastSessionID || report.Sequence > lastSequence) {
@@ -1073,9 +1117,9 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 	}
 	if _, err = tx.Exec(`UPDATE control_nodes SET period_rx_bytes=period_rx_bytes+?,period_tx_bytes=period_tx_bytes+?,
 		lifetime_rx_bytes=lifetime_rx_bytes+?,lifetime_tx_bytes=lifetime_tx_bytes+?,last_raw_rx_bytes=?,last_raw_tx_bytes=?,
-		last_boot_id=?,last_report_session_id=?,last_sequence=?,interface_name=?,agent_version=?,applied_config_hash=?,agent_listener_error=?,event_spool_error=?,event_queue_depth=?,event_dropped=?,last_seen_at_ms=?,updated_at_ms=? WHERE id=?`,
+		last_boot_id=?,last_report_session_id=?,last_sequence=?,interface_name=?,agent_version=?,applied_config_hash=?,agent_listener_error=?,event_spool_error=?,event_queue_depth=?,event_dropped=?,cache_clear_applied_generation=CASE WHEN ? > cache_clear_applied_generation AND ? <= ? THEN ? ELSE cache_clear_applied_generation END,last_seen_at_ms=?,updated_at_ms=? WHERE id=?`,
 		deltaRX, deltaTX, deltaRX, deltaTX, report.RXBytes, report.TXBytes, counterEpoch, sessionID, report.Sequence,
-		strings.TrimSpace(report.InterfaceName), strings.TrimSpace(report.AgentVersion), strings.TrimSpace(report.AppliedConfigHash), strings.TrimSpace(report.ListenerError), strings.TrimSpace(report.EventSpoolError), report.EventQueueDepth, report.EventDropped, now.UnixMilli(), now.UnixMilli(), id); err != nil {
+		strings.TrimSpace(report.InterfaceName), strings.TrimSpace(report.AgentVersion), strings.TrimSpace(report.AppliedConfigHash), strings.TrimSpace(report.ListenerError), strings.TrimSpace(report.EventSpoolError), report.EventQueueDepth, report.EventDropped, report.CacheClearGeneration, report.CacheClearGeneration, cacheClearGeneration, report.CacheClearGeneration, now.UnixMilli(), now.UnixMilli(), id); err != nil {
 		return nodeReportCommitResult{}, err
 	}
 
@@ -1110,7 +1154,7 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 			sessionID, count, stat.LastRequestAtMS, stat.LastStatus, now.UnixMilli(), scheduleID); err != nil {
 			return nodeReportCommitResult{}, err
 		}
-		if err := recordNodeSiteTrafficTx(tx, id, counterEpoch, stat, now.UnixMilli(), allowedSites); err != nil {
+		if err := recordNodeSiteTrafficTx(tx, id, siteCounterEpoch, stat, now.UnixMilli(), allowedSites); err != nil {
 			return nodeReportCommitResult{}, err
 		}
 	}

--- a/node_repository_test.go
+++ b/node_repository_test.go
@@ -681,6 +681,31 @@ func TestAgentConfigHashSeparatesReleaseMetadata(t *testing.T) {
 	if agentSupportsProbeSecret("v1.9.42") || !agentSupportsProbeSecret("v1.9.43") {
 		t.Fatal("probe secret compatibility gate is incorrect")
 	}
+	if agentSupportsCacheClear("v1.9.49") || !agentSupportsCacheClear("v1.9.50") {
+		t.Fatal("cache clear compatibility gate is incorrect")
+	}
+	cacheGenerationConfig := config
+	cacheGenerationConfig.CacheClearGeneration = 7
+	cacheGenerationHash, err := agentConfigHash(cacheGenerationConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyCacheGenerationHash, err := agentConfigHashForVersion(cacheGenerationConfig, "v1.9.49")
+	if err != nil {
+		t.Fatal(err)
+	}
+	withoutCacheGeneration := cacheGenerationConfig
+	withoutCacheGeneration.CacheClearGeneration = 0
+	wantLegacyCacheGenerationHash, err := agentConfigHash(withoutCacheGeneration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacyCacheGenerationHash != wantLegacyCacheGenerationHash || cacheGenerationHash == legacyCacheGenerationHash {
+		t.Fatalf("cache clear field was not gated for v1.9.49: legacy=%q want=%q runtime=%q", legacyCacheGenerationHash, wantLegacyCacheGenerationHash, cacheGenerationHash)
+	}
+	if got, err := agentConfigHashForVersion(cacheGenerationConfig, "v1.9.50"); err != nil || got != cacheGenerationHash {
+		t.Fatalf("v1.9.50 config hash did not include cache clear generation: got=%q want=%q err=%v", got, cacheGenerationHash, err)
+	}
 	preProbeSecret := config
 	preProbeSecret.ProbeSecret = ""
 	preProbeHash, err := agentConfigHash(preProbeSecret)

--- a/proxy_lifecycle.go
+++ b/proxy_lifecycle.go
@@ -259,6 +259,27 @@ func (pm *ProxyManager) SiteTrafficHistory(site Site, hours int) (*TrafficHistor
 		PersistedTraffic: trafficBillableBytes(billingMode, persistedIn, persistedOut),
 		TrafficUsed:      trafficBillableBytes(billingMode, persistedIn, persistedOut),
 	}
+	// An applied Agent is the runtime authority for the site. Keep the
+	// per-site history endpoint on the same model as dashboard/overview instead
+	// of falling back to a stale controller-local proxy instance.
+	nodeLive, err := pm.database.NodeSiteLiveTrafficSnapshot(time.Now())
+	if err != nil {
+		return nil, err
+	}
+	if remote, ok := nodeLive[site.ID]; ok {
+		logs, err := pm.database.GetTrafficLogs(site.ID, hours)
+		if err != nil {
+			return nil, err
+		}
+		snap.Running = remote.Running
+		snap.CumulativeBytesIn = remote.CumulativeBytesIn
+		snap.CumulativeBytesOut = remote.CumulativeBytesOut
+		snap.Requests = remote.Requests
+		snap.SampledAtMS = remote.SampledAtMS
+		snap.CacheSizeBytes = remote.CacheSizeBytes
+		snap.AgentRuntime = true
+		return &TrafficHistory{Snapshot: snap, Logs: logs, BillingMode: billingMode}, nil
+	}
 
 	pm.mu.RLock()
 	inst, present := pm.proxies[site.ID]
@@ -377,6 +398,8 @@ func (pm *ProxyManager) dashboardSnapshotFromSites(sites []Site, monthlyBySite m
 			st.CumulativeBytesOut = remote.CumulativeBytesOut
 			st.Requests = remote.Requests
 			st.SampledAtMS = remote.SampledAtMS
+			st.CacheSizeBytes = remote.CacheSizeBytes
+			st.AgentRuntime = true
 			st.BytesIn = 0
 			st.BytesOut = 0
 			st.TrafficUsed = st.PersistedTraffic

--- a/review_regression_test.go
+++ b/review_regression_test.go
@@ -364,8 +364,57 @@ func TestReviewSiteTrafficCounterContinuesAcrossAgentRestart(t *testing.T) {
 	if err := app.db.db.QueryRow("SELECT COALESCE(SUM(bytes_in),0),COALESCE(SUM(bytes_out),0),COALESCE(SUM(requests),0) FROM node_site_traffic_logs WHERE node_id=? AND site_id=?", node.ID, site.ID).Scan(&gotIn, &gotOut, &gotRequests); err != nil {
 		t.Fatal(err)
 	}
-	if gotIn != 500 || gotOut != 600 || gotRequests != 4 {
-		t.Fatalf("site traffic delta after Agent restart = in %d out %d requests %d, want 500/600/4", gotIn, gotOut, gotRequests)
+	if gotIn != 500 || gotOut != 600 || gotRequests != 14 {
+		t.Fatalf("site traffic after Agent restart = in %d out %d requests %d, want 500/600/14 (including first report)", gotIn, gotOut, gotRequests)
+	}
+}
+
+func TestReviewSiteTrafficCounterSeparatesRepeatedConfigEpochs(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now()
+	node, enrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "site-counter-epochs", Address: "203.0.113.23", Port: 9090}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, token, err := app.db.EnrollControlNode(enrollment, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "site-counter-epochs", PublicHost: "site-counter-epochs.example.test", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:18081"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.SaveSiteNodeSchedule(site.ID, true, "fixed", node.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec("UPDATE site_node_schedules SET desired_node_id=? WHERE site_id=?", node.ID, site.ID); err != nil {
+		t.Fatal(err)
+	}
+	report := func(sequence int64, epoch string, in, out, requests int64, at time.Time) {
+		t.Helper()
+		_, reportErr := app.db.RecordNodeReport(token, NodeReport{
+			BootID: "same-kernel", ReportSessionID: "same-session", CounterEpoch: "kernel:eth0", SiteCounterEpoch: epoch,
+			Sequence: sequence, InterfaceName: "eth0", SiteStats: []NodeSiteStat{{
+				Host: site.PublicHost, BytesIn: in, BytesOut: out, CumulativeBytesIn: in, CumulativeBytesOut: out,
+				RequestCount: requests, LastRequestAtMS: at.UnixMilli(), LastStatus: 200,
+			}},
+		}, at)
+		if reportErr != nil {
+			t.Fatal(reportErr)
+		}
+	}
+	report(1, "1", 1000, 2000, 10, now)
+	// The runtime returns to an earlier configuration hash after a second
+	// transition. Each monotonic Agent-side epoch must still count its first
+	// post-apply sample rather than treating it as a duplicate baseline.
+	report(2, "2", 100, 200, 5, now.Add(time.Second))
+	report(3, "3", 50, 80, 3, now.Add(2*time.Second))
+	var gotIn, gotOut, gotRequests int64
+	if err := app.db.db.QueryRow("SELECT COALESCE(SUM(bytes_in),0),COALESCE(SUM(bytes_out),0),COALESCE(SUM(requests),0) FROM node_site_traffic_logs WHERE node_id=? AND site_id=?", node.ID, site.ID).Scan(&gotIn, &gotOut, &gotRequests); err != nil {
+		t.Fatal(err)
+	}
+	if gotIn != 1150 || gotOut != 2280 || gotRequests != 18 {
+		t.Fatalf("repeated config epochs lost first deltas: in=%d out=%d requests=%d, want 1150/2280/18", gotIn, gotOut, gotRequests)
 	}
 }
 

--- a/site_node_scheduler.go
+++ b/site_node_scheduler.go
@@ -70,20 +70,21 @@ type AgentSiteRoute struct {
 }
 
 type AgentRuntimeConfig struct {
-	SchemaVersion    int              `json:"schema_version"`
-	ConfigHash       string           `json:"config_hash"`
-	NodeGUID         string           `json:"node_guid"`
-	EntryMode        string           `json:"entry_mode"`
-	HTTPPort         int              `json:"http_port"`
-	HTTPSPort        int              `json:"https_port"`
-	CertificatePEM   string           `json:"certificate_pem,omitempty"`
-	PrivateKeyPEM    string           `json:"private_key_pem,omitempty"`
-	DynamicKey       string           `json:"dynamic_key,omitempty"`
-	ProbeSecret      string           `json:"probe_secret,omitempty"`
-	AgentVersion     string           `json:"agent_version,omitempty"`
-	AgentSHA256      string           `json:"agent_sha256,omitempty"`
-	AgentDownloadURL string           `json:"agent_download_url,omitempty"`
-	Routes           []AgentSiteRoute `json:"routes"`
+	SchemaVersion        int              `json:"schema_version"`
+	ConfigHash           string           `json:"config_hash"`
+	NodeGUID             string           `json:"node_guid"`
+	EntryMode            string           `json:"entry_mode"`
+	HTTPPort             int              `json:"http_port"`
+	HTTPSPort            int              `json:"https_port"`
+	CertificatePEM       string           `json:"certificate_pem,omitempty"`
+	PrivateKeyPEM        string           `json:"private_key_pem,omitempty"`
+	DynamicKey           string           `json:"dynamic_key,omitempty"`
+	ProbeSecret          string           `json:"probe_secret,omitempty"`
+	AgentVersion         string           `json:"agent_version,omitempty"`
+	AgentSHA256          string           `json:"agent_sha256,omitempty"`
+	AgentDownloadURL     string           `json:"agent_download_url,omitempty"`
+	CacheClearGeneration int64            `json:"cache_clear_generation,omitempty"`
+	Routes               []AgentSiteRoute `json:"routes"`
 }
 
 func deriveNodeRuntimeKey(master []byte, nodeGUID, purpose string) []byte {
@@ -371,6 +372,7 @@ func agentConfigHash(config AgentRuntimeConfig) (string, error) {
 func agentConfigLegacyHash(config AgentRuntimeConfig) (string, error) {
 	config.ConfigHash = ""
 	config.AgentDownloadURL = ""
+	config.CacheClearGeneration = 0
 	// ProbeSecret was added after the legacy Agent contract. Older Agents ignore
 	// the field, so omit it from the compatibility hash while current Agents
 	// use the runtime hash above and authenticate their health probes with it.
@@ -431,9 +433,38 @@ func agentSupportsProbeSecret(version string) bool {
 	return patch >= 43
 }
 
+// agentSupportsCacheClear reports whether the Agent understands the
+// cache_clear_generation field in the runtime config. This field was added in
+// the next controller/Agent rollout after the v1.9.49 wire contract. Older
+// Agents ignore the JSON field, so the controller must calculate the hash over
+// the shape they actually know until they upgrade.
+func agentSupportsCacheClear(version string) bool {
+	version = strings.TrimSpace(strings.TrimPrefix(version, "v"))
+	parts := strings.Split(version, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	major, errMajor := strconv.Atoi(parts[0])
+	minor, errMinor := strconv.Atoi(parts[1])
+	patch, errPatch := strconv.Atoi(parts[2])
+	if errMajor != nil || errMinor != nil || errPatch != nil {
+		return false
+	}
+	if major != 1 {
+		return major > 1
+	}
+	if minor != 9 {
+		return minor > 9
+	}
+	return patch >= 50
+}
+
 func agentConfigHashForVersion(config AgentRuntimeConfig, version string) (string, error) {
 	if !agentSupportsProbeSecret(version) {
 		config.ProbeSecret = ""
+	}
+	if !agentSupportsCacheClear(version) {
+		config.CacheClearGeneration = 0
 	}
 	if agentUsesRuntimeConfigHash(version) {
 		return agentConfigHash(config)
@@ -493,8 +524,7 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 	if probeErr != nil {
 		return AgentRuntimeConfig{}, probeErr
 	}
-	probeSecret, probeErr := decodeNodeProbeSecret(probeSecretText)
-	if probeErr != nil {
+	if _, probeErr := decodeNodeProbeSecret(probeSecretText); probeErr != nil {
 		return AgentRuntimeConfig{}, probeErr
 	}
 	for rows.Next() {
@@ -570,7 +600,8 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 	// Keep the legacy field names in the Agent wire contract during rolling
 	// upgrades. Their values now describe one HTTPS-only listener.
 	config := AgentRuntimeConfig{SchemaVersion: agentConfigSchemaVersion, NodeGUID: node.GUID, EntryMode: "direct",
-		HTTPPort: 0, HTTPSPort: node.Port, DynamicKey: encodeRuntimeKey(dynamicKey), ProbeSecret: encodeRuntimeKey(probeSecret), Routes: routes}
+		HTTPPort: 0, HTTPSPort: node.Port, DynamicKey: encodeRuntimeKey(dynamicKey), ProbeSecret: probeSecretText,
+		CacheClearGeneration: node.CacheClearGeneration, Routes: routes}
 	// Legacy Agents do not send a platform header. Do not advertise the
 	// controller's local binary to those clients: on a cross-architecture
 	// rollout that checksum would make an old arm64 Agent download an amd64

--- a/tests/traffic_page.test.js
+++ b/tests/traffic_page.test.js
@@ -461,10 +461,10 @@ test('dashboard live speed uses consecutive bidirectional SSE counters and rejec
   loadInto(sandbox, 'api.js', 'pages/dashboard.js');
   await vm.runInContext('loadDashboardTable()', sandbox);
 
-  vm.runInContext('updateDashboardSiteSpeeds([{id:1, cumulative_bytes_in:100, cumulative_bytes_out:200, bytes_in:100, bytes_out:200, traffic_used:300}])', sandbox);
+  vm.runInContext("updateDashboardSiteSpeeds([{id:1, cumulative_bytes_in:100, cumulative_bytes_out:200, bytes_in:100, bytes_out:200, traffic_used:300}], 0, 'bidirectional')", sandbox);
   assert.ok(elements['dash-table'].innerHTML.includes('↓ 0 B/s'));
   now = 3000;
-  vm.runInContext('updateDashboardSiteSpeeds([{id:1, cumulative_bytes_in:2148, cumulative_bytes_out:1048776, bytes_in:2148, bytes_out:1048776, traffic_used:1050924}])', sandbox);
+  vm.runInContext("updateDashboardSiteSpeeds([{id:1, cumulative_bytes_in:2148, cumulative_bytes_out:1048776, bytes_in:2148, bytes_out:1048776, traffic_used:1050924}], 0, 'bidirectional')", sandbox);
   const html = elements['dash-table'].innerHTML;
   assert.ok(html.includes('↓ 512 KB/s'), html);
   assert.ok(html.includes('↑ 1 KB/s'), html);
@@ -472,7 +472,7 @@ test('dashboard live speed uses consecutive bidirectional SSE counters and rejec
   assert.equal(billedSample, 2 * (2048 + 1048576), 'bidirectional realtime traffic must count both VPS network legs');
 
   const trendLength = vm.runInContext("dashboardRealtimeTrendSamples.get('all').length", sandbox);
-  vm.runInContext('updateDashboardSiteSpeeds([{id:1, sampled_at_ms:3000, cumulative_bytes_in:2148, cumulative_bytes_out:1048776, requests:0}])', sandbox);
+  vm.runInContext("updateDashboardSiteSpeeds([{id:1, sampled_at_ms:3000, cumulative_bytes_in:2148, cumulative_bytes_out:1048776, requests:0}], 3000, 'bidirectional')", sandbox);
   assert.equal(vm.runInContext("dashboardRealtimeTrendSamples.get('all').length", sandbox), trendLength, 'an unchanged Agent sample must not append a synthetic trend point');
 
   await vm.runInContext('loadDashboardTable()', sandbox);
@@ -482,7 +482,7 @@ test('dashboard live speed uses consecutive bidirectional SSE counters and rejec
   assert.ok(!refreshedHTML.includes('dashboard-speed-placeholder'), 'refreshing site metadata must not flash the speed placeholder');
 
   now = 5000;
-  vm.runInContext('updateDashboardSiteSpeeds([{id:1, cumulative_bytes_in:1, cumulative_bytes_out:1, bytes_in:1, bytes_out:1, traffic_used:2}])', sandbox);
+  vm.runInContext("updateDashboardSiteSpeeds([{id:1, cumulative_bytes_in:1, cumulative_bytes_out:1, bytes_in:1, bytes_out:1, traffic_used:2}], 0, 'bidirectional')", sandbox);
   assert.ok(elements['dash-table'].innerHTML.includes('↓ 0 B/s'), 'counter reset must render zero instead of a negative speed or placeholder');
   assert.ok(!elements['dash-table'].innerHTML.includes('dashboard-speed-placeholder'));
 });
@@ -521,6 +521,66 @@ test('dashboard realtime tooltip aligns sparse site samples by timestamp', () =>
   assert.doesNotMatch(tooltip, /Beta[\s\S]*↓ 0 B\/s/);
 });
 
+test('dashboard all-sites speed keeps the latest rate from asynchronous sites', async () => {
+  const elements = { 'dash-table': makeElement('dash-table'), 's-cache': makeElement('s-cache') };
+  const sandbox = {
+    window: {}, document: makeDocument(elements), console,
+    Date: { now: () => 3000 },
+    Toast: { error() {}, success() {}, info() {} },
+    fetch: async () => okJson([
+      { id: 1, name: 'Alpha', target_url: 'http://a.example', ua_mode: 'infuse', listen_port: 8001, running: true, traffic_used: 0, cache_size_bytes: 0 },
+      { id: 2, name: 'Beta', target_url: 'http://b.example', ua_mode: 'infuse', listen_port: 8002, running: true, traffic_used: 0, cache_size_bytes: 0 },
+    ]),
+    Router: { current: 'dashboard' },
+    setInterval() { return 1; }, clearInterval() {}, setTimeout() { return 0; }, clearTimeout() {},
+  };
+  vm.createContext(sandbox);
+  loadInto(sandbox, 'api.js', 'pages/dashboard.js');
+  await vm.runInContext('loadDashboardTable()', sandbox);
+  vm.runInContext("updateDashboardSiteSpeeds([{id:1, sampled_at_ms:1000, cumulative_bytes_in:0, cumulative_bytes_out:0, running:true},{id:2, sampled_at_ms:1000, cumulative_bytes_in:0, cumulative_bytes_out:0, running:true}], 1000, 'outbound')", sandbox);
+  vm.runInContext("updateDashboardSiteSpeeds([{id:1, sampled_at_ms:2000, cumulative_bytes_in:0, cumulative_bytes_out:1000, running:true},{id:2, sampled_at_ms:2000, cumulative_bytes_in:0, cumulative_bytes_out:500, running:true}], 2000, 'outbound')", sandbox);
+  vm.runInContext("updateDashboardSiteSpeeds([{id:1, sampled_at_ms:3000, cumulative_bytes_in:0, cumulative_bytes_out:2000, running:true},{id:2, sampled_at_ms:2000, cumulative_bytes_in:0, cumulative_bytes_out:500, running:true}], 3000, 'outbound')", sandbox);
+  const aggregate = vm.runInContext("dashboardRealtimeTrendSamples.get('all').at(-1)", sandbox);
+  assert.equal(aggregate.download_bps, 1500, 'aggregate speed must include the last valid sample from both sites');
+});
+
+test('dashboard clears a stale site speed even when its sample timestamp is unchanged', async () => {
+  const elements = { 'dash-table': makeElement('dash-table'), 's-cache': makeElement('s-cache') };
+  const sandbox = {
+    window: {}, document: makeDocument(elements), console,
+    Date: { now: () => 3000 },
+    Toast: { error() {}, success() {}, info() {} },
+    fetch: async () => okJson([{ id: 1, name: 'Alpha', target_url: 'http://a.example', ua_mode: 'infuse', listen_port: 8001, running: true, traffic_used: 0, cache_size_bytes: 0 }]),
+    Router: { current: 'dashboard' },
+    setInterval() { return 1; }, clearInterval() {}, setTimeout() { return 0; }, clearTimeout() {},
+  };
+  vm.createContext(sandbox);
+  loadInto(sandbox, 'api.js', 'pages/dashboard.js');
+  await vm.runInContext('loadDashboardTable()', sandbox);
+  vm.runInContext("updateDashboardSiteSpeeds([{id:1, sampled_at_ms:1000, cumulative_bytes_in:0, cumulative_bytes_out:0, running:true}], 1000, 'outbound')", sandbox);
+  vm.runInContext("updateDashboardSiteSpeeds([{id:1, sampled_at_ms:2000, cumulative_bytes_in:0, cumulative_bytes_out:1000, running:true}], 2000, 'outbound')", sandbox);
+  vm.runInContext("updateDashboardSiteSpeeds([{id:1, sampled_at_ms:2000, cumulative_bytes_in:0, cumulative_bytes_out:1000, running:false}], 3000, 'outbound')", sandbox);
+  assert.ok(elements['dash-table'].innerHTML.includes('↓ 0 B/s'), 'offline sites must not retain their old nonzero speed');
+});
+
+test('dashboard does not calculate realtime traffic until billing mode is known', async () => {
+  const elements = { 'dash-table': makeElement('dash-table'), 's-cache': makeElement('s-cache') };
+  const sandbox = {
+    window: {}, document: makeDocument(elements), console,
+    Date: { now: () => 2000 },
+    Toast: { error() {}, success() {}, info() {} },
+    fetch: async () => okJson([{ id: 1, name: 'Alpha', target_url: 'http://a.example', ua_mode: 'infuse', listen_port: 8001, running: true, traffic_used: 0, cache_size_bytes: 0 }]),
+    Router: { current: 'dashboard' },
+    setInterval() { return 1; }, clearInterval() {}, setTimeout() { return 0; }, clearTimeout() {},
+  };
+  vm.createContext(sandbox);
+  loadInto(sandbox, 'api.js', 'pages/dashboard.js');
+  await vm.runInContext('loadDashboardTable()', sandbox);
+  vm.runInContext("updateDashboardSiteSpeeds([{id:1, sampled_at_ms:1000, cumulative_bytes_in:0, cumulative_bytes_out:0, running:true}], 1000)", sandbox);
+  vm.runInContext("updateDashboardSiteSpeeds([{id:1, sampled_at_ms:2000, cumulative_bytes_in:100, cumulative_bytes_out:200, running:true}], 2000)", sandbox);
+  assert.equal(vm.runInContext("dashboardRealtimeTrendSamples.get('all').at(-1).traffic_bytes", sandbox), undefined);
+});
+
 test('dashboard keeps SSE samples that arrive before the site list and across partial payloads', async () => {
   const elements = { 'dash-table': makeElement('dash-table'), 's-cache': makeElement('s-cache') };
   let now = 1000;
@@ -535,14 +595,14 @@ test('dashboard keeps SSE samples that arrive before the site list and across pa
   vm.createContext(sandbox);
   loadInto(sandbox, 'api.js', 'pages/dashboard.js');
 
-  vm.runInContext('updateDashboardSiteSpeeds([{id:1, cumulative_bytes_in:100, cumulative_bytes_out:200, bytes_in:100, bytes_out:200, traffic_used:300}])', sandbox);
+  vm.runInContext("updateDashboardSiteSpeeds([{id:1, cumulative_bytes_in:100, cumulative_bytes_out:200, bytes_in:100, bytes_out:200, traffic_used:300}], 0, 'bidirectional')", sandbox);
   await vm.runInContext('loadDashboardTable()', sandbox);
   assert.ok(elements['dash-table'].innerHTML.includes('↓ 0 B/s'), 'the first pre-list sample should render a stable zero rate');
 
   now = 2000;
-  vm.runInContext('updateDashboardSiteSpeeds([])', sandbox);
+  vm.runInContext("updateDashboardSiteSpeeds([], 2000, 'bidirectional')", sandbox);
   now = 3000;
-  vm.runInContext('updateDashboardSiteSpeeds([{id:1, cumulative_bytes_in:2148, cumulative_bytes_out:1048776, bytes_in:0, bytes_out:0, traffic_used:1050924}])', sandbox);
+  vm.runInContext("updateDashboardSiteSpeeds([{id:1, cumulative_bytes_in:2148, cumulative_bytes_out:1048776, bytes_in:0, bytes_out:0, traffic_used:1050924}], 3000, 'bidirectional')", sandbox);
   assert.ok(elements['dash-table'].innerHTML.includes('↓ 512 KB/s'), 'the sample received before /api/sites must be used');
   assert.ok(elements['dash-table'].innerHTML.includes('↑ 1 KB/s'), 'the bidirectional sample must be retained');
 });

--- a/traffic_repository.go
+++ b/traffic_repository.go
@@ -38,6 +38,8 @@ type SiteTraffic struct {
 	MonthlyTraffic     int64  `json:"monthly_traffic"`
 	Requests           int64  `json:"requests"`
 	SampledAtMS        int64  `json:"sampled_at_ms,omitempty"`
+	CacheSizeBytes     int64  `json:"cache_size_bytes,omitempty"`
+	AgentRuntime       bool   `json:"-"`
 }
 
 // TrafficSnapshot is the single authoritative global traffic payload shared by
@@ -68,6 +70,7 @@ type NodeSiteLiveTraffic struct {
 	CumulativeBytesOut int64
 	Requests           int64
 	SampledAtMS        int64
+	CacheSizeBytes     int64
 }
 
 // TrafficHistory is the single-site envelope returned by
@@ -293,6 +296,7 @@ func (d *DB) NodeSiteLiveTrafficSnapshot(now time.Time) (map[int64]NodeSiteLiveT
 			COALESCE(c.last_bytes_in, 0),
 			COALESCE(c.last_bytes_out, 0),
 			COALESCE(c.last_request_count, sch.agent_request_count, 0),
+			COALESCE(c.cache_size_bytes, 0),
 			COALESCE(c.updated_at_ms, 0),
 			COALESCE(n.last_seen_at_ms, 0),
 			COALESCE(n.enabled, 0),
@@ -315,7 +319,7 @@ func (d *DB) NodeSiteLiveTrafficSnapshot(now time.Time) (map[int64]NodeSiteLiveT
 		var nodeLastSeenMS int64
 		var nodeEnabled int
 		var listenerError, dnsStatus string
-		if err := rows.Scan(&value.SiteID, &value.NodeID, &value.CumulativeBytesIn, &value.CumulativeBytesOut, &value.Requests, &value.SampledAtMS, &nodeLastSeenMS, &nodeEnabled, &listenerError, &dnsStatus); err != nil {
+		if err := rows.Scan(&value.SiteID, &value.NodeID, &value.CumulativeBytesIn, &value.CumulativeBytesOut, &value.Requests, &value.CacheSizeBytes, &value.SampledAtMS, &nodeLastSeenMS, &nodeEnabled, &listenerError, &dnsStatus); err != nil {
 			return nil, err
 		}
 		nodeFresh := nodeLastSeenMS > 0 && now.Sub(time.UnixMilli(nodeLastSeenMS)) <= nodeOnlineWindow

--- a/web/static/js/pages/dashboard.js
+++ b/web/static/js/pages/dashboard.js
@@ -12,10 +12,13 @@ let dashboardTrendState = { siteId: 'all', range: 'realtime', customStart: '', c
 let dashboardTrendCharts = new Map();
 let dashboardTrendData = null;
 let dashboardSites = [];
+let dashboardSitesInitialized = false;
 let dashboardSpeedSamples = new Map();
 let dashboardLiveSpeeds = new Map();
 let dashboardRealtimeTrendSamples = new Map();
 let dashboardRealtimeTrendSiteSamples = new Map();
+let dashboardLatestRatesBySite = new Map();
+let dashboardBillingMode = null;
 let dashboardLastSnapshotMS = 0;
 
 function dashboardCreateAbortController() {
@@ -142,6 +145,7 @@ async function loadDashboardBootstrap() {
       const speed = dashboardLiveSpeeds.get(Number(site.id)) || current?._liveSpeed;
       return speed ? { ...site, _liveSpeed: speed } : site;
     }) : [];
+    dashboardSitesInitialized = true;
     const cacheEl = document.getElementById('s-cache');
     if (cacheEl) cacheEl.textContent = formatBytes(dashboardSites.reduce((total, site) => total + Number(site.cache_size_bytes || 0), 0));
     if (data.snapshot) updateDashboardLive(data.snapshot);
@@ -298,7 +302,15 @@ function dashboardTrendTooltip(point, metric, range, pointIndex = -1) {
         // that site and cannot be indexed by the aggregate point index. Use
         // the latest sample at or before the hovered timestamp instead of
         // turning a sparse array lookup into a misleading zero.
-        const sample = dashboardRealtimeSiteSampleAt(site.id, point.timestamp_ms) || { download_bps: 0, upload_bps: 0, requests: 0, traffic_bytes: 0 };
+        let sample;
+        if (metric === 'speed') {
+          sample = dashboardRealtimeSiteSampleAt(site.id, point.timestamp_ms) || { download_bps: 0, upload_bps: 0, requests: 0, traffic_bytes: 0 };
+        } else {
+          // Traffic and request values describe the contribution to this
+          // aggregate interval. Carrying forward the previous sparse sample
+          // would count the same bytes again when another site reports.
+          sample = point.site_contributions?.[String(site.id)] || { download_bps: 0, upload_bps: 0, requests: 0, traffic_bytes: 0 };
+        }
         siteRows.push(`<div class="dashboard-chart-tooltip-row"><strong>${esc(site.name || `站点 ${site.id}`)}</strong><span>${dashboardTrendMetricLine(sample, metric)}</span></div>`);
       });
     } else {
@@ -322,12 +334,18 @@ function dashboardRealtimeSiteSampleAt(siteID, timestampMS) {
   if (!samples.length) return null;
   const target = Number(timestampMS);
   if (!Number.isFinite(target)) return samples[samples.length - 1] || null;
+  let low = 0;
+  let high = samples.length - 1;
   let latest = null;
-  for (const sample of samples) {
-    const sampledAt = Number(sample?.timestamp_ms);
-    if (!Number.isFinite(sampledAt)) continue;
-    if (sampledAt > target) break;
-    latest = sample;
+  while (low <= high) {
+    const middle = (low + high) >> 1;
+    const sampledAt = Number(samples[middle]?.timestamp_ms);
+    if (!Number.isFinite(sampledAt) || sampledAt > target) {
+      high = middle - 1;
+    } else {
+      latest = samples[middle];
+      low = middle + 1;
+    }
   }
   return latest;
 }
@@ -794,6 +812,17 @@ function updateDashboardLive(stats) {
 	const generatedAt = Number(stats?.generated_at_ms || 0);
 	if (generatedAt > 0 && generatedAt < dashboardLastSnapshotMS) return;
 	if (generatedAt > 0) dashboardLastSnapshotMS = generatedAt;
+	const incomingBillingMode = String(stats?.billing_mode || '').toLowerCase();
+	if (incomingBillingMode === 'outbound' || incomingBillingMode === 'bidirectional') {
+	  if (dashboardBillingMode && dashboardBillingMode !== incomingBillingMode) {
+	    // Existing realtime traffic was calculated under the old policy. Drop
+	    // only that derived sequence; counter baselines and live rates remain
+	    // valid and will continue on the next sample.
+	    dashboardRealtimeTrendSamples = new Map();
+	    dashboardRealtimeTrendSiteSamples = new Map();
+	  }
+	  dashboardBillingMode = incomingBillingMode;
+	}
 	const panelDomainEl = document.getElementById('s-panel-domain');
 	const currentPanelURL = dashboardCurrentPanelURL(stats.panel_access_url);
 	if (panelDomainEl && currentPanelURL) panelDomainEl.textContent = currentPanelURL;
@@ -812,11 +841,12 @@ function updateDashboardLive(stats) {
 
   const requestsEl = document.getElementById('s-requests');
   if (requestsEl) requestsEl.textContent = formatNumber(stats.total_requests || 0) + ' 请求';
-  updateDashboardSiteSpeeds(stats.live_sites || [], generatedAt);
+  updateDashboardSiteSpeeds(stats.live_sites || [], generatedAt, dashboardBillingMode);
   updateDashboardTrendRealtime();
 }
 
-function updateDashboardSiteSpeeds(liveSites, snapshotMS) {
+function updateDashboardSiteSpeeds(liveSites, snapshotMS, billingModeOverride) {
+  const snapshotValue = Number(snapshotMS || 0);
   const liveMap = new Map();
   const trendDeltas = new Map();
   const rateSamples = new Map();
@@ -827,17 +857,30 @@ function updateDashboardSiteSpeeds(liveSites, snapshotMS) {
   let totalRateIn = 0;
   let totalRateOut = 0;
   let totalDeltaRequests = 0;
+  // Runtime samples must never guess the billing policy while bootstrap and
+  // trends are still racing. Direct callers may provide an explicit legacy
+  // fallback, but the normal SSE path passes dashboardBillingMode (which can
+  // intentionally remain null until the authoritative snapshot arrives).
+  const billingMode = billingModeOverride === undefined
+    ? (dashboardBillingMode || dashboardTrendData?.billing_mode || null)
+    : billingModeOverride;
+  const billingKnown = billingMode === 'outbound' || billingMode === 'bidirectional';
+  const freshnessWindowMS = 45 * 1000;
   for (const site of (liveSites || [])) {
     const siteID = Number(site.id);
     if (!Number.isFinite(siteID)) continue;
     liveMap.set(siteID, site);
-    const sourceTimestamp = Number(site.sampled_at_ms || snapshotMS || Date.now());
+    const sourceTimestamp = Number(site.sampled_at_ms || snapshotValue || Date.now());
+    const running = site.running === undefined ? true : site.running === true;
+    const fresh = running && sourceTimestamp > 0 && (snapshotValue <= 0 || (sourceTimestamp <= snapshotValue + 5000 && snapshotValue - sourceTimestamp <= freshnessWindowMS));
     const current = {
       trafficUsed: Number(site.monthly_traffic != null ? site.monthly_traffic : (site.traffic_used || 0)),
       bytesIn: Number(site.cumulative_bytes_in != null ? site.cumulative_bytes_in : (site.bytes_in || site.bytes_in_total || 0)),
       bytesOut: Number(site.cumulative_bytes_out != null ? site.cumulative_bytes_out : (site.bytes_out || site.bytes_out_total || 0)),
       requests: Number(site.requests || 0),
       timestamp: sourceTimestamp,
+      running,
+      fresh,
     };
     const previous = dashboardSpeedSamples.get(siteID);
     if (!previous) {
@@ -846,19 +889,31 @@ function updateDashboardSiteSpeeds(liveSites, snapshotMS) {
       changedSiteTimestamps.set(siteID, current.timestamp);
       rateSamples.set(String(siteID), { download_bps: 0, upload_bps: 0 });
       trendDeltas.set(siteID, { bytesIn: 0, bytesOut: 0, requests: 0 });
+    } else if (!fresh) {
+      // A stale/offline sample must immediately clear a previously displayed
+      // rate, even when its timestamp did not advance. Keep the current
+      // counters as the recovery baseline.
+      if (previous.running || previous.fresh || (dashboardLiveSpeeds.get(siteID)?.down || 0) !== 0 || (dashboardLiveSpeeds.get(siteID)?.up || 0) !== 0) {
+        changedSiteIDs.add(siteID);
+        changedSiteTimestamps.set(siteID, current.timestamp);
+        rateSamples.set(String(siteID), { download_bps: 0, upload_bps: 0 });
+        trendDeltas.set(siteID, { bytesIn: 0, bytesOut: 0, requests: 0 });
+      }
+      dashboardLiveSpeeds.set(siteID, { down: 0, up: 0 });
     } else if (current.timestamp > previous.timestamp) {
       changedSiteIDs.add(siteID);
       changedSiteTimestamps.set(siteID, current.timestamp);
+      // After an offline interval, establish a fresh baseline rather than
+      // charging the whole outage as a single speed sample.
+      const recovering = previous.running !== true || previous.fresh !== true;
       const seconds = (current.timestamp - previous.timestamp) / 1000;
       const down = current.bytesOut - previous.bytesOut;
       const up = current.bytesIn - previous.bytesIn;
-      if (down >= 0 && up >= 0) {
+      if (!recovering && seconds > 0 && down >= 0 && up >= 0) {
         const downRate = down / seconds;
         const upRate = up / seconds;
         dashboardLiveSpeeds.set(siteID, { down: downRate, up: upRate });
         rateSamples.set(String(siteID), { download_bps: downRate, upload_bps: upRate });
-        totalRateOut += downRate;
-        totalRateIn += upRate;
         const requests = Math.max(0, current.requests - previous.requests);
         trendDeltas.set(siteID, { bytesIn: up, bytesOut: down, requests });
         totalDeltaIn += up;
@@ -872,36 +927,96 @@ function updateDashboardSiteSpeeds(liveSites, snapshotMS) {
         trendDeltas.set(siteID, { bytesIn: 0, bytesOut: 0, requests: 0 });
       }
     } else if (current.timestamp === previous.timestamp) {
-      // The Agent has not emitted a new sample. Keep the previous speed and
-      // do not append a synthetic zero point to the realtime trend.
-      continue;
+      // The Agent has not emitted a new sample. Keep its last valid rate; the
+      // aggregate speed is recomputed from all such rates below.
+      if (current.fresh && previous.fresh) {
+        const existing = dashboardLiveSpeeds.get(siteID) || { down: 0, up: 0 };
+        dashboardLiveSpeeds.set(siteID, existing);
+      }
     } else {
       // A stale sample must never move the counter baseline backwards.
       continue;
     }
     // Keep the latest sample even when a later SSE payload omits another site.
     dashboardSpeedSamples.set(siteID, current);
+    const speed = dashboardLiveSpeeds.get(siteID) || { down: 0, up: 0 };
+    dashboardLatestRatesBySite.set(siteID, { down: speed.down || 0, up: speed.up || 0, sampledAt: current.timestamp, running: current.running, fresh: current.fresh });
+  }
+  // Sum the latest valid rate for every site, not only sites that emitted in
+  // this SSE payload. Agents report asynchronously, so this is the only way
+  // the all-sites card can remain an accurate aggregate.
+  for (const [siteID, latest] of dashboardLatestRatesBySite) {
+    const current = liveMap.get(siteID);
+    if (current) {
+      const timestamp = Number(current.sampled_at_ms || snapshotValue || latest.sampledAt || 0);
+      latest.running = current.running === undefined ? latest.running : current.running === true;
+      latest.fresh = latest.running && timestamp > 0 && (snapshotValue <= 0 || (timestamp <= snapshotValue + 5000 && snapshotValue - timestamp <= freshnessWindowMS));
+      latest.sampledAt = timestamp || latest.sampledAt;
+    } else if (snapshotValue > 0 && latest.sampledAt > 0 && snapshotValue - latest.sampledAt > freshnessWindowMS) {
+      const wasActive = latest.running && latest.fresh;
+      latest.running = false;
+      latest.fresh = false;
+      // A missing site sample is also an offline signal once it ages out of
+      // the freshness window. Mark the stored counter baseline stale so a
+      // later recovery establishes a new baseline instead of charging the
+      // whole outage interval as one speed sample.
+      const baseline = dashboardSpeedSamples.get(siteID);
+      if (baseline) {
+        baseline.running = false;
+        baseline.fresh = false;
+      }
+      const existingSpeed = dashboardLiveSpeeds.get(siteID) || { down: 0, up: 0 };
+      if (wasActive || existingSpeed.down !== 0 || existingSpeed.up !== 0) {
+        dashboardLiveSpeeds.set(siteID, { down: 0, up: 0 });
+        changedSiteIDs.add(siteID);
+        changedSiteTimestamps.set(siteID, latest.sampledAt);
+        rateSamples.set(String(siteID), { download_bps: 0, upload_bps: 0 });
+        trendDeltas.set(siteID, { bytesIn: 0, bytesOut: 0, requests: 0 });
+      }
+    }
+    if (latest.running && latest.fresh) {
+      totalRateOut += Math.max(0, Number(latest.down || 0));
+      totalRateIn += Math.max(0, Number(latest.up || 0));
+    }
   }
   const sampledAt = Number(snapshotMS || Date.now());
-  const appendRealtimeTrendSample = (key, sample, sampleTimestamp = sampledAt) => {
+  const appendRealtimeTrendSample = (key, sample, sampleTimestamp = sampledAt, contributions = null) => {
     const samples = dashboardRealtimeTrendSamples.get(key) || [];
     const bytesIn = Math.max(0, Number(sample?.bytesIn || 0));
     const bytesOut = Math.max(0, Number(sample?.bytesOut || 0));
-    samples.push({
+    const point = {
       timestamp_ms: Number(sampleTimestamp || sampledAt),
       download_bps: Math.max(0, Number(sample?.download_bps || 0)),
       upload_bps: Math.max(0, Number(sample?.upload_bps || 0)),
       bytes_in: bytesIn,
       bytes_out: bytesOut,
       requests: Math.max(0, Number(sample?.requests || 0)),
-      traffic_bytes: dashboardTrendData?.billing_mode === 'outbound' ? bytesOut : 2 * (bytesIn + bytesOut),
-    });
+    };
+    if (billingKnown) point.traffic_bytes = billingMode === 'outbound' ? bytesOut : 2 * (bytesIn + bytesOut);
+    if (contributions && Object.keys(contributions).length) point.site_contributions = contributions;
+    samples.push(point);
     // Keep the active dashboard session responsive without imposing a time
     // window; the X axis adapts to however many samples are available.
-    dashboardRealtimeTrendSamples.set(key, samples.slice(-1800));
+    if (samples.length > 1800) samples.splice(0, samples.length - 1800);
+    dashboardRealtimeTrendSamples.set(key, samples);
   };
   if (changedSiteIDs.size > 0) {
-    appendRealtimeTrendSample('all', { download_bps: totalRateOut, upload_bps: totalRateIn, bytesIn: totalDeltaIn, bytesOut: totalDeltaOut, requests: totalDeltaRequests });
+    const contributions = {};
+    for (const siteID of changedSiteIDs) {
+      const delta = trendDeltas.get(siteID) || {};
+      const rate = rateSamples.get(String(siteID)) || {};
+      contributions[String(siteID)] = {
+        download_bps: Math.max(0, Number(rate.download_bps || 0)),
+        upload_bps: Math.max(0, Number(rate.upload_bps || 0)),
+        bytes_in: Math.max(0, Number(delta.bytesIn || 0)),
+        bytes_out: Math.max(0, Number(delta.bytesOut || 0)),
+        requests: Math.max(0, Number(delta.requests || 0)),
+      };
+      if (billingKnown) contributions[String(siteID)].traffic_bytes = billingMode === 'outbound'
+        ? contributions[String(siteID)].bytes_out
+        : 2 * (contributions[String(siteID)].bytes_in + contributions[String(siteID)].bytes_out);
+    }
+    appendRealtimeTrendSample('all', { download_bps: totalRateOut, upload_bps: totalRateIn, bytesIn: totalDeltaIn, bytesOut: totalDeltaOut, requests: totalDeltaRequests }, sampledAt, contributions);
   }
   for (const siteID of changedSiteIDs) {
     const rate = rateSamples.get(String(siteID)) || {};
@@ -915,13 +1030,14 @@ function updateDashboardSiteSpeeds(liveSites, snapshotMS) {
       bytes_in: Math.max(0, Number(delta.bytesIn || 0)),
       bytes_out: Math.max(0, Number(delta.bytesOut || 0)),
       requests: Math.max(0, Number(delta.requests || 0)),
-      traffic_bytes: dashboardTrendData?.billing_mode === 'outbound' ? Math.max(0, Number(delta.bytesOut || 0)) : 2 * (Math.max(0, Number(delta.bytesIn || 0)) + Math.max(0, Number(delta.bytesOut || 0))),
     };
+    if (billingKnown) siteSample.traffic_bytes = billingMode === 'outbound' ? siteSample.bytes_out : 2 * (siteSample.bytes_in + siteSample.bytes_out);
     // Keep the site series timestamp aligned with the Agent sample. The
     // aggregate series still uses the controller snapshot timestamp.
     appendRealtimeTrendSample(String(siteID), { ...rate, ...delta }, siteSampledAt);
     siteSamples.push(siteSample);
-    dashboardRealtimeTrendSiteSamples.set(String(siteID), siteSamples.slice(-1800));
+    if (siteSamples.length > 1800) siteSamples.splice(0, siteSamples.length - 1800);
+    dashboardRealtimeTrendSiteSamples.set(String(siteID), siteSamples);
   }
   dashboardSites = dashboardSites.map(site => {
     const siteID = Number(site.id);
@@ -969,10 +1085,13 @@ function animateValue(id, newVal) {
 function stopDashSSE() {
   dashboardSpeedSamples = new Map();
   dashboardLiveSpeeds = new Map();
+  dashboardLatestRatesBySite = new Map();
+  dashboardBillingMode = null;
   dashboardRealtimeTrendSamples = new Map();
   dashboardRealtimeTrendSiteSamples = new Map();
   dashboardLastSnapshotMS = 0;
   dashboardTrendData = null;
+  dashboardSitesInitialized = false;
   dashboardTrendCharts = new Map();
   if (dashboardTrendResizeObserver) {
     dashboardTrendResizeObserver.disconnect();
@@ -1025,7 +1144,8 @@ async function loadDashboardTable() {
 
     if (!sites || sites.length === 0) {
       dashboardSites = [];
-      tbody.innerHTML = '<tr><td colspan="8" style="text-align:center;color:var(--white-38);padding:40px">暂无站点，前往站点管理添加</td></tr>';
+      dashboardSitesInitialized = true;
+      renderDashboardTableRows();
       return;
     }
 
@@ -1044,7 +1164,21 @@ async function loadDashboardTable() {
 
 function renderDashboardTableRows() {
   const tbody = document.getElementById('dash-table');
-  if (!tbody || !dashboardSites.length) return;
+  if (!tbody) return;
+  if (!dashboardSites.length) {
+    if (!dashboardSitesInitialized) return;
+    dashboardSpeedSamples.clear();
+    dashboardLiveSpeeds.clear();
+    dashboardLatestRatesBySite.clear();
+    dashboardRealtimeTrendSiteSamples.clear();
+    tbody.innerHTML = '<tr><td colspan="8" style="text-align:center;color:var(--white-38);padding:40px">暂无站点，前往站点管理添加</td></tr>';
+    return;
+  }
+  const known = new Set(dashboardSites.map(site => Number(site.id)));
+  for (const map of [dashboardSpeedSamples, dashboardLiveSpeeds, dashboardLatestRatesBySite]) {
+    for (const siteID of map.keys()) if (!known.has(siteID)) map.delete(siteID);
+  }
+  for (const siteID of dashboardRealtimeTrendSiteSamples.keys()) if (!known.has(Number(siteID))) dashboardRealtimeTrendSiteSamples.delete(siteID);
   tbody.innerHTML = dashboardSites.map(s => `
       <tr>
         <td style="font-weight:600">${esc(s.name)}</td>

--- a/web/static/js/pages/request-logs.js
+++ b/web/static/js/pages/request-logs.js
@@ -429,8 +429,12 @@ async function clearRequestLogs() {
 async function clearAssetCache() {
   if (!confirm('确认清除所有站点的图片与静态资源缓存？站点配置和请求日志不会受到影响。')) return;
   try {
-    await API.clearAssetCache();
-    Toast.success('资产缓存已清除');
+    const result = await API.clearAssetCache();
+    if (result?.status === 'pending' && Number(result.nodes_pending || 0) > 0) {
+      Toast.success(`主控缓存已清除，${result.nodes_pending} 个节点将在下次配置同步后清除`);
+    } else {
+      Toast.success('资产缓存已清除');
+    }
   } catch (error) {
     Toast.error(error.message);
   }


### PR DESCRIPTION
## Summary
- isolate Agent site telemetry by authorized Node → Site mapping and independent report counter epochs
- persist first report request deltas and stable central SiteID cache namespaces across Agent rebuilds
- add shared Agent report admission limits, cache clear generation reporting, and remote cache visibility
- fix dashboard async site speed aggregation, stale/offline reset, billing-mode handling, sparse tooltip contributions, and pending trend windows
- keep dashboard and traffic snapshots on the same Agent runtime authority model
- retain legacy Agent config compatibility while rolling out cache clear generation

## Validation
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `node --test tests/*.test.js`
- `node --check web/static/js/pages/dashboard.js`
- `govulncheck ./...`
- `actionlint .github/workflows/release.yml`
- `git diff --check`

Gosec continues to report only the repository's existing low-severity findings when run without the CI severity filter.