### PR TITLE
fix: restore Agent media library telemetry

### DIFF
--- a/edge_agent.go
+++ b/edge_agent.go
@@ -568,6 +568,37 @@ type edgeTelemetryEvent struct {
 	Observation dynamicObservationEvent
 }
 
+// edgeTelemetryEventSiteID converts the ephemeral site ID used by the
+// Agent's in-memory proxy database back to the stable Controller site ID.
+// Runtime routes are rebuilt from every config apply, so their local
+// auto-increment IDs must never cross the Agent report boundary.
+func edgeTelemetryEventSiteID(event edgeTelemetryEvent, localSites map[int64]edgeSiteIdentity) (edgeTelemetryEvent, bool) {
+	var localID int64
+	switch event.Kind {
+	case "media_counts":
+		localID = event.Media.SiteID
+	case "retention":
+		localID = event.Retention.SiteID
+	case "observation":
+		localID = event.Observation.SiteID
+	default:
+		return event, false
+	}
+	identity, ok := localSites[localID]
+	if !ok || identity.centralID <= 0 {
+		return event, false
+	}
+	switch event.Kind {
+	case "media_counts":
+		event.Media.SiteID = identity.centralID
+	case "retention":
+		event.Retention.SiteID = identity.centralID
+	case "observation":
+		event.Observation.SiteID = identity.centralID
+	}
+	return event, true
+}
+
 func (runtime *edgeAgentRuntime) recordTelemetry(event edgeTelemetryEvent) {
 	if runtime == nil {
 		return
@@ -901,8 +932,14 @@ func buildEdgeProxy(config AgentRuntimeConfig, runtime *edgeAgentRuntime) (*edge
 		return nil, err
 	}
 	database.edgeEphemeral = true
-	database.edgeTelemetrySink = runtime.recordTelemetry
 	bundle := &edgeProxyBundle{database: database, localSites: make(map[int64]edgeSiteIdentity)}
+	database.edgeTelemetrySink = func(event edgeTelemetryEvent) {
+		mapped, ok := edgeTelemetryEventSiteID(event, bundle.localSites)
+		if !ok {
+			return
+		}
+		runtime.recordTelemetry(mapped)
+	}
 	fail := func(err error) (*edgeProxyBundle, error) {
 		bundle.close()
 		return nil, err

--- a/edge_agent_test.go
+++ b/edge_agent_test.go
@@ -91,6 +91,48 @@ func TestBuildEdgeProxyIgnoresControllerOnlySiteIconMetadata(t *testing.T) {
 	bundle.close()
 }
 
+func TestEdgeProxyReportsMediaCountsWithCentralSiteID(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !isMediaLibraryCountsPath(r.URL.Path) {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"MovieCount":12,"SeriesCount":34,"EpisodeCount":56}`)
+	}))
+	defer upstream.Close()
+	runtime := &edgeAgentRuntime{stateDir: t.TempDir()}
+	config := AgentRuntimeConfig{
+		SchemaVersion: 1, NodeGUID: "media-count-node", HTTPSPort: 19090, DynamicKey: testEdgeRuntimeKey(t),
+		Routes: []AgentSiteRoute{{
+			SiteID: 73, Host: "counts.example.test", TargetURL: upstream.URL,
+			Site: Site{
+				Name: "counts", PublicHost: "counts.example.test", IngressMode: ingressModeHost,
+				TargetURL: upstream.URL, PlaybackMode: "direct", MainVideoStreamMode: "proxy",
+				StreamHosts: "[]", UAMode: passthroughUAMode, ClientIPMode: clientIPModeBoth,
+			},
+			FailoverTargets: "[]", StreamHostsRaw: "[]", DynamicSources: "[]", DynamicRules: "[]",
+		}},
+	}
+	bundle, err := buildEdgeProxy(config, runtime)
+	if err != nil {
+		t.Fatalf("build edge proxy: %v", err)
+	}
+	defer bundle.close()
+	response := httptest.NewRecorder()
+	bundle.handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "https://counts.example.test/Items/Counts", nil))
+	if response.Code != http.StatusOK || response.Body.String() != `{"MovieCount":12,"SeriesCount":34,"EpisodeCount":56}` {
+		t.Fatalf("media count response = %d %q", response.Code, response.Body.String())
+	}
+	media, _, _ := runtime.telemetrySnapshot()
+	if len(media) != 1 {
+		t.Fatalf("media telemetry = %#v, want one event", media)
+	}
+	if media[0].SiteID != 73 || media[0].MovieCount != 12 || media[0].SeriesCount != 34 || media[0].EpisodeCount != 56 {
+		t.Fatalf("media telemetry = %#v, want central site 73 with counts", media[0])
+	}
+}
+
 func TestEdgeEventSpoolUsesIndependentKeyAcrossReenrollment(t *testing.T) {
 	dir := t.TempDir()
 	key := make([]byte, 32)

--- a/tests/sites_ingress_mode.test.js
+++ b/tests/sites_ingress_mode.test.js
@@ -227,7 +227,9 @@ test('site identity icons stay circular and transparent in cards and dashboard r
   assert.match(css, /\.dashboard-site-identity\s*\{[\s\S]*?justify-content:\s*center;/);
   assert.match(css, /\.dashboard-site-identity\s*\{[\s\S]*?display:\s*grid;[\s\S]*?grid-template-columns:\s*54px\s+minmax\(0,\s*1fr\);/);
   assert.match(css, /\.dashboard-site-identity \.dashboard-site-icon\s*\{[\s\S]*?justify-self:\s*center;/);
-  assert.match(css, /\.dashboard-site-status table th:first-child,[\s\S]*?\.dashboard-site-status table td:first-child\s*\{[\s\S]*?text-align:\s*center;/);
+  assert.match(dashboard, /dashboard-site-column-heading[\s\S]*?站点/);
+  assert.match(css, /\.dashboard-site-column-heading\s*\{[\s\S]*?display:\s*grid;[\s\S]*?grid-template-columns:\s*54px\s+minmax\(0,\s*1fr\);[\s\S]*?gap:\s*12px;/);
+  assert.match(css, /\.dashboard-site-status table th:first-child,[\s\S]*?\.dashboard-site-status table td:first-child\s*\{[\s\S]*?text-align:\s*left;/);
   assert.match(css, /\.dashboard-site-identity \.dashboard-site-icon\s*\{[\s\S]*?width:\s*42px;[\s\S]*?background:\s*transparent;/);
   assert.match(css, /\.dashboard-site-status table\s*\{[\s\S]*?min-width:\s*980px;[\s\S]*?table-layout:\s*auto;/);
   assert.match(css, /\.dashboard-site-status table th:first-child,[\s\S]*?\.dashboard-site-status table td:first-child\s*\{[\s\S]*?min-width:\s*210px;/);

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -7456,11 +7456,24 @@ html[data-theme="light"] .page:not(#page-watch-history) .account-session-card h2
   line-height: 1.2;
 }
 
-/* Keep the first column heading aligned with the centered icon/name group
-   beneath it. Other dashboard table columns retain their default alignment. */
+/* Keep the first column heading aligned with the site name track beneath it.
+   The empty first track mirrors the circular icon so the heading does not
+   drift toward the middle of the widened mobile column. */
+.dashboard-site-column-heading {
+  display: grid;
+  grid-template-columns: 54px minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  text-align: left;
+}
+.dashboard-site-column-heading > span:first-child {
+  display: block;
+  width: 54px;
+  height: 1px;
+}
 .dashboard-site-status table th:first-child,
 .dashboard-site-status table td:first-child {
-  text-align: center;
+  text-align: left;
 }
 
 @media (max-width: 768px) {

--- a/web/static/js/pages/dashboard.js
+++ b/web/static/js/pages/dashboard.js
@@ -106,7 +106,7 @@ function renderDashboard() {
       <div style="overflow-x:auto">
         <table>
           <thead><tr>
-            <th>站点</th><th>状态</th><th>回源地址</th><th>UA 模式</th><th>入口</th><th>实时网速</th><th>已用流量</th><th>缓存大小</th>
+            <th><span class="dashboard-site-column-heading"><span aria-hidden="true"></span><span>站点</span></span></th><th>状态</th><th>回源地址</th><th>UA 模式</th><th>入口</th><th>实时网速</th><th>已用流量</th><th>缓存大小</th>
           </tr></thead>
           <tbody id="dash-table"></tbody>
         </table>


### PR DESCRIPTION
## What changed

- Map Agent media counts, retention updates, and dynamic observations from ephemeral edge site IDs back to stable Controller site IDs before reporting.
- Drop unknown local telemetry IDs instead of allowing them to cross the Agent report boundary.
- Align the dashboard site heading with the icon/name identity grid on narrow screens.
- Add a regression test covering `/Items/Counts` through the real edge proxy path.

## Validation

- `go test ./...`
- `go test -race ./...`
- `node --test tests/*.test.js`
- `git diff --check`
