### PR TITLE
fix: gate scheduler cutover on site readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ docker compose logs -f meridian
 
 首次启动时日志会输出一次管理员初始化令牌。打开 `http://服务器地址:9090` 完成初始化。数据库、TLS 状态和缓存位于 `./data`，更新容器不会删除它们。`network_mode: host` 会让面板和站点端口直接使用宿主机网络，请先确认端口没有被其他服务占用。
 
-生产环境可以把 `latest` 换成固定版本，例如 `ghcr.io/chanhui800/meridian:v1.9.52`。固定版本便于回滚和排查问题。
+生产环境可以把 `latest` 换成固定版本，例如 `ghcr.io/chanhui800/meridian:v1.9.53`。固定版本便于回滚和排查问题。
 
 ### Linux 原生安装
 
 从固定 Release 安装（推荐）：
 
 ```bash
-VERSION=v1.9.52
+VERSION=v1.9.53
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL \

--- a/database_migrations.go
+++ b/database_migrations.go
@@ -19,7 +19,7 @@ const (
 	// databaseSchemaVersion is independent from the application and backup
 	// format versions. It is persisted in SQLite so restores can reject a
 	// database whose columns/state are newer than this binary understands.
-	databaseSchemaVersion = 31
+	databaseSchemaVersion = 32
 )
 
 func (d *DB) migrate() error {
@@ -727,6 +727,32 @@ func (d *DB) migrateOnce() error {
 			if _, err := conn.ExecContext(ctx, migration.sql); err != nil {
 				return err
 			}
+		}
+	}
+	// Schema 32 introduced the per-site configuration application deadline.
+	// Older databases have no reliable timestamp for schedules that were
+	// already waiting on an Agent, so start their cooldown during migration.
+	// Schedules whose hashes already agree remain ready and keep the zero value.
+	if previousSchemaVersion < 32 {
+		if _, err := conn.ExecContext(ctx, `
+			UPDATE site_node_schedules
+			SET config_pending_since_ms=?
+			WHERE enabled=1
+			  AND desired_node_id IS NOT NULL
+			  AND config_pending_since_ms=0
+			  AND EXISTS (
+				  SELECT 1
+				  FROM control_nodes n
+				  WHERE n.id=site_node_schedules.desired_node_id
+				    AND (
+					    site_node_schedules.config_hash=''
+					    OR n.desired_config_hash=''
+					    OR n.applied_config_hash<>n.desired_config_hash
+					    OR site_node_schedules.config_hash<>n.desired_config_hash
+				    )
+			  )
+		`, time.Now().UnixMilli()); err != nil {
+			return err
 		}
 	}
 	if _, err := conn.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS node_request_events (

--- a/node_repository_test.go
+++ b/node_repository_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -515,6 +516,132 @@ func TestAgentConfigPollingDoesNotResetPendingSince(t *testing.T) {
 	}
 	if clearedSchedule.ConfigPendingSinceMS != 0 {
 		t.Fatalf("applied config did not clear pending timer: %#v", clearedSchedule)
+	}
+}
+
+func TestSiteScheduleReadinessBlocksDNSUntilSiteConfigIsApplied(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Date(2026, 8, 30, 14, 30, 0, 0, time.UTC)
+	site, err := app.db.CreateSiteRecord(Site{
+		Name:        "site-readiness",
+		PublicHost:  "site-readiness.example.com",
+		IngressMode: ingressModeHost,
+		TargetURL:   "http://127.0.0.1:8096",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	node, _, err := app.db.CreateControlNode(NodeCreateInput{
+		Name:    "site-readiness-node",
+		Address: "203.0.113.45",
+		Port:    9090,
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.SaveSiteNodeSchedule(site.ID, true, "fixed", node.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec(`
+		UPDATE control_nodes
+		SET desired_config_hash=?, applied_config_hash=?
+		WHERE id=?`, "site-config-v1", "site-config-v1", node.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec(`
+		UPDATE site_node_schedules
+		SET desired_node_id=?, config_hash=?, config_pending_since_ms=?
+		WHERE site_id=?`, node.ID, "site-config-v1", now.UnixMilli(), site.ID); err != nil {
+		t.Fatal(err)
+	}
+	schedule, err := app.db.siteNodeSchedule(site.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = app.reconcileOneSiteSchedule(context.Background(), schedule, now)
+	var readiness *nodeReadinessError
+	if !errors.As(err, &readiness) || readiness.Kind != readinessConfig {
+		t.Fatalf("reconcile error = %v, want config readiness error", err)
+	}
+	if !strings.Contains(err.Error(), "site configuration") {
+		t.Fatalf("reconcile error = %q, want site configuration detail", err)
+	}
+}
+
+func TestSchema32BackfillsPendingSiteConfigurationTimers(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Date(2026, 8, 30, 15, 0, 0, 0, time.UTC)
+	stableNode, _, err := app.db.CreateControlNode(NodeCreateInput{Name: "stable-schema-node", Address: "203.0.113.46"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pendingNode, _, err := app.db.CreateControlNode(NodeCreateInput{Name: "pending-schema-node", Address: "203.0.113.47"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stableSite, err := app.db.CreateSiteRecord(Site{Name: "stable-schema-site", ListenPort: freePort(t), PublicHost: "stable-schema.example.com", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:8096"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pendingSite, err := app.db.CreateSiteRecord(Site{Name: "pending-schema-site", ListenPort: freePort(t), PublicHost: "pending-schema.example.com", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:8096"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, item := range []struct {
+		nodeID int64
+		siteID int64
+		hash   string
+	}{
+		{stableNode.ID, stableSite.ID, "stable-config"},
+		{pendingNode.ID, pendingSite.ID, "pending-config"},
+	} {
+		if _, err := app.db.SaveSiteNodeSchedule(item.siteID, true, "fixed", item.nodeID, now); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := app.db.db.Exec(`
+			UPDATE site_node_schedules
+			SET desired_node_id=?, config_hash=?, config_pending_since_ms=0
+			WHERE site_id=?`, item.nodeID, item.hash, item.siteID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := app.db.db.Exec(`
+		UPDATE control_nodes
+		SET desired_config_hash=?, applied_config_hash=?
+		WHERE id=?`, "stable-config", "stable-config", stableNode.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec(`
+		UPDATE control_nodes
+		SET desired_config_hash=?, applied_config_hash=?
+		WHERE id=?`, "pending-config", "old-config", pendingNode.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec("PRAGMA user_version = 31"); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.db.migrate(); err != nil {
+		t.Fatalf("schema 32 migration: %v", err)
+	}
+	var stablePending, pendingSince int64
+	if err := app.db.db.QueryRow("SELECT config_pending_since_ms FROM site_node_schedules WHERE site_id=?", stableSite.ID).Scan(&stablePending); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.db.db.QueryRow("SELECT config_pending_since_ms FROM site_node_schedules WHERE site_id=?", pendingSite.ID).Scan(&pendingSince); err != nil {
+		t.Fatal(err)
+	}
+	if stablePending != 0 {
+		t.Fatalf("stable schedule pending_since=%d, want 0", stablePending)
+	}
+	if pendingSince <= 0 {
+		t.Fatalf("inconsistent schedule pending_since=%d, want migration timestamp", pendingSince)
+	}
+	var schemaVersion int
+	if err := app.db.db.QueryRow("PRAGMA user_version").Scan(&schemaVersion); err != nil {
+		t.Fatal(err)
+	}
+	if schemaVersion != 32 {
+		t.Fatalf("schema version=%d, want 32", schemaVersion)
 	}
 }
 

--- a/site_node_scheduler.go
+++ b/site_node_scheduler.go
@@ -264,6 +264,22 @@ func readinessError(kind string, err error) error {
 	return &nodeReadinessError{Kind: kind, Err: err}
 }
 
+// siteScheduleConfigReady keeps DNS cutover tied to the route that is about
+// to receive traffic. A node-level hash can still match while a newly moved
+// site is waiting for the Agent to fetch and apply its next configuration.
+func siteScheduleConfigReady(schedule SiteNodeSchedule, node ControlNode) bool {
+	if schedule.ConfigPendingSinceMS > 0 {
+		return false
+	}
+	scheduleHash := strings.TrimSpace(schedule.ConfigHash)
+	desiredHash := strings.TrimSpace(node.DesiredConfigHash)
+	appliedHash := strings.TrimSpace(node.AppliedConfigHash)
+	if scheduleHash == "" || desiredHash == "" || appliedHash == "" {
+		return false
+	}
+	return scheduleHash == desiredHash && scheduleHash == appliedHash
+}
+
 func (d *DB) siteNodeProbeCooldowns(siteID int64, now time.Time) (map[int64]bool, error) {
 	rows, err := d.db.Query("SELECT node_id FROM site_node_probe_failures WHERE site_id=? AND failed_until_ms>?", siteID, now.UnixMilli())
 	if err != nil {
@@ -1050,6 +1066,9 @@ func (a *App) reconcileOneSiteSchedule(ctx context.Context, schedule SiteNodeSch
 	if err != nil {
 		return readinessError(readinessListener, err)
 	}
+	if !siteScheduleConfigReady(schedule, node) {
+		return readinessError(readinessConfig, errors.New("Agent has not applied the site configuration"))
+	}
 	if a.panelCertificates == nil {
 		return readinessError(readinessCertificate, errors.New("edge TLS certificate is unavailable"))
 	}
@@ -1059,9 +1078,6 @@ func (a *App) reconcileOneSiteSchedule(ctx context.Context, schedule SiteNodeSch
 	}
 	if err := certificateCoversHost(edgeCertFile, schedule.PublicHost); err != nil {
 		return readinessError(readinessCertificate, err)
-	}
-	if node.DesiredConfigHash == "" || node.AppliedConfigHash != node.DesiredConfigHash {
-		return readinessError(readinessConfig, errors.New("Agent has not applied the desired configuration"))
 	}
 	if node.AgentListenerError != "" {
 		return readinessError(readinessListener, errors.New(node.AgentListenerError))


### PR DESCRIPTION
## 变更
- 以站点级 ConfigHash、节点 Desired/Applied hash 和 pending timer 共同作为 DNS 切换前置条件，避免节点迁移时过早切流。
- 将数据库 schema 升到 32，并为旧库中未一致的启用调度回填 config_pending_since_ms。
- 增加站点级 readiness 与 schema migration 回归测试。
- 更新 README 固定版本示例到 v1.9.53。

## 验证
- go test ./...
- go test -race ./...
- go vet ./...
- node --test tests/*.test.js
