### PR TITLE
fix: stabilize scheduler, agent rollback, and icon selection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,9 @@ jobs:
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: meridian-release-binaries
-          path: meridian-*
+          path: |
+            meridian-*
+            install.sh
 
   release:
     needs: [verify, build, docker]
@@ -183,13 +185,14 @@ jobs:
           merge-multiple: true
 
       - name: Generate checksums
-        run: sha256sum meridian-* > SHA256SUMS
+        run: sha256sum meridian-* install.sh > SHA256SUMS
 
       - name: Attest release artifacts
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.2.2
         with:
           subject-path: |
             meridian-*
+            install.sh
             SHA256SUMS
 
       - name: Create Release
@@ -198,6 +201,7 @@ jobs:
           tag_name: ${{ needs.verify.outputs.release_tag }}
           files: |
             meridian-*
+            install.sh
             SHA256SUMS
           generate_release_notes: true
           draft: true

--- a/README.md
+++ b/README.md
@@ -60,24 +60,27 @@ docker compose logs -f meridian
 
 首次启动时日志会输出一次管理员初始化令牌。打开 `http://服务器地址:9090` 完成初始化。数据库、TLS 状态和缓存位于 `./data`，更新容器不会删除它们。`network_mode: host` 会让面板和站点端口直接使用宿主机网络，请先确认端口没有被其他服务占用。
 
-生产环境可以把 `latest` 换成固定版本，例如 `ghcr.io/chanhui800/meridian:v1.9.51`。固定版本便于回滚和排查问题。
+生产环境可以把 `latest` 换成固定版本，例如 `ghcr.io/chanhui800/meridian:v1.9.52`。固定版本便于回滚和排查问题。
 
 ### Linux 原生安装
 
-交互安装：
+从固定 Release 安装（推荐）：
 
 ```bash
+VERSION=v1.9.52
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
 curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL \
-  https://raw.githubusercontent.com/chanhui800/Meridian/main/install.sh | sudo bash
+  -o "$tmp_dir/install.sh" \
+  "https://github.com/chanhui800/Meridian/releases/download/${VERSION}/install.sh"
+curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL \
+  -o "$tmp_dir/SHA256SUMS" \
+  "https://github.com/chanhui800/Meridian/releases/download/${VERSION}/SHA256SUMS"
+(cd "$tmp_dir" && grep ' install.sh$' SHA256SUMS | sha256sum -c -)
+sudo bash "$tmp_dir/install.sh" install -y --no-domain
 ```
 
-无交互安装：
-
-```bash
-curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL \
-  https://raw.githubusercontent.com/chanhui800/Meridian/main/install.sh | \
-  sudo bash -s -- install -y --no-domain
-```
+安装器和校验文件均来自同一个固定 Release。升级时将 `VERSION` 改为目标版本；不要从可变的 `main` 分支直接执行安装脚本。
 
 默认数据库为 `/var/lib/meridian/meridian.db`，服务名为 `meridian`：
 

--- a/app_sites.go
+++ b/app_sites.go
@@ -815,20 +815,25 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 				a.jsonErr(w, http.StatusBadRequest, "icon_name and icon_url must be provided together")
 				return
 			}
-			candidate.IconName, candidate.IconURL, err = normalizeSiteIconSelection(*req.IconName, *req.IconURL)
+			incomingName, incomingURL, normalizeErr := normalizeSiteIconSelection(*req.IconName, *req.IconURL)
+			err = normalizeErr
 			if err != nil {
 				a.jsonErr(w, http.StatusBadRequest, err.Error())
 				return
 			}
-			pack, packErr := a.db.SiteIconPack()
-			if packErr != nil {
-				a.jsonErr(w, http.StatusInternalServerError, "读取站点图标包失败")
-				return
-			}
-			candidate.IconName, candidate.IconURL, err = pack.normalizeSelection(candidate.IconName, candidate.IconURL)
-			if err != nil {
-				a.jsonErr(w, http.StatusBadRequest, err.Error())
-				return
+			if strings.EqualFold(incomingName, oldSite.IconName) && incomingURL == oldSite.IconURL {
+				candidate.IconName, candidate.IconURL = oldSite.IconName, oldSite.IconURL
+			} else {
+				pack, packErr := a.db.SiteIconPack()
+				if packErr != nil {
+					a.jsonErr(w, http.StatusInternalServerError, "读取站点图标包失败")
+					return
+				}
+				candidate.IconName, candidate.IconURL, err = pack.validateNewSelection(incomingName, incomingURL)
+				if err != nil {
+					a.jsonErr(w, http.StatusBadRequest, err.Error())
+					return
+				}
 			}
 		}
 		candidate.ListenPort = listenPort

--- a/database_migrations.go
+++ b/database_migrations.go
@@ -418,6 +418,7 @@ func (d *DB) migrateOnce() error {
 		dns_status TEXT NOT NULL DEFAULT 'disabled',
 		config_hash TEXT NOT NULL DEFAULT '',
 		last_error TEXT NOT NULL DEFAULT '',
+		config_pending_since_ms INTEGER NOT NULL DEFAULT 0,
 		created_at_ms INTEGER NOT NULL DEFAULT 0,
 		updated_at_ms INTEGER NOT NULL DEFAULT 0
 	);
@@ -716,6 +717,7 @@ func (d *DB) migrateOnce() error {
 		{"site_node_schedules", "agent_request_count", "ALTER TABLE site_node_schedules ADD COLUMN agent_request_count BIGINT NOT NULL DEFAULT 0"},
 		{"site_node_schedules", "agent_last_request_at_ms", "ALTER TABLE site_node_schedules ADD COLUMN agent_last_request_at_ms INTEGER NOT NULL DEFAULT 0"},
 		{"site_node_schedules", "agent_last_status", "ALTER TABLE site_node_schedules ADD COLUMN agent_last_status INTEGER NOT NULL DEFAULT 0"},
+		{"site_node_schedules", "config_pending_since_ms", "ALTER TABLE site_node_schedules ADD COLUMN config_pending_since_ms INTEGER NOT NULL DEFAULT 0"},
 	} {
 		var exists int
 		if err := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM pragma_table_info(?) WHERE name=?", migration.table, migration.column).Scan(&exists); err != nil {

--- a/edge_agent.go
+++ b/edge_agent.go
@@ -520,6 +520,20 @@ type edgeAgentRuntime struct {
 	siteReported         map[int64]ProxyRuntimeStat
 	resolver             dynamicIPResolver
 	transport            dynamicTransportFactory
+	listen               func(string, string) (net.Listener, error)
+}
+
+type edgeAgentRuntimeState struct {
+	port                 int
+	server               *http.Server
+	bundle               *edgeProxyBundle
+	nodeGUID             string
+	certificate          *tls.Certificate
+	handler              http.Handler
+	cacheClearGeneration int64
+	siteCounterEpoch     uint64
+	siteReported         map[int64]ProxyRuntimeStat
+	listenerError        string
 }
 
 func (runtime *edgeAgentRuntime) queueEvent(event NodeRequestEvent) {
@@ -1029,7 +1043,11 @@ func (runtime *edgeAgentRuntime) stopServer() {
 }
 
 func (runtime *edgeAgentRuntime) startServer(port int) error {
-	listener, err := net.Listen("tcp", ":"+strconv.Itoa(port))
+	listen := runtime.listen
+	if listen == nil {
+		listen = net.Listen
+	}
+	listener, err := listen("tcp", ":"+strconv.Itoa(port))
 	if err != nil {
 		return err
 	}
@@ -1046,6 +1064,44 @@ func (runtime *edgeAgentRuntime) startServer(port int) error {
 		}
 	}()
 	return nil
+}
+
+// rollbackApply restores the in-memory candidate state and, when the old
+// listener was stopped for the attempted transition, puts that listener back.
+// A failed listener restore is part of the returned error; silently reporting
+// the old state as healthy would leave the Agent unreachable while its status
+// claims that the rollback succeeded.
+func (runtime *edgeAgentRuntime) rollbackApply(old edgeAgentRuntimeState, listenerWasStopped, newServerStarted bool, cause error) error {
+	if newServerStarted {
+		runtime.stopServer()
+	}
+	runtime.mu.Lock()
+	runtime.nodeGUID = old.nodeGUID
+	runtime.port = old.port
+	runtime.certificate = old.certificate
+	runtime.handler = old.handler
+	runtime.bundle = old.bundle
+	runtime.cacheClearGeneration = old.cacheClearGeneration
+	runtime.siteCounterEpoch = old.siteCounterEpoch
+	runtime.siteReported = old.siteReported
+	runtime.listenerError = old.listenerError
+	if listenerWasStopped {
+		runtime.server = nil
+	} else {
+		runtime.server = old.server
+	}
+	runtime.mu.Unlock()
+	if listenerWasStopped && old.server != nil {
+		if err := runtime.startServer(old.port); err != nil {
+			restoreErr := fmt.Errorf("restore old listener on port %d: %w", old.port, err)
+			runtime.mu.Lock()
+			runtime.listenerError = restoreErr.Error()
+			runtime.server = nil
+			runtime.mu.Unlock()
+			return errors.Join(cause, restoreErr)
+		}
+	}
+	return cause
 }
 
 func (runtime *edgeAgentRuntime) apply(config AgentRuntimeConfig) error {
@@ -1069,17 +1125,20 @@ func (runtime *edgeAgentRuntime) apply(config AgentRuntimeConfig) error {
 		return err
 	}
 	runtime.mu.RLock()
-	oldPort, oldServer, oldBundle := runtime.port, runtime.server, runtime.bundle
-	oldNodeGUID, oldCertificate, oldHandler := runtime.nodeGUID, runtime.certificate, runtime.handler
-	oldCacheClearGeneration := runtime.cacheClearGeneration
-	oldSiteCounterEpoch := runtime.siteCounterEpoch
+	oldState := edgeAgentRuntimeState{
+		port: runtime.port, server: runtime.server, bundle: runtime.bundle,
+		nodeGUID: runtime.nodeGUID, certificate: runtime.certificate, handler: runtime.handler,
+		cacheClearGeneration: runtime.cacheClearGeneration, siteCounterEpoch: runtime.siteCounterEpoch,
+		listenerError: runtime.listenerError,
+	}
 	oldSiteReported := make(map[int64]ProxyRuntimeStat, len(runtime.siteReported))
 	for siteID, value := range runtime.siteReported {
 		oldSiteReported[siteID] = value
 	}
 	runtime.mu.RUnlock()
+	oldState.siteReported = oldSiteReported
 	needsListener := len(config.Routes) > 0
-	listenerChanged := oldPort != config.HTTPSPort || (oldServer == nil) != !needsListener
+	listenerChanged := oldState.port != config.HTTPSPort || (oldState.server == nil) != !needsListener
 	if listenerChanged {
 		runtime.stopServer()
 	}
@@ -1099,45 +1158,19 @@ func (runtime *edgeAgentRuntime) apply(config AgentRuntimeConfig) error {
 	if listenerChanged && needsListener {
 		if err := runtime.startServer(config.HTTPSPort); err != nil {
 			bundle.close()
-			runtime.mu.Lock()
-			runtime.nodeGUID = oldNodeGUID
-			runtime.port = oldPort
-			runtime.certificate = oldCertificate
-			runtime.handler = oldHandler
-			runtime.bundle = oldBundle
-			runtime.siteCounterEpoch = oldSiteCounterEpoch
-			runtime.siteReported = oldSiteReported
-			runtime.listenerError = err.Error()
-			runtime.mu.Unlock()
-			if oldServer != nil {
-				_ = runtime.startServer(oldPort)
-			}
-			return err
+			return runtime.rollbackApply(oldState, listenerChanged, false, err)
 		}
 		newServerStarted = true
 	}
-	if config.CacheClearGeneration > oldCacheClearGeneration {
+	if config.CacheClearGeneration > oldState.cacheClearGeneration {
 		if err := bundle.manager.ClearAssetCache(); err != nil {
-			// The candidate listener is already bound at this point. Stop it
-			// before restoring the old runtime, otherwise the failed apply leaks a
-			// server that is no longer represented by runtime.server.
+			// Close the candidate listener before tearing down its proxy bundle;
+			// otherwise a request racing the rollback could observe a closed bundle.
 			if newServerStarted {
 				runtime.stopServer()
 			}
 			bundle.close()
-			runtime.mu.Lock()
-			runtime.nodeGUID = oldNodeGUID
-			runtime.port = oldPort
-			runtime.certificate = oldCertificate
-			runtime.handler = oldHandler
-			runtime.bundle = oldBundle
-			runtime.siteCounterEpoch = oldSiteCounterEpoch
-			runtime.siteReported = oldSiteReported
-			runtime.mu.Unlock()
-			if oldServer != nil {
-				_ = runtime.startServer(oldPort)
-			}
-			return err
+			return runtime.rollbackApply(oldState, listenerChanged, false, err)
 		}
 	}
 	runtime.mu.Lock()
@@ -1148,11 +1181,11 @@ func (runtime *edgeAgentRuntime) apply(config AgentRuntimeConfig) error {
 	}
 	runtime.listenerError = ""
 	runtime.mu.Unlock()
-	if oldBundle != nil {
+	if oldState.bundle != nil {
 		// A config refresh must not cancel requests that were admitted by the
 		// previous bundle. Stop accepting new requests on it, let active streams
 		// drain, and only force-close them after the bounded grace period.
-		go oldBundle.drain(15 * time.Second)
+		go oldState.bundle.drain(15 * time.Second)
 	}
 	return nil
 }

--- a/edge_agent_test.go
+++ b/edge_agent_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -26,6 +27,26 @@ func testEdgeRuntimeKey(t *testing.T) string {
 		t.Fatal(err)
 	}
 	return base64.RawURLEncoding.EncodeToString(value)
+}
+
+func TestEdgeAgentRollbackSurfacesListenerRestoreFailure(t *testing.T) {
+	cause := errors.New("clear asset cache failed")
+	listenErr := errors.New("address already in use")
+	runtime := &edgeAgentRuntime{listen: func(string, string) (net.Listener, error) {
+		return nil, listenErr
+	}}
+	oldServer := &http.Server{}
+	err := runtime.rollbackApply(edgeAgentRuntimeState{port: 9090, server: oldServer}, true, false, cause)
+	if !errors.Is(err, cause) || !errors.Is(err, listenErr) {
+		t.Fatalf("rollback error=%v, want cause and listener error", err)
+	}
+	if runtime.server != nil {
+		t.Fatal("runtime retained a server after listener restore failed")
+	}
+	_, listenerError := runtime.status()
+	if !strings.Contains(listenerError, "restore old listener on port 9090") {
+		t.Fatalf("listener error=%q, want restore failure", listenerError)
+	}
 }
 
 func TestEdgeEventSpoolUsesIndependentKeyAcrossReenrollment(t *testing.T) {

--- a/node_repository.go
+++ b/node_repository.go
@@ -1072,9 +1072,9 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 
 	var id, lastSequence, lastRX, lastTX int64
 	var cacheClearGeneration int64
-	var lastBootID, lastSessionID string
-	err = tx.QueryRow(`SELECT id,last_sequence,last_raw_rx_bytes,last_raw_tx_bytes,last_boot_id,last_report_session_id,cache_clear_generation FROM control_nodes WHERE agent_token_hash=?`, hashNodeToken(agentToken)).Scan(
-		&id, &lastSequence, &lastRX, &lastTX, &lastBootID, &lastSessionID, &cacheClearGeneration)
+	var lastBootID, lastSessionID, desiredConfigHash string
+	err = tx.QueryRow(`SELECT id,last_sequence,last_raw_rx_bytes,last_raw_tx_bytes,last_boot_id,last_report_session_id,cache_clear_generation,desired_config_hash FROM control_nodes WHERE agent_token_hash=?`, hashNodeToken(agentToken)).Scan(
+		&id, &lastSequence, &lastRX, &lastTX, &lastBootID, &lastSessionID, &cacheClearGeneration, &desiredConfigHash)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nodeReportCommitResult{}, errInvalidAgentToken
 	}
@@ -1133,6 +1133,12 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 		deltaRX, deltaTX, deltaRX, deltaTX, report.RXBytes, report.TXBytes, counterEpoch, sessionID, report.Sequence,
 		strings.TrimSpace(report.InterfaceName), strings.TrimSpace(report.AgentVersion), strings.TrimSpace(report.AppliedConfigHash), strings.TrimSpace(report.ListenerError), strings.TrimSpace(report.EventSpoolError), report.EventQueueDepth, report.EventDropped, report.CacheClearGeneration, report.CacheClearGeneration, cacheClearGeneration, report.CacheClearGeneration, now.UnixMilli(), now.UnixMilli(), id); err != nil {
 		return nodeReportCommitResult{}, err
+	}
+	if appliedHash := strings.TrimSpace(report.AppliedConfigHash); appliedHash != "" && appliedHash == strings.TrimSpace(desiredConfigHash) {
+		if _, err := tx.Exec(`UPDATE site_node_schedules SET config_pending_since_ms=0
+			WHERE enabled=1 AND desired_node_id=? AND config_hash=? AND config_pending_since_ms>0`, id, appliedHash); err != nil {
+			return nodeReportCommitResult{}, err
+		}
 	}
 
 	for _, stat := range report.SiteStats {

--- a/node_repository_test.go
+++ b/node_repository_test.go
@@ -455,6 +455,69 @@ func TestSiteNodeSchedulingIsOptInAndCanFollowGlobalNode(t *testing.T) {
 	}
 }
 
+func TestAgentConfigPollingDoesNotResetPendingSince(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Date(2026, 8, 30, 14, 0, 0, 0, time.UTC)
+	node, enrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "config-node", Address: "203.0.113.15", Port: 9090}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, agentToken, err := app.db.EnrollControlNode(enrollment, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.RecordNodeReport(agentToken, NodeReport{BootID: "config-boot", Sequence: 1, InterfaceName: "eth0", AgentVersion: "test"}, now); err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "config-site", PublicHost: "config.example.com", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:8096"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.SaveSiteNodeSchedule(site.ID, true, "fixed", node.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	// A config request with no enabled site routes still exercises the exact
+	// schedule hash update used by real Agents, without requiring a certificate.
+	if _, err := app.db.db.Exec("UPDATE sites SET enabled=0 WHERE id=?", site.ID); err != nil {
+		t.Fatal(err)
+	}
+	first, err := app.buildAgentConfigForPlatform(agentToken, now.Add(time.Second), "")
+	if err != nil {
+		t.Fatalf("first config: %v", err)
+	}
+	firstSchedule, err := app.db.siteNodeSchedule(site.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstSchedule.ConfigPendingSinceMS == 0 || first.ConfigHash == "" {
+		t.Fatalf("initial config did not start pending timer: schedule=%#v config=%#v", firstSchedule, first)
+	}
+	if _, err := app.db.RecordNodeReport(agentToken, NodeReport{BootID: "config-boot", Sequence: 2, InterfaceName: "eth0", AgentVersion: "test"}, now.Add(60*time.Second)); err != nil {
+		t.Fatalf("keep node online for polling: %v", err)
+	}
+	second, err := app.buildAgentConfigForPlatform(agentToken, now.Add(60*time.Second), "")
+	if err != nil {
+		t.Fatalf("polled config: %v", err)
+	}
+	secondSchedule, err := app.db.siteNodeSchedule(site.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secondSchedule.ConfigPendingSinceMS != firstSchedule.ConfigPendingSinceMS {
+		t.Fatalf("config polling reset pending timer: first=%d second=%d hashes=%q/%q", firstSchedule.ConfigPendingSinceMS, secondSchedule.ConfigPendingSinceMS, first.ConfigHash, second.ConfigHash)
+	}
+	if _, err := app.db.RecordNodeReport(agentToken, NodeReport{BootID: "config-boot", Sequence: 3, InterfaceName: "eth0", AgentVersion: "test", AppliedConfigHash: second.ConfigHash}, now.Add(70*time.Second)); err != nil {
+		t.Fatalf("applied config report: %v", err)
+	}
+	clearedSchedule, err := app.db.siteNodeSchedule(site.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if clearedSchedule.ConfigPendingSinceMS != 0 {
+		t.Fatalf("applied config did not clear pending timer: %#v", clearedSchedule)
+	}
+}
+
 func TestSiteNodeAutoSchedulingFallsBackAfterProbeCooldown(t *testing.T) {
 	app := newTestApp(t)
 	now := time.Date(2026, 8, 30, 15, 0, 0, 0, time.UTC)

--- a/site_icons.go
+++ b/site_icons.go
@@ -213,20 +213,29 @@ func (p SiteIconPack) icon(name string) (SiteIcon, bool) {
 	return SiteIcon{}, false
 }
 
-func (p SiteIconPack) normalizeSelection(name, imageURL string) (string, string, error) {
+// validateNewSelection validates a selection the operator is actively making
+// against the currently loaded icon pack. Existing persisted selections are
+// intentionally handled by the site update path so replacing a pack cannot
+// invalidate unrelated edits.
+func (p SiteIconPack) validateNewSelection(name, imageURL string) (string, string, error) {
 	name, imageURL, err := normalizeSiteIconSelection(name, imageURL)
 	if err != nil || name == "" {
 		return name, imageURL, err
 	}
-	if icon, ok := p.icon(name); ok {
-		if imageURL != icon.URL {
-			return "", "", errors.New("icon url does not match the selected icon pack entry")
-		}
-		return icon.Name, icon.URL, nil
+	icon, ok := p.icon(name)
+	if !ok {
+		return "", "", errors.New("selected icon does not exist in the current icon pack")
 	}
-	// Keep an existing selection usable after an icon pack is replaced. The URL
-	// has already passed the strict HTTPS validation above.
-	return name, imageURL, nil
+	if imageURL != icon.URL {
+		return "", "", errors.New("icon url does not match the selected icon pack entry")
+	}
+	return icon.Name, icon.URL, nil
+}
+
+// normalizeSelection is kept as a compatibility name for callers that mean
+// an explicit picker selection. It is deliberately strict for new values.
+func (p SiteIconPack) normalizeSelection(name, imageURL string) (string, string, error) {
+	return p.validateNewSelection(name, imageURL)
 }
 
 func iconPackUpdatedAt() string { return time.Now().UTC().Format(time.RFC3339) }

--- a/site_icons_test.go
+++ b/site_icons_test.go
@@ -118,4 +118,45 @@ func TestUpdateSiteIconOnlyChangesIconMetadata(t *testing.T) {
 	if _, err := db.UpdateSiteIcon(site.ID, "", "https://cdn.example.test/emby.png"); err == nil {
 		t.Fatal("expected incomplete icon selection to be rejected")
 	}
+	if _, err := db.UpdateSiteIcon(site.ID, "Custom", "https://cdn.example.test/custom.png"); err == nil {
+		t.Fatal("unknown icon selection unexpectedly accepted")
+	}
+}
+
+func TestSiteEditPreservesIconAfterPackReplacement(t *testing.T) {
+	db, err := openDB(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	oldURL := "https://cdn.example.test/v1/emby.png"
+	newURL := "https://cdn.example.test/v2/emby.png"
+	if err := db.SaveSiteIconPack(SiteIconPack{Icons: []SiteIcon{{Name: "Emby", URL: oldURL}}}); err != nil {
+		t.Fatal(err)
+	}
+	site, err := db.CreateSiteRecord(Site{Name: "before", IconName: "Emby", IconURL: oldURL, ListenPort: 18097, IngressMode: ingressModePort, TargetURL: "http://127.0.0.1:8096", PlaybackMode: "direct", StreamHosts: "[]", UAMode: passthroughUAMode})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SaveSiteIconPack(SiteIconPack{Icons: []SiteIcon{{Name: "Emby", URL: newURL}}}); err != nil {
+		t.Fatal(err)
+	}
+	site.Name = "after"
+	if err := db.UpdateSiteRecord(*site); err != nil {
+		t.Fatalf("editing site after icon pack replacement: %v", err)
+	}
+	updated, err := db.GetSite(site.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Name != "after" || updated.IconName != "Emby" || updated.IconURL != oldURL {
+		t.Fatalf("site edit changed persisted icon: %#v", updated)
+	}
+	if _, err := db.UpdateSiteIcon(site.ID, "Emby", newURL); err != nil {
+		t.Fatalf("selecting replacement icon: %v", err)
+	}
+	updated, err = db.GetSite(site.ID)
+	if err != nil || updated.IconURL != newURL {
+		t.Fatalf("replacement icon not applied: %#v err=%v", updated, err)
+	}
 }

--- a/site_node_scheduler.go
+++ b/site_node_scheduler.go
@@ -46,6 +46,7 @@ type SiteNodeSchedule struct {
 	AgentRequestCount    int64  `json:"agent_request_count"`
 	AgentLastRequestAtMS int64  `json:"agent_last_request_at_ms"`
 	AgentLastStatus      int    `json:"agent_last_status"`
+	ConfigPendingSinceMS int64  `json:"config_pending_since_ms"`
 	UpdatedAtMS          int64  `json:"updated_at_ms"`
 	cfZoneID             string
 	cfRecordID           string
@@ -110,7 +111,7 @@ func scanSiteNodeSchedule(scanner interface{ Scan(...any) error }) (SiteNodeSche
 	err := scanner.Scan(&value.SiteID, &value.SiteName, &value.PublicHost, &enabled, &value.Mode, &fixed, &desired, &applied,
 		&value.cfZoneID, &value.cfRecordID, &value.cfRecordType, &value.AppliedAddress, &value.DNSStatus,
 		&value.ConfigHash, &value.LastError, &value.DesiredNodeName, &value.AppliedNodeName, &value.AppliedNodePort,
-		&value.AgentBootID, &value.AgentRequestCount, &value.AgentLastRequestAtMS, &value.AgentLastStatus, &value.UpdatedAtMS)
+		&value.AgentBootID, &value.AgentRequestCount, &value.AgentLastRequestAtMS, &value.AgentLastStatus, &value.ConfigPendingSinceMS, &value.UpdatedAtMS)
 	value.Enabled = enabled != 0
 	if fixed.Valid {
 		value.FixedNodeID = fixed.Int64
@@ -128,7 +129,7 @@ const siteNodeScheduleSelect = `SELECT s.id,s.name,s.public_host,COALESCE(n.enab
 	n.fixed_node_id,n.desired_node_id,n.applied_node_id,COALESCE(n.cf_zone_id,''),COALESCE(n.cf_record_id,''),
 	COALESCE(n.cf_record_type,''),COALESCE(n.applied_address,''),COALESCE(n.dns_status,'disabled'),
 	COALESCE(n.config_hash,''),COALESCE(n.last_error,''),COALESCE(d.name,''),COALESCE(an.name,''),COALESCE(an.https_port,0),
-	COALESCE(n.agent_boot_id,''),COALESCE(n.agent_request_count,0),COALESCE(n.agent_last_request_at_ms,0),COALESCE(n.agent_last_status,0),COALESCE(n.updated_at_ms,0)
+	COALESCE(n.agent_boot_id,''),COALESCE(n.agent_request_count,0),COALESCE(n.agent_last_request_at_ms,0),COALESCE(n.agent_last_status,0),COALESCE(n.config_pending_since_ms,0),COALESCE(n.updated_at_ms,0)
 	FROM sites s LEFT JOIN site_node_schedules n ON n.site_id=s.id
 	LEFT JOIN control_nodes d ON d.id=n.desired_node_id LEFT JOIN control_nodes an ON an.id=n.applied_node_id`
 
@@ -190,15 +191,38 @@ func (d *DB) SaveSiteNodeSchedule(siteID int64, enabled bool, mode string, fixed
 	} else if mode != "fixed" {
 		fixedNodeID = 0
 	}
+	var oldEnabled int
+	var oldMode string
+	var oldFixed sql.NullInt64
+	var oldPendingSince int64
+	lookupErr := d.db.QueryRow("SELECT enabled,mode,fixed_node_id,config_pending_since_ms FROM site_node_schedules WHERE site_id=?", siteID).
+		Scan(&oldEnabled, &oldMode, &oldFixed, &oldPendingSince)
+	if lookupErr != nil && !errors.Is(lookupErr, sql.ErrNoRows) {
+		return SiteNodeSchedule{}, lookupErr
+	}
+	pendingSince := int64(0)
+	if enabled {
+		pendingSince = now.UnixMilli()
+		oldFixedID := int64(0)
+		if oldFixed.Valid {
+			oldFixedID = oldFixed.Int64
+		}
+		if lookupErr == nil && oldEnabled != 0 && oldMode == mode && oldFixedID == fixedNodeID {
+			// Saving an unchanged form must not restart the configuration
+			// application deadline. Only a real assignment/config change starts it.
+			pendingSince = oldPendingSince
+		}
+	}
 	status := "disabled"
 	if enabled {
 		status = "pending"
 	}
 	_, err = d.db.Exec(`INSERT INTO site_node_schedules
-		(site_id,enabled,mode,fixed_node_id,dns_status,created_at_ms,updated_at_ms)
-		VALUES(?,?,?,?,?,?,?) ON CONFLICT(site_id) DO UPDATE SET enabled=excluded.enabled,mode=excluded.mode,
-		fixed_node_id=excluded.fixed_node_id,dns_status=excluded.dns_status,last_error='',updated_at_ms=excluded.updated_at_ms`,
-		siteID, sqliteBool(enabled), mode, nullableNodeID(fixedNodeID), status, now.UnixMilli(), now.UnixMilli())
+		(site_id,enabled,mode,fixed_node_id,dns_status,config_pending_since_ms,created_at_ms,updated_at_ms)
+		VALUES(?,?,?,?,?,?,?,?) ON CONFLICT(site_id) DO UPDATE SET enabled=excluded.enabled,mode=excluded.mode,
+		fixed_node_id=excluded.fixed_node_id,dns_status=excluded.dns_status,config_pending_since_ms=excluded.config_pending_since_ms,
+		last_error='',updated_at_ms=excluded.updated_at_ms`,
+		siteID, sqliteBool(enabled), mode, nullableNodeID(fixedNodeID), status, pendingSince, now.UnixMilli(), now.UnixMilli())
 	if err != nil {
 		return SiteNodeSchedule{}, err
 	}
@@ -354,9 +378,14 @@ func (a *App) refreshSiteAssignments(now time.Time) error {
 		if desired != value.DesiredNodeID {
 			status = "pending"
 		}
-		if desired != value.DesiredNodeID || status != value.DNSStatus || lastError != value.LastError {
-			if _, err := a.db.db.Exec(`UPDATE site_node_schedules SET desired_node_id=?,dns_status=?,last_error=?,updated_at_ms=? WHERE site_id=?`,
-				nullableNodeID(desired), status, lastError, now.UnixMilli(), value.SiteID); err != nil {
+		if desired != value.DesiredNodeID {
+			if _, err := a.db.db.Exec(`UPDATE site_node_schedules SET desired_node_id=?,dns_status=?,last_error=?,config_pending_since_ms=?,updated_at_ms=? WHERE site_id=?`,
+				nullableNodeID(desired), status, lastError, now.UnixMilli(), now.UnixMilli(), value.SiteID); err != nil {
+				return err
+			}
+		} else if status != value.DNSStatus || lastError != value.LastError {
+			if _, err := a.db.db.Exec(`UPDATE site_node_schedules SET dns_status=?,last_error=?,updated_at_ms=? WHERE site_id=?`,
+				status, lastError, now.UnixMilli(), value.SiteID); err != nil {
 				return err
 			}
 		}
@@ -745,7 +774,10 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 	if err != nil {
 		return AgentRuntimeConfig{}, err
 	}
-	_, err = a.db.db.Exec("UPDATE site_node_schedules SET config_hash=?,updated_at_ms=? WHERE enabled=1 AND desired_node_id=?", config.ConfigHash, now.UnixMilli(), node.ID)
+	_, err = a.db.db.Exec(`UPDATE site_node_schedules SET
+		config_pending_since_ms=CASE WHEN config_hash<>? THEN ? ELSE config_pending_since_ms END,
+		config_hash=?,updated_at_ms=? WHERE enabled=1 AND desired_node_id=?`,
+		config.ConfigHash, now.UnixMilli(), config.ConfigHash, now.UnixMilli(), node.ID)
 	return config, err
 }
 
@@ -1111,8 +1143,8 @@ func (a *App) reconcileSiteNodeScheduling(ctx context.Context) {
 				var schedulerMode string
 				if modeErr := a.db.db.QueryRow("SELECT mode FROM node_scheduler_settings WHERE id=1").Scan(&schedulerMode); modeErr == nil && schedulerMode == "auto" {
 					shouldCooldown := readiness.Kind == readinessCertificate || readiness.Kind == readinessListener || readiness.Kind == readinessProbe
-					if readiness.Kind == readinessConfig && value.UpdatedAtMS > 0 {
-						shouldCooldown = now.Sub(time.UnixMilli(value.UpdatedAtMS)) >= 90*time.Second
+					if readiness.Kind == readinessConfig && value.ConfigPendingSinceMS > 0 {
+						shouldCooldown = now.Sub(time.UnixMilli(value.ConfigPendingSinceMS)) >= 90*time.Second
 					}
 					if shouldCooldown {
 						if cooldownErr := a.db.recordSiteNodeProbeFailure(value.SiteID, value.DesiredNodeID, err, now); cooldownErr != nil {

--- a/site_repository.go
+++ b/site_repository.go
@@ -236,6 +236,16 @@ func (d *DB) CreateSiteRecord(site Site) (*Site, error) {
 	if err != nil {
 		return nil, err
 	}
+	if site.IconName != "" {
+		pack, packErr := d.SiteIconPack()
+		if packErr != nil {
+			return nil, packErr
+		}
+		site.IconName, site.IconURL, err = pack.validateNewSelection(site.IconName, site.IconURL)
+		if err != nil {
+			return nil, err
+		}
+	}
 	site.PrimaryLineName, err = normalizePrimaryLineName(site.PrimaryLineName)
 	if err != nil {
 		return nil, err
@@ -409,7 +419,7 @@ func (d *DB) UpdateSiteIcon(id int64, name, imageURL string) (*Site, error) {
 	if err != nil {
 		return nil, err
 	}
-	name, imageURL, err = pack.normalizeSelection(name, imageURL)
+	name, imageURL, err = pack.validateNewSelection(name, imageURL)
 	if err != nil {
 		return nil, err
 	}
@@ -437,6 +447,28 @@ func (d *DB) updateSiteRecord(site Site, restoreRevision bool) error {
 	site.IconName, site.IconURL, err = normalizeSiteIconSelection(site.IconName, site.IconURL)
 	if err != nil {
 		return err
+	}
+	// A normal site edit often round-trips the icon fields from an older pack.
+	// Preserve that exact persisted pair when it is unchanged, even if the
+	// current pack now contains the same name at a different URL. Only a new
+	// selection is checked against the current pack.
+	var storedIconName, storedIconURL string
+	iconLookupErr := d.db.QueryRow("SELECT icon_name,icon_url FROM sites WHERE id=?", site.ID).Scan(&storedIconName, &storedIconURL)
+	if iconLookupErr != nil && !errors.Is(iconLookupErr, sql.ErrNoRows) {
+		return iconLookupErr
+	}
+	unchangedIcon := iconLookupErr == nil && strings.EqualFold(strings.TrimSpace(site.IconName), strings.TrimSpace(storedIconName)) && site.IconURL == storedIconURL
+	if unchangedIcon {
+		site.IconName, site.IconURL = storedIconName, storedIconURL
+	} else if site.IconName != "" {
+		pack, packErr := d.SiteIconPack()
+		if packErr != nil {
+			return packErr
+		}
+		site.IconName, site.IconURL, err = pack.validateNewSelection(site.IconName, site.IconURL)
+		if err != nil {
+			return err
+		}
 	}
 	site.PrimaryLineName, err = normalizePrimaryLineName(site.PrimaryLineName)
 	if err != nil {


### PR DESCRIPTION
## Summary
- apply valid Agent runtime configuration even when release update metadata/download is temporarily unavailable
- bound Agent pre-auth concurrency to credential lookup and carry authenticated identity through request context
- inspect staged restore databases in place instead of copying them into system temp
- reject Probe Secret persistence when only an ephemeral JWT secret is available
- add a frozen v1.9.42 wire/hash compatibility regression test

## Validation
- go test ./...
- go test -race ./...
- go vet ./...