### PR TITLE
fix: stabilize scheduler config convergence and certificate queue

### DIFF
--- a/certificate_worker.go
+++ b/certificate_worker.go
@@ -21,10 +21,12 @@ type certificateWorker struct {
 	manager *panelCertificateManager
 	ctx     context.Context
 	cancel  context.CancelFunc
-	jobs    chan certificateJob
 	wg      sync.WaitGroup
 	mu      sync.Mutex
-	pending map[int64]int
+	pending map[int64]certificateJob
+	running map[int64]struct{}
+	retry   map[int64]struct{}
+	wake    chan struct{}
 }
 
 var certificateRetryDelays = []time.Duration{time.Minute, 5 * time.Minute, 15 * time.Minute, time.Hour}
@@ -34,7 +36,13 @@ func newCertificateWorker(parent context.Context, db *DB, manager *panelCertific
 		return nil
 	}
 	ctx, cancel := context.WithCancel(parent)
-	w := &certificateWorker{db: db, manager: manager, ctx: ctx, cancel: cancel, jobs: make(chan certificateJob, 64), pending: make(map[int64]int)}
+	w := &certificateWorker{
+		db: db, manager: manager, ctx: ctx, cancel: cancel,
+		pending: make(map[int64]certificateJob),
+		running: make(map[int64]struct{}),
+		retry:   make(map[int64]struct{}),
+		wake:    make(chan struct{}, 1),
+	}
 	w.wg.Add(1)
 	go w.run()
 	return w
@@ -49,26 +57,51 @@ func (w *certificateWorker) enqueue(nodeID int64) {
 		w.mu.Unlock()
 		return
 	}
-	w.pending[nodeID] = 0
+	if _, exists := w.running[nodeID]; exists {
+		w.mu.Unlock()
+		return
+	}
+	if _, exists := w.retry[nodeID]; exists {
+		w.mu.Unlock()
+		return
+	}
+	w.pending[nodeID] = certificateJob{nodeID: nodeID}
 	w.mu.Unlock()
-	w.queue(certificateJob{nodeID: nodeID})
+	w.signal()
 }
 
-// queue never blocks the caller. Enrollment must remain a fast operation even
-// when a large fleet has filled the bounded ACME work queue; the job stays in
-// pending and is retried once capacity is available.
+// queue schedules a retry without recursively creating short-lived timers.
+// The worker keeps one pending job per node and wakes its single consumer when
+// the retry becomes due. This prevents a full queue from creating a timer storm
+// during large enrollments or an ACME outage.
 func (w *certificateWorker) queue(job certificateJob) {
 	if w == nil {
 		return
 	}
-	select {
-	case w.jobs <- job:
-	case <-w.ctx.Done():
-		w.mu.Lock()
-		delete(w.pending, job.nodeID)
+	if w.ctx.Err() != nil {
+		return
+	}
+	w.mu.Lock()
+	if _, exists := w.running[job.nodeID]; exists {
 		w.mu.Unlock()
+		return
+	}
+	if existing, exists := w.pending[job.nodeID]; exists && existing.attempt >= job.attempt {
+		w.mu.Unlock()
+		return
+	}
+	w.pending[job.nodeID] = job
+	w.mu.Unlock()
+	w.signal()
+}
+
+func (w *certificateWorker) signal() {
+	if w == nil {
+		return
+	}
+	select {
+	case w.wake <- struct{}{}:
 	default:
-		time.AfterFunc(250*time.Millisecond, func() { w.queue(job) })
 	}
 }
 
@@ -76,12 +109,29 @@ func (w *certificateWorker) run() {
 	defer w.wg.Done()
 	for {
 		select {
-		case job := <-w.jobs:
-			w.process(job)
+		case <-w.wake:
+			for {
+				job, ok := w.takePending()
+				if !ok {
+					break
+				}
+				w.process(job)
+			}
 		case <-w.ctx.Done():
 			return
 		}
 	}
+}
+
+func (w *certificateWorker) takePending() (certificateJob, bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for nodeID, job := range w.pending {
+		delete(w.pending, nodeID)
+		w.running[nodeID] = struct{}{}
+		return job, true
+	}
+	return certificateJob{}, false
 }
 
 func (w *certificateWorker) process(job certificateJob) {
@@ -93,13 +143,13 @@ func (w *certificateWorker) process(job certificateJob) {
 	}
 	if err == nil {
 		w.mu.Lock()
-		delete(w.pending, job.nodeID)
+		delete(w.running, job.nodeID)
 		w.mu.Unlock()
 		return
 	}
 	if job.attempt >= len(certificateRetryDelays) {
 		w.mu.Lock()
-		delete(w.pending, job.nodeID)
+		delete(w.running, job.nodeID)
 		w.mu.Unlock()
 		log.Printf("[edge-certificate] node %d provisioning failed after retries: %v", job.nodeID, err)
 		return
@@ -107,7 +157,14 @@ func (w *certificateWorker) process(job certificateJob) {
 	delay := certificateRetryDelays[job.attempt]
 	next := certificateJob{nodeID: job.nodeID, attempt: job.attempt + 1}
 	log.Printf("[edge-certificate] node %d provisioning failed: %v; retrying in %s", job.nodeID, err, delay)
+	w.mu.Lock()
+	delete(w.running, job.nodeID)
+	w.retry[job.nodeID] = struct{}{}
+	w.mu.Unlock()
 	time.AfterFunc(delay, func() {
+		w.mu.Lock()
+		delete(w.retry, next.nodeID)
+		w.mu.Unlock()
 		w.queue(next)
 	})
 }

--- a/certificate_worker_test.go
+++ b/certificate_worker_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCertificateWorkerDeduplicatesPendingAndRunningJobs(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w := &certificateWorker{
+		ctx:     ctx,
+		pending: make(map[int64]certificateJob),
+		running: make(map[int64]struct{}),
+		retry:   make(map[int64]struct{}),
+		wake:    make(chan struct{}, 1),
+	}
+
+	w.enqueue(17)
+	w.enqueue(17)
+	if len(w.pending) != 1 {
+		t.Fatalf("pending jobs=%d, want one deduplicated job", len(w.pending))
+	}
+	job, ok := w.takePending()
+	if !ok || job.nodeID != 17 {
+		t.Fatalf("takePending=%#v, ok=%t", job, ok)
+	}
+	w.enqueue(17)
+	if len(w.pending) != 0 {
+		t.Fatal("running node accepted a duplicate job")
+	}
+
+	w.mu.Lock()
+	delete(w.running, 17)
+	w.mu.Unlock()
+	w.queue(certificateJob{nodeID: 17, attempt: 1})
+	w.queue(certificateJob{nodeID: 17, attempt: 1})
+	if got := w.pending[17].attempt; got != 1 || len(w.pending) != 1 {
+		t.Fatalf("retry pending=%#v, want one attempt-1 job", w.pending)
+	}
+}
+
+func TestCertificateWorkerQueueDoesNotCreateOverflowTimers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w := &certificateWorker{
+		ctx:     ctx,
+		pending: make(map[int64]certificateJob),
+		running: make(map[int64]struct{}),
+		retry:   make(map[int64]struct{}),
+		wake:    make(chan struct{}, 1),
+	}
+
+	for nodeID := int64(1); nodeID <= 1000; nodeID++ {
+		w.queue(certificateJob{nodeID: nodeID})
+	}
+	if len(w.pending) != 1000 {
+		t.Fatalf("pending jobs=%d, want 1000", len(w.pending))
+	}
+	select {
+	case <-w.wake:
+	default:
+		t.Fatal("queue did not wake the worker")
+	}
+	select {
+	case <-w.wake:
+		t.Fatal("duplicate queue operations created extra wake work")
+	default:
+	}
+}

--- a/edge_agent_test.go
+++ b/edge_agent_test.go
@@ -133,6 +133,33 @@ func TestEdgeProxyReportsMediaCountsWithCentralSiteID(t *testing.T) {
 	}
 }
 
+func TestEdgeTelemetryMapsRetentionAndObservationToCentralSiteID(t *testing.T) {
+	localSites := map[int64]edgeSiteIdentity{
+		3: {centralID: 91, host: "mapped.example.test"},
+	}
+	retention, ok := edgeTelemetryEventSiteID(edgeTelemetryEvent{
+		Kind:      "retention",
+		Retention: accountRetentionCompletionEvent{SiteID: 3, ExpectedStartedAtMS: 10, CompletedAtMS: 20},
+	}, localSites)
+	if !ok || retention.Retention.SiteID != 91 {
+		t.Fatalf("retention mapping = %#v, ok=%t", retention.Retention, ok)
+	}
+	observation, ok := edgeTelemetryEventSiteID(edgeTelemetryEvent{
+		Kind:        "observation",
+		Observation: dynamicObservationEvent{SiteID: 3, CanonicalAuthority: "mapped.example.test", Source: dynamicObservationSourceHLS, Decision: "allow", ReasonCode: dynamicObservationReasonCandidateAllowed},
+	}, localSites)
+	if !ok || observation.Observation.SiteID != 91 {
+		t.Fatalf("observation mapping = %#v, ok=%t", observation.Observation, ok)
+	}
+}
+
+func TestEdgeTelemetryDropsUnknownLocalSiteID(t *testing.T) {
+	event := edgeTelemetryEvent{Kind: "retention", Retention: accountRetentionCompletionEvent{SiteID: 404}}
+	if _, ok := edgeTelemetryEventSiteID(event, map[int64]edgeSiteIdentity{3: {centralID: 91}}); ok {
+		t.Fatal("unknown local site ID was accepted")
+	}
+}
+
 func TestEdgeEventSpoolUsesIndependentKeyAcrossReenrollment(t *testing.T) {
 	dir := t.TempDir()
 	key := make([]byte, 32)

--- a/node_repository.go
+++ b/node_repository.go
@@ -591,19 +591,37 @@ func (d *DB) UpdateControlNode(id int64, input NodeCreateInput, enabled bool, no
 	if err != nil {
 		return ControlNode{}, err
 	}
-	current, err := d.controlNodeByID(id, now)
+	// Read the timezone before opening the write transaction. The database is
+	// intentionally configured with a single SQLite connection, so issuing a
+	// nested query while the transaction is open would deadlock.
+	scheduleTimezone := d.currentSystemSettings().ScheduleTimezone
+	tx, err := d.db.Begin()
 	if err != nil {
 		return ControlNode{}, err
 	}
+	defer tx.Rollback()
+	var currentAddress string
+	var currentPort, currentResetDay int
+	if err := tx.QueryRow("SELECT address,https_port,reset_day FROM control_nodes WHERE id=?", id).Scan(&currentAddress, &currentPort, &currentResetDay); errors.Is(err, sql.ErrNoRows) {
+		return ControlNode{}, errNodeNotFound
+	} else if err != nil {
+		return ControlNode{}, err
+	}
+
+	// Address and HTTPS port are part of the Agent's runtime reachability.
+	// Changing either one must invalidate the applied config before the next
+	// scheduler reconciliation; otherwise the scheduler can probe an old
+	// endpoint while the node still advertises the old config hash.
+	runtimeChanged := strings.TrimSpace(currentAddress) != strings.TrimSpace(input.Address) || currentPort != input.Port
 	var result sql.Result
-	if current.ResetDay != input.ResetDay {
-		cycleStart := nodeCycleStart(now, input.ResetDay, d.currentSystemSettings().ScheduleTimezone)
-		result, err = d.db.Exec(`UPDATE control_nodes SET name=?,address=?,entry_mode='direct',http_port=0,https_port=?,enabled=?,priority=?,traffic_quota=?,billing_mode=?,reset_day=?,traffic_manual_offset_bytes=?,
-			cycle_started_at_ms=?,period_rx_bytes=0,period_tx_bytes=0,updated_at_ms=? WHERE id=?`, input.Name, input.Address,
-			input.Port, sqliteBool(enabled), input.Priority, input.TrafficQuota, input.BillingMode, input.ResetDay, input.TrafficManualOffsetBytes, cycleStart, now.UnixMilli(), id)
+	if currentResetDay != input.ResetDay {
+		cycleStart := nodeCycleStart(now, input.ResetDay, scheduleTimezone)
+		result, err = tx.Exec(`UPDATE control_nodes SET name=?,address=?,entry_mode='direct',http_port=0,https_port=?,enabled=?,priority=?,traffic_quota=?,billing_mode=?,reset_day=?,traffic_manual_offset_bytes=?,
+			cycle_started_at_ms=?,period_rx_bytes=0,period_tx_bytes=0,desired_config_hash=CASE WHEN ? THEN '' ELSE desired_config_hash END,updated_at_ms=? WHERE id=?`, input.Name, input.Address,
+			input.Port, sqliteBool(enabled), input.Priority, input.TrafficQuota, input.BillingMode, input.ResetDay, input.TrafficManualOffsetBytes, cycleStart, sqliteBool(runtimeChanged), now.UnixMilli(), id)
 	} else {
-		result, err = d.db.Exec(`UPDATE control_nodes SET name=?,address=?,entry_mode='direct',http_port=0,https_port=?,enabled=?,priority=?,traffic_quota=?,billing_mode=?,traffic_manual_offset_bytes=?,updated_at_ms=? WHERE id=?`,
-			input.Name, input.Address, input.Port, sqliteBool(enabled), input.Priority, input.TrafficQuota, input.BillingMode, input.TrafficManualOffsetBytes, now.UnixMilli(), id)
+		result, err = tx.Exec(`UPDATE control_nodes SET name=?,address=?,entry_mode='direct',http_port=0,https_port=?,enabled=?,priority=?,traffic_quota=?,billing_mode=?,traffic_manual_offset_bytes=?,desired_config_hash=CASE WHEN ? THEN '' ELSE desired_config_hash END,updated_at_ms=? WHERE id=?`,
+			input.Name, input.Address, input.Port, sqliteBool(enabled), input.Priority, input.TrafficQuota, input.BillingMode, input.TrafficManualOffsetBytes, sqliteBool(runtimeChanged), now.UnixMilli(), id)
 	}
 	if err != nil {
 		if isSQLiteUniqueConstraintError(err) {
@@ -617,6 +635,18 @@ func (d *DB) UpdateControlNode(id int64, input NodeCreateInput, enabled bool, no
 	}
 	if rows != 1 {
 		return ControlNode{}, errNodeNotFound
+	}
+	if runtimeChanged {
+		if _, err := tx.Exec(`UPDATE site_node_schedules SET
+			config_hash='',
+			config_pending_since_ms=CASE WHEN enabled=1 THEN ? ELSE 0 END,
+			updated_at_ms=?
+			WHERE desired_node_id=? OR applied_node_id=?`, now.UnixMilli(), now.UnixMilli(), id, id); err != nil {
+			return ControlNode{}, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return ControlNode{}, err
 	}
 	return d.controlNodeByID(id, now)
 }
@@ -1200,9 +1230,24 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 		strings.TrimSpace(report.InterfaceName), strings.TrimSpace(report.AgentVersion), strings.TrimSpace(report.AppliedConfigHash), applyError, applyErrorAtMS, applyFailures, strings.TrimSpace(report.ListenerError), strings.TrimSpace(report.EventSpoolError), report.EventQueueDepth, report.EventDropped, report.CacheClearGeneration, report.CacheClearGeneration, cacheClearGeneration, report.CacheClearGeneration, now.UnixMilli(), now.UnixMilli(), id); err != nil {
 		return nodeReportCommitResult{}, err
 	}
-	if appliedHash := strings.TrimSpace(report.AppliedConfigHash); appliedHash != "" && appliedHash == strings.TrimSpace(desiredConfigHash) {
-		if _, err := tx.Exec(`UPDATE site_node_schedules SET config_pending_since_ms=0
-			WHERE enabled=1 AND desired_node_id=? AND config_hash=? AND config_pending_since_ms>0`, id, appliedHash); err != nil {
+	// A cold-started Agent may report before it has successfully applied the
+	// desired runtime config. Start the scheduler's pending clock from that
+	// report even when the config hash itself did not change (for example after
+	// an Agent process restart). Without this, a persistent apply failure leaves
+	// config_pending_since_ms at zero and the automatic failover cooldown can
+	// never begin.
+	appliedHash := strings.TrimSpace(report.AppliedConfigHash)
+	desiredHash := strings.TrimSpace(desiredConfigHash)
+	if desiredHash != "" && appliedHash != desiredHash {
+		if _, err := tx.Exec(`UPDATE site_node_schedules SET
+			config_pending_since_ms=CASE WHEN config_pending_since_ms=0 THEN ? ELSE config_pending_since_ms END,
+			updated_at_ms=CASE WHEN config_pending_since_ms=0 THEN ? ELSE updated_at_ms END
+			WHERE enabled=1 AND desired_node_id=? AND config_hash=?`, now.UnixMilli(), now.UnixMilli(), id, desiredHash); err != nil {
+			return nodeReportCommitResult{}, err
+		}
+	} else if appliedHash != "" && appliedHash == desiredHash {
+		if _, err := tx.Exec(`UPDATE site_node_schedules SET config_pending_since_ms=0,updated_at_ms=?
+			WHERE enabled=1 AND desired_node_id=? AND config_hash=? AND config_pending_since_ms>0`, now.UnixMilli(), id, appliedHash); err != nil {
 			return nodeReportCommitResult{}, err
 		}
 	}

--- a/node_repository_test.go
+++ b/node_repository_test.go
@@ -88,6 +88,48 @@ func TestControlNodeEnrollmentTrafficAndDelete(t *testing.T) {
 	}
 }
 
+func TestUpdateControlNodePortInvalidatesRuntimeConfig(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Date(2026, 8, 30, 12, 30, 0, 0, time.UTC)
+	node, _, err := app.db.CreateControlNode(NodeCreateInput{Name: "runtime-node", Address: "203.0.113.152", Port: 9090}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "runtime-site", PublicHost: "runtime.example.com", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:8096"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.SaveSiteNodeSchedule(site.ID, true, "fixed", node.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	const appliedHash = "runtime-config-v1"
+	if _, err := app.db.db.Exec(`UPDATE control_nodes SET desired_config_hash=?,applied_config_hash=? WHERE id=?`, appliedHash, appliedHash, node.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec(`UPDATE site_node_schedules SET desired_node_id=?,applied_node_id=?,config_hash=?,config_pending_since_ms=0 WHERE site_id=?`, node.ID, node.ID, appliedHash, site.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	updated, err := app.db.UpdateControlNode(node.ID, NodeCreateInput{
+		Name: node.Name, Address: node.Address, Port: 9091, Priority: node.Priority,
+		TrafficQuota: node.TrafficQuota, BillingMode: node.BillingMode, ResetDay: node.ResetDay,
+		TrafficManualOffsetBytes: node.TrafficManualOffset,
+	}, true, now.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.DesiredConfigHash != "" {
+		t.Fatalf("port change left desired config hash=%q", updated.DesiredConfigHash)
+	}
+	schedule, err := app.db.siteNodeSchedule(site.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if schedule.ConfigHash != "" || schedule.ConfigPendingSinceMS != now.Add(time.Second).UnixMilli() {
+		t.Fatalf("port change did not invalidate schedule: %#v", schedule)
+	}
+}
+
 func TestRecordNodeReportPersistsAndClearsApplyError(t *testing.T) {
 	app := newTestApp(t)
 	now := time.Now().UTC()
@@ -564,6 +606,58 @@ func TestAgentConfigPollingDoesNotResetPendingSince(t *testing.T) {
 	}
 	if clearedSchedule.ConfigPendingSinceMS != 0 {
 		t.Fatalf("applied config did not clear pending timer: %#v", clearedSchedule)
+	}
+}
+
+func TestAgentColdStartMismatchStartsPendingConfigTimer(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Date(2026, 8, 30, 14, 15, 0, 0, time.UTC)
+	node, enrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "cold-start-node", Address: "203.0.113.151", Port: 9090}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, token, err := app.db.EnrollControlNode(enrollment, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "cold-start-site", PublicHost: "cold-start.example.com", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:8096"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.SaveSiteNodeSchedule(site.ID, true, "fixed", node.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	const desiredHash = "cold-start-config-v1"
+	if _, err := app.db.db.Exec(`UPDATE control_nodes SET desired_config_hash=?,applied_config_hash='' WHERE id=?`, desiredHash, node.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec(`UPDATE site_node_schedules SET desired_node_id=?,config_hash=?,config_pending_since_ms=0 WHERE site_id=?`, node.ID, desiredHash, site.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	// The Agent has restarted and has not applied the desired hash yet. The
+	// first heartbeat must start the pending clock even though the hash itself
+	// did not change during this process restart.
+	if _, err := app.db.RecordNodeReport(token, NodeReport{BootID: "cold-boot", Sequence: 1, InterfaceName: "eth0"}, now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	schedule, err := app.db.siteNodeSchedule(site.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if schedule.ConfigPendingSinceMS != now.Add(time.Second).UnixMilli() {
+		t.Fatalf("cold-start mismatch pending_since=%d, want %d", schedule.ConfigPendingSinceMS, now.Add(time.Second).UnixMilli())
+	}
+
+	if _, err := app.db.RecordNodeReport(token, NodeReport{BootID: "cold-boot", Sequence: 2, InterfaceName: "eth0", AppliedConfigHash: desiredHash}, now.Add(2*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	schedule, err = app.db.siteNodeSchedule(site.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if schedule.ConfigPendingSinceMS != 0 {
+		t.Fatalf("matching applied hash did not clear pending timer: %#v", schedule)
 	}
 }
 


### PR DESCRIPTION
## Changes
- start the site scheduler pending timer when an Agent cold-start report has not applied the desired config
- invalidate node runtime configuration when its address or HTTPS port changes
- deduplicate certificate provisioning work without recursive overflow timers
- add scheduler and telemetry regression coverage

## Validation
- go test ./...
- go test -race ./...
- go vet ./...
