### PR TITLE
docs: use latest release in install examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,27 +60,19 @@ docker compose logs -f meridian
 
 首次启动时日志会输出一次管理员初始化令牌。打开 `http://服务器地址:9090` 完成初始化。数据库、TLS 状态和缓存位于 `./data`，更新容器不会删除它们。`network_mode: host` 会让面板和站点端口直接使用宿主机网络，请先确认端口没有被其他服务占用。
 
-生产环境可以把 `latest` 换成固定版本，例如 `ghcr.io/chanhui800/meridian:v1.9.58`。固定版本便于回滚和排查问题。
+生产环境可以把 `latest` 换成固定版本。固定版本便于回滚和排查问题。
 
 ### Linux 原生安装
 
-从固定 Release 安装（推荐）：
+安装最新正式版：
 
 ```bash
-VERSION=v1.9.58
-tmp_dir="$(mktemp -d)"
-trap 'rm -rf "$tmp_dir"' EXIT
-curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL \
-  -o "$tmp_dir/install.sh" \
-  "https://github.com/chanhui800/Meridian/releases/download/${VERSION}/install.sh"
-curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL \
-  -o "$tmp_dir/SHA256SUMS" \
-  "https://github.com/chanhui800/Meridian/releases/download/${VERSION}/SHA256SUMS"
-(cd "$tmp_dir" && grep ' install.sh$' SHA256SUMS | sha256sum -c -)
-sudo bash "$tmp_dir/install.sh" install -y --no-domain
+curl -fsSL \
+  https://github.com/chanhui800/Meridian/releases/latest/download/install.sh \
+  | sudo bash -s -- install -y --no-domain
 ```
 
-安装器和校验文件均来自同一个固定 Release。升级时将 `VERSION` 改为目标版本；不要从可变的 `main` 分支直接执行安装脚本。
+安装器会自动获取最新正式 Release，并校验实际下载的程序。需要固定版本或在高安全环境中安装时，再使用固定 Release 的校验流程；不要从可变的 `main` 分支直接执行安装脚本。
 
 默认数据库为 `/var/lib/meridian/meridian.db`，服务名为 `meridian`：
 

--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ docker compose logs -f meridian
 
 首次启动时日志会输出一次管理员初始化令牌。打开 `http://服务器地址:9090` 完成初始化。数据库、TLS 状态和缓存位于 `./data`，更新容器不会删除它们。`network_mode: host` 会让面板和站点端口直接使用宿主机网络，请先确认端口没有被其他服务占用。
 
-生产环境可以把 `latest` 换成固定版本，例如 `ghcr.io/chanhui800/meridian:v1.9.53`。固定版本便于回滚和排查问题。
+生产环境可以把 `latest` 换成固定版本，例如 `ghcr.io/chanhui800/meridian:v1.9.58`。固定版本便于回滚和排查问题。
 
 ### Linux 原生安装
 
 从固定 Release 安装（推荐）：
 
 ```bash
-VERSION=v1.9.53
+VERSION=v1.9.58
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL \

--- a/README.md
+++ b/README.md
@@ -64,25 +64,25 @@ docker compose logs -f meridian
 
 ### Linux 原生安装
 
-安装最新正式版：
+启动交互式管理菜单（安装、更新、修改密码、卸载和删除数据）：
 
 ```bash
 curl -fsSL \
   https://github.com/chanhui800/Meridian/releases/latest/download/install.sh \
-  | sudo bash -s -- install -y --no-domain
+  | sudo bash
 ```
 
 安装器会自动获取最新正式 Release，并校验实际下载的程序。需要固定版本或在高安全环境中安装时，再使用固定 Release 的校验流程；不要从可变的 `main` 分支直接执行安装脚本。
 
-卸载 Meridian（默认保留数据库、TLS 状态和备份）：
+菜单中的卸载选项默认保留数据库、TLS 状态和备份；选择“卸载并删除数据”才会删除 Meridian 数据目录。自动化部署仍可使用参数：
 
 ```bash
-curl -fsSL \
-  https://github.com/chanhui800/Meridian/releases/latest/download/install.sh \
-  | sudo bash -s -- uninstall -y
+curl -fsSL https://github.com/chanhui800/Meridian/releases/latest/download/install.sh | sudo bash -s -- install -y --no-domain
+# 卸载但保留数据
+curl -fsSL https://github.com/chanhui800/Meridian/releases/latest/download/install.sh | sudo bash -s -- uninstall -y
+# 卸载并删除数据
+curl -fsSL https://github.com/chanhui800/Meridian/releases/latest/download/install.sh | sudo bash -s -- uninstall -y --purge
 ```
-
-确认不再保留数据时使用 `uninstall -y --purge`；该操作会删除 Meridian 数据目录。
 
 默认数据库为 `/var/lib/meridian/meridian.db`，服务名为 `meridian`：
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ curl -fsSL \
 
 安装器会自动获取最新正式 Release，并校验实际下载的程序。需要固定版本或在高安全环境中安装时，再使用固定 Release 的校验流程；不要从可变的 `main` 分支直接执行安装脚本。
 
+卸载 Meridian（默认保留数据库、TLS 状态和备份）：
+
+```bash
+curl -fsSL \
+  https://github.com/chanhui800/Meridian/releases/latest/download/install.sh \
+  | sudo bash -s -- uninstall -y
+```
+
+确认不再保留数据时使用 `uninstall -y --purge`；该操作会删除 Meridian 数据目录。
+
 默认数据库为 `/var/lib/meridian/meridian.db`，服务名为 `meridian`：
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,7 @@ PREVIOUS_AGENT_BIN_AMD64="${INSTALL_DIR}/${AGENT_BIN_AMD64_NAME}.previous"
 PREVIOUS_AGENT_BIN_ARM64="${INSTALL_DIR}/${AGENT_BIN_ARM64_NAME}.previous"
 ASSUME_YES="${MERIDIAN_ASSUME_YES:-0}"
 PURGE_DATA=0
+UNINSTALL_KEEP_DATA=0
 DOMAIN_MODE="ask"
 REQUESTED_DOMAIN=""
 CERTBOT_EMAIL=""
@@ -2194,7 +2195,7 @@ do_uninstall() {
     if [ "$ASSUME_YES" != "1" ]; then
         if [ "$PURGE_DATA" = "1" ]; then
             warn "已指定 --purge，数据目录将在确认卸载后删除: $DATA_DIR"
-        else
+        elif [ "$UNINSTALL_KEEP_DATA" != "1" ]; then
             if ask_yes_no "是否同时删除数据目录 ${DATA_DIR}（数据库和密钥）？" 0; then
                 remove_data=1
             fi
@@ -2255,7 +2256,7 @@ Meridian 一键安装工具
   -y, --yes        非交互确认；安装未指定域名时保留现有配置，首次安装则使用 IP
   --purge          卸载时删除数据目录；不会删除备份、Nginx、Certbot 或证书
 
-不带参数运行时进入四项菜单。
+不带参数运行时进入交互式菜单，可选择安装、更新、修改密码、卸载（保留数据）或卸载并删除数据。
 USAGE
 }
 
@@ -2267,14 +2268,16 @@ main_menu() {
     printf '  1) 安装\n'
     printf '  2) 更新到最新版\n'
     printf '  3) 修改管理员密码\n'
-    printf '  4) 卸载\n'
+    printf '  4) 卸载（保留数据）\n'
+    printf '  5) 卸载并删除数据\n'
     printf '  0) 退出\n\n'
-    read -r -p "请选择 [0-4]: " choice
+    read -r -p "请选择 [0-5]: " choice
     case "$choice" in
         1) do_install ;;
         2) do_update ;;
         3) do_password ;;
-        4) do_uninstall ;;
+        4) PURGE_DATA=0; UNINSTALL_KEEP_DATA=1; do_uninstall ;;
+        5) PURGE_DATA=1; UNINSTALL_KEEP_DATA=0; do_uninstall ;;
         0) exit 0 ;;
         *) fail "无效选项" ;;
     esac

--- a/tests/install_test.sh
+++ b/tests/install_test.sh
@@ -44,7 +44,7 @@ printf '%s' "$stdin_help" | grep -Fq 'Meridian 一键安装工具' \
 # disposable PTY while Bash still reads the installer itself from stdin.
 if command -v script >/dev/null 2>&1; then
     piped_menu=$(printf '0\n' | script -qec "bash < '${REPO_ROOT}/install.sh'" /dev/null)
-    printf '%s' "$piped_menu" | grep -Fq '请选择 [0-4]:' \
+    printf '%s' "$piped_menu" | grep -Fq '请选择 [0-5]:' \
         || { echo 'FAIL: piped menu was not attached to the terminal' >&2; exit 1; }
     if printf '%s' "$piped_menu" | grep -Fq '无效选项'; then
         echo 'FAIL: piped menu did not read the terminal selection' >&2
@@ -1215,11 +1215,11 @@ for removed_command in status restart logs backup rollback; do
 done
 
 menu_text=$(printf '0\n' | main_menu)
-for menu_item in '1) 安装' '2) 更新到最新版' '3) 修改管理员密码' '4) 卸载' '0) 退出'; do
+for menu_item in '1) 安装' '2) 更新到最新版' '3) 修改管理员密码' '4) 卸载（保留数据）' '5) 卸载并删除数据' '0) 退出'; do
     printf '%s' "$menu_text" | grep -Fq "$menu_item"
 done
-if printf '%s' "$menu_text" | grep -Eq '^  [5-9]\)'; then
-    echo 'FAIL: menu exposes more than four operations' >&2
+if printf '%s' "$menu_text" | grep -Eq '^  [6-9]\)'; then
+    echo 'FAIL: menu exposes more than five operations' >&2
     exit 1
 fi
 


### PR DESCRIPTION
Update the README Docker and Linux native installation examples to the current latest formal release v1.9.58. The installer itself already resolves the latest formal Release for install/update.