### PR TITLE
fix: harden agent convergence and cleanup transactions

### DIFF
--- a/app_nodes.go
+++ b/app_nodes.go
@@ -685,7 +685,7 @@ func (a *App) handleAgentReport(w http.ResponseWriter, r *http.Request) {
 		a.jsonErr(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	configChanged := nodeReportConfigChanged(result.Node, report.AppliedConfigHash)
+	configChanged := nodeReportConfigChanged(result.Node, report.AppliedConfigHash, report.AppliedConfigRevision)
 	a.jsonOK(w, map[string]interface{}{
 		"accepted": true, "node_id": result.Node.ID, "next_report_seconds": 15,
 		"accepted_event_ids": result.AcceptedEventIDs, "accepted_event_uids": result.AcceptedEventUIDs,
@@ -698,9 +698,12 @@ func (a *App) handleAgentReport(w http.ResponseWriter, r *http.Request) {
 // nodeReportConfigChanged tells an Agent to fetch immediately when the
 // controller has invalidated its runtime snapshot. A blank desired hash is a
 // deliberate invalidation marker, so it must also trigger a refresh.
-func nodeReportConfigChanged(node ControlNode, appliedHash string) bool {
+func nodeReportConfigChanged(node ControlNode, appliedHash string, appliedRevision int64) bool {
 	desired := strings.TrimSpace(node.DesiredConfigHash)
 	applied := strings.TrimSpace(appliedHash)
+	if appliedRevision > 0 && node.DesiredConfigRevision > 0 && appliedRevision != node.DesiredConfigRevision {
+		return true
+	}
 	return node.ConfigDirty || desired == "" || desired != applied
 }
 
@@ -779,7 +782,7 @@ func (a *App) handleAgentWebSocket(ws *websocket.Conn) {
 			"accepted_event_ids": result.AcceptedEventIDs, "accepted_event_uids": result.AcceptedEventUIDs,
 			"discarded_event_ids": result.DiscardedEventIDs, "discarded_event_uids": result.DiscardedEventUIDs,
 			"config_hash":    result.Node.DesiredConfigHash,
-			"config_changed": nodeReportConfigChanged(result.Node, report.AppliedConfigHash),
+			"config_changed": nodeReportConfigChanged(result.Node, report.AppliedConfigHash, report.AppliedConfigRevision),
 		}
 		if err := ws.SetWriteDeadline(time.Now().Add(10 * time.Second)); err != nil {
 			return

--- a/app_traffic.go
+++ b/app_traffic.go
@@ -113,7 +113,10 @@ func (a *App) handleAssetCache(w http.ResponseWriter, r *http.Request) {
 		}
 		nowMS := time.Now().UnixMilli()
 		result, err := a.db.db.Exec(`UPDATE control_nodes
-			SET cache_clear_generation=cache_clear_generation+1,config_dirty=1,updated_at_ms=?
+			SET cache_clear_generation=cache_clear_generation+1,
+				config_revision=config_revision+1,
+				desired_config_hash='',desired_config_revision=0,
+				config_dirty=1,updated_at_ms=?
 			WHERE enabled=1 AND agent_token_hash<>''`, nowMS)
 		if err != nil {
 			a.jsonErr(w, http.StatusInternalServerError, "schedule agent cache clear failed")

--- a/backup_restore.go
+++ b/backup_restore.go
@@ -506,7 +506,9 @@ func (a *App) databaseSnapshot() (string, func(), error) {
 		return "", func() {}, err
 	}
 	if a.pm != nil {
-		a.pm.FlushTraffic()
+		if err := a.pm.FlushTrafficStrict(); err != nil {
+			return "", func() {}, fmt.Errorf("刷新流量计数: %w", err)
+		}
 	}
 	if err := a.db.flushDynamicObservations(); err != nil {
 		return "", func() {}, fmt.Errorf("刷新日志队列: %w", err)
@@ -699,6 +701,29 @@ func (a *App) buildBackupToFile(password string, includeTLS bool) (builtBackupFi
 		// Back up the resolved pair under stable archive names; restore rebuilds
 		// each node's current directory from these files.
 		if edgeRoot := edgeNodeTLSRoot(a.dbPath); edgeRoot != "" {
+			// Only database-owned node GUIDs belong in a restorable TLS backup.
+			// Leftover directories from deleted nodes are cleanup candidates, not
+			// live Meridian state, and must never be resurrected by a restore.
+			knownGUIDs := make(map[string]struct{})
+			rows, queryErr := a.db.db.Query("SELECT guid FROM control_nodes WHERE TRIM(guid) <> ''")
+			if queryErr != nil {
+				return builtBackupFile{}, fmt.Errorf("读取 Edge 节点清单: %w", queryErr)
+			}
+			for rows.Next() {
+				var guid string
+				if scanErr := rows.Scan(&guid); scanErr != nil {
+					_ = rows.Close()
+					return builtBackupFile{}, fmt.Errorf("读取 Edge 节点清单: %w", scanErr)
+				}
+				if validTLSNodeGUID(guid) {
+					knownGUIDs[guid] = struct{}{}
+				}
+			}
+			if rowsErr := rows.Err(); rowsErr != nil {
+				_ = rows.Close()
+				return builtBackupFile{}, fmt.Errorf("读取 Edge 节点清单: %w", rowsErr)
+			}
+			_ = rows.Close()
 			entries, readErr := os.ReadDir(edgeRoot)
 			if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
 				return builtBackupFile{}, fmt.Errorf("读取 Edge 节点证书目录: %w", readErr)
@@ -708,6 +733,9 @@ func (a *App) buildBackupToFile(password string, includeTLS bool) (builtBackupFi
 					continue
 				}
 				guid := entry.Name()
+				if _, known := knownGUIDs[guid]; !known {
+					continue
+				}
 				for _, filename := range []string{"fullchain.pem", "privkey.pem"} {
 					name := backupTLSEdgeNodesPrefix + guid + "/" + filename
 					path := filepath.Join(edgeRoot, guid, "current", filename)

--- a/backup_restore_test.go
+++ b/backup_restore_test.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	_ "modernc.org/sqlite"
 )
@@ -161,6 +162,10 @@ func TestBuildBackupIncludesTLSOnlyWhenSelected(t *testing.T) {
 	if _, err := db.db.Exec(`INSERT INTO users (username, password_hash) VALUES ('admin', 'hash')`); err != nil {
 		t.Fatal(err)
 	}
+	node, _, err := db.CreateControlNode(NodeCreateInput{Name: "backup-edge", Address: "203.0.113.10", Port: 443}, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
 	tlsDir := filepath.Join(dir, "tls")
 	if err := os.MkdirAll(tlsDir, 0o700); err != nil {
 		t.Fatal(err)
@@ -175,7 +180,7 @@ func TestBuildBackupIncludesTLSOnlyWhenSelected(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	edgeDir := filepath.Join(tlsDir, "edge-nodes", "node-a", "current")
+	edgeDir := filepath.Join(tlsDir, "edge-nodes", node.GUID, "current")
 	if err := os.MkdirAll(edgeDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
@@ -231,7 +236,7 @@ func TestBuildBackupIncludesTLSOnlyWhenSelected(t *testing.T) {
 			t.Fatalf("selected TLS backup is missing %s", name)
 		}
 	}
-	for _, name := range []string{backupTLSEdgeNodesPrefix + "node-a/fullchain.pem", backupTLSEdgeNodesPrefix + "node-a/privkey.pem"} {
+	for _, name := range []string{backupTLSEdgeNodesPrefix + node.GUID + "/fullchain.pem", backupTLSEdgeNodesPrefix + node.GUID + "/privkey.pem"} {
 		if _, ok := entries[name]; !ok {
 			t.Fatalf("selected TLS backup is missing %s", name)
 		}

--- a/command_line.go
+++ b/command_line.go
@@ -297,6 +297,9 @@ func runIssueEdgeCertificateCommand(output io.Writer) error {
 			continue
 		} else if changed {
 			installed++
+			if dirtyErr := db.markAgentConfigDirty(node.ID); dirtyErr != nil {
+				failures = append(failures, fmt.Errorf("node %s mark config dirty: %w", node.Name, dirtyErr))
+			}
 		}
 	}
 	if err := errors.Join(failures...); err != nil {

--- a/database_migrations.go
+++ b/database_migrations.go
@@ -19,7 +19,7 @@ const (
 	// databaseSchemaVersion is independent from the application and backup
 	// format versions. It is persisted in SQLite so restores can reject a
 	// database whose columns/state are newer than this binary understands.
-	databaseSchemaVersion = 35
+	databaseSchemaVersion = 37
 )
 
 func (d *DB) migrate() error {
@@ -382,6 +382,9 @@ func (d *DB) migrateOnce() error {
 		desired_config_hash TEXT NOT NULL DEFAULT '',
 		config_dirty INTEGER NOT NULL DEFAULT 0,
 		applied_config_hash TEXT NOT NULL DEFAULT '',
+		config_revision BIGINT NOT NULL DEFAULT 0,
+		desired_config_revision BIGINT NOT NULL DEFAULT 0,
+		applied_config_revision BIGINT NOT NULL DEFAULT 0,
 		agent_apply_error TEXT NOT NULL DEFAULT '',
 		agent_apply_error_at_ms INTEGER NOT NULL DEFAULT 0,
 		agent_apply_failures BIGINT NOT NULL DEFAULT 0,
@@ -439,6 +442,13 @@ func (d *DB) migrateOnce() error {
 		PRIMARY KEY(site_id,node_id)
 	);
 	CREATE INDEX IF NOT EXISTS idx_site_node_probe_failures_until ON site_node_probe_failures(site_id,failed_until_ms);
+	CREATE TABLE IF NOT EXISTS node_tls_cleanup_jobs (
+		node_guid TEXT PRIMARY KEY,
+		created_at_ms INTEGER NOT NULL,
+		attempts INTEGER NOT NULL DEFAULT 0,
+		last_error TEXT NOT NULL DEFAULT '',
+		updated_at_ms INTEGER NOT NULL
+	);
 	`); err != nil {
 		return err
 	}
@@ -475,6 +485,9 @@ func (d *DB) migrateOnce() error {
 		{"desired_config_hash", "ALTER TABLE control_nodes ADD COLUMN desired_config_hash TEXT NOT NULL DEFAULT ''"},
 		{"config_dirty", "ALTER TABLE control_nodes ADD COLUMN config_dirty INTEGER NOT NULL DEFAULT 0"},
 		{"applied_config_hash", "ALTER TABLE control_nodes ADD COLUMN applied_config_hash TEXT NOT NULL DEFAULT ''"},
+		{"config_revision", "ALTER TABLE control_nodes ADD COLUMN config_revision BIGINT NOT NULL DEFAULT 0"},
+		{"desired_config_revision", "ALTER TABLE control_nodes ADD COLUMN desired_config_revision BIGINT NOT NULL DEFAULT 0"},
+		{"applied_config_revision", "ALTER TABLE control_nodes ADD COLUMN applied_config_revision BIGINT NOT NULL DEFAULT 0"},
 		{"agent_apply_error", "ALTER TABLE control_nodes ADD COLUMN agent_apply_error TEXT NOT NULL DEFAULT ''"},
 		{"agent_apply_error_at_ms", "ALTER TABLE control_nodes ADD COLUMN agent_apply_error_at_ms INTEGER NOT NULL DEFAULT 0"},
 		{"agent_apply_failures", "ALTER TABLE control_nodes ADD COLUMN agent_apply_failures BIGINT NOT NULL DEFAULT 0"},
@@ -747,6 +760,18 @@ func (d *DB) migrateOnce() error {
 		if _, err := conn.ExecContext(ctx, `UPDATE control_nodes SET config_dirty=CASE
 			WHEN desired_config_hash='' OR desired_config_hash<>applied_config_hash THEN 1
 			ELSE config_dirty END`); err != nil {
+			return err
+		}
+	}
+	if previousSchemaVersion < 36 {
+		// Revision zero is reserved for legacy Agents that do not send the
+		// revision field. Give every already-invalidated node a non-zero
+		// generation so the first modern config fetch cannot be acknowledged by
+		// an old heartbeat from before this migration.
+		if _, err := conn.ExecContext(ctx, `UPDATE control_nodes SET
+			config_revision=CASE WHEN config_revision=0 AND (config_dirty=1 OR desired_config_hash='' OR desired_config_hash<>applied_config_hash) THEN 1 ELSE config_revision END,
+			desired_config_revision=CASE WHEN desired_config_hash<>'' THEN CASE WHEN config_revision>0 THEN config_revision ELSE 1 END ELSE 0 END,
+			applied_config_revision=CASE WHEN desired_config_hash<>'' AND desired_config_hash=applied_config_hash THEN CASE WHEN config_revision>0 THEN config_revision ELSE 1 END ELSE 0 END`); err != nil {
 			return err
 		}
 	}

--- a/edge_agent.go
+++ b/edge_agent.go
@@ -507,6 +507,7 @@ type edgeAgentRuntime struct {
 	server               *http.Server
 	bundle               *edgeProxyBundle
 	appliedHash          string
+	appliedRevision      int64
 	siteCounterEpoch     uint64
 	cacheClearGeneration int64
 	listenerError        string
@@ -531,6 +532,8 @@ type edgeAgentRuntimeState struct {
 	server               *http.Server
 	bundle               *edgeProxyBundle
 	nodeGUID             string
+	appliedHash          string
+	appliedRevision      int64
 	certificate          *tls.Certificate
 	handler              http.Handler
 	cacheClearGeneration int64
@@ -1129,6 +1132,8 @@ func (runtime *edgeAgentRuntime) rollbackApply(old edgeAgentRuntimeState, listen
 	}
 	runtime.mu.Lock()
 	runtime.nodeGUID = old.nodeGUID
+	runtime.appliedHash = old.appliedHash
+	runtime.appliedRevision = old.appliedRevision
 	runtime.port = old.port
 	runtime.certificate = old.certificate
 	runtime.handler = old.handler
@@ -1192,7 +1197,7 @@ func (runtime *edgeAgentRuntime) apply(config AgentRuntimeConfig) (retErr error)
 	runtime.mu.RLock()
 	oldState := edgeAgentRuntimeState{
 		port: runtime.port, server: runtime.server, bundle: runtime.bundle,
-		nodeGUID: runtime.nodeGUID, certificate: runtime.certificate, handler: runtime.handler,
+		nodeGUID: runtime.nodeGUID, appliedHash: runtime.appliedHash, appliedRevision: runtime.appliedRevision, certificate: runtime.certificate, handler: runtime.handler,
 		cacheClearGeneration: runtime.cacheClearGeneration, siteCounterEpoch: runtime.siteCounterEpoch,
 		listenerError: runtime.listenerError,
 	}
@@ -1243,6 +1248,7 @@ func (runtime *edgeAgentRuntime) apply(config AgentRuntimeConfig) (retErr error)
 	}
 	runtime.mu.Lock()
 	runtime.appliedHash = config.ConfigHash
+	runtime.appliedRevision = config.ConfigRevision
 	runtime.siteCounterEpoch++
 	if config.CacheClearGeneration > runtime.cacheClearGeneration {
 		runtime.cacheClearGeneration = config.CacheClearGeneration
@@ -1293,10 +1299,10 @@ func agentStatusError(err error) string {
 	return value[:maxAgentStatusErrorLength]
 }
 
-func (runtime *edgeAgentRuntime) status() (string, string, string, int64, int64) {
+func (runtime *edgeAgentRuntime) status() (string, int64, string, string, int64, int64) {
 	runtime.mu.RLock()
 	defer runtime.mu.RUnlock()
-	return runtime.appliedHash, runtime.listenerError, runtime.applyError, runtime.applyErrorAtMS, runtime.applyFailures
+	return runtime.appliedHash, runtime.appliedRevision, runtime.listenerError, runtime.applyError, runtime.applyErrorAtMS, runtime.applyFailures
 }
 
 func (runtime *edgeAgentRuntime) close() {
@@ -1851,7 +1857,7 @@ func runEdgeAgent() error {
 				// Refresh the pending payload when the Controller sends a newer
 				// hash, but do not reset an in-progress retry backoff when the
 				// same failing configuration is fetched again after a report ACK.
-				if pendingConfig == nil || pendingConfig.ConfigHash != config.ConfigHash {
+				if pendingConfig == nil || !agentConfigIdentityEqual(*pendingConfig, config) {
 					pendingConfig = &config
 					nextApplyAttempt = now
 					applyFailures = 0
@@ -1874,8 +1880,8 @@ func runEdgeAgent() error {
 			}
 		}
 		if pendingConfig != nil && (nextApplyAttempt.IsZero() || !now.Before(nextApplyAttempt)) {
-			applied, _, _, _, _ := runtime.status()
-			if pendingConfig.ConfigHash == applied {
+			applied, appliedRevision, _, _, _, _ := runtime.status()
+			if agentConfigIdentityEqual(*pendingConfig, AgentRuntimeConfig{ConfigHash: applied, ConfigRevision: appliedRevision}) {
 				pendingConfig = nil
 				applyFailures = 0
 				nextApplyAttempt = time.Time{}
@@ -1903,7 +1909,7 @@ func runEdgeAgent() error {
 		if collectErr != nil {
 			fmt.Fprintf(os.Stderr, "Meridian Agent traffic collection failed: %v\n", collectErr)
 		} else {
-			report.AppliedConfigHash, report.ListenerError, report.ApplyError, report.ApplyErrorAtMS, report.ApplyFailures = runtime.status()
+			report.AppliedConfigHash, report.AppliedConfigRevision, report.ListenerError, report.ApplyError, report.ApplyErrorAtMS, report.ApplyFailures = runtime.status()
 			runtime.mu.RLock()
 			report.CacheClearGeneration = runtime.cacheClearGeneration
 			report.SiteCounterEpoch = strconv.FormatUint(runtime.siteCounterEpoch, 10)
@@ -1992,4 +1998,14 @@ func runEdgeAgent() error {
 		}()):
 		}
 	}
+}
+
+// agentConfigIdentityEqual includes the monotonic revision alongside the
+// content hash. A revision can change while the serialized runtime content
+// returns to an earlier value (for example an edit is reverted); treating the
+// hash alone as an acknowledgement would leave the Controller's CAS revision
+// permanently pending.
+func agentConfigIdentityEqual(left, right AgentRuntimeConfig) bool {
+	return strings.TrimSpace(left.ConfigHash) == strings.TrimSpace(right.ConfigHash) &&
+		left.ConfigRevision == right.ConfigRevision
 }

--- a/edge_agent_test.go
+++ b/edge_agent_test.go
@@ -43,7 +43,7 @@ func TestEdgeAgentRollbackSurfacesListenerRestoreFailure(t *testing.T) {
 	if runtime.server != nil {
 		t.Fatal("runtime retained a server after listener restore failed")
 	}
-	_, listenerError, applyError, _, _ := runtime.status()
+	_, _, listenerError, applyError, _, _ := runtime.status()
 	if !strings.Contains(listenerError, "restore old listener on port 9090") {
 		t.Fatalf("listener error=%q, want restore failure", listenerError)
 	}
@@ -58,9 +58,22 @@ func TestEdgeAgentApplyFailureIsExposedInRuntimeStatus(t *testing.T) {
 	if err == nil {
 		t.Fatal("invalid configuration unexpectedly applied")
 	}
-	_, _, applyError, _, _ := runtime.status()
+	_, _, _, applyError, _, _ := runtime.status()
 	if applyError == "" || !strings.Contains(applyError, "Agent configuration is invalid") {
 		t.Fatalf("apply error=%q, want the runtime apply failure", applyError)
+	}
+}
+
+func TestAgentConfigIdentityRequiresRevisionAndHash(t *testing.T) {
+	base := AgentRuntimeConfig{ConfigHash: "same", ConfigRevision: 7}
+	if !agentConfigIdentityEqual(base, AgentRuntimeConfig{ConfigHash: "same", ConfigRevision: 7}) {
+		t.Fatal("matching config hash and revision were not recognized")
+	}
+	if agentConfigIdentityEqual(base, AgentRuntimeConfig{ConfigHash: "same", ConfigRevision: 8}) {
+		t.Fatal("different config revision was incorrectly acknowledged")
+	}
+	if agentConfigIdentityEqual(base, AgentRuntimeConfig{ConfigHash: "other", ConfigRevision: 7}) {
+		t.Fatal("different config hash was incorrectly acknowledged")
 	}
 }
 

--- a/node_repository.go
+++ b/node_repository.go
@@ -53,6 +53,9 @@ type ControlNode struct {
 	DesiredConfigHash           string `json:"desired_config_hash"`
 	ConfigDirty                 bool   `json:"config_dirty"`
 	AppliedConfigHash           string `json:"applied_config_hash"`
+	ConfigRevision              int64  `json:"config_revision"`
+	DesiredConfigRevision       int64  `json:"desired_config_revision"`
+	AppliedConfigRevision       int64  `json:"applied_config_revision"`
 	AgentApplyError             string `json:"agent_apply_error"`
 	AgentApplyErrorAtMS         int64  `json:"agent_apply_error_at_ms"`
 	AgentApplyFailures          int64  `json:"agent_apply_failures"`
@@ -122,29 +125,30 @@ type NodeCreateInput struct {
 }
 
 type NodeReport struct {
-	BootID               string                   `json:"boot_id"`
-	ReportSessionID      string                   `json:"report_session_id,omitempty"`
-	CounterEpoch         string                   `json:"counter_epoch,omitempty"`
-	SiteCounterEpoch     string                   `json:"site_counter_epoch,omitempty"`
-	Sequence             int64                    `json:"sequence"`
-	InterfaceName        string                   `json:"interface_name"`
-	RXBytes              int64                    `json:"rx_bytes"`
-	TXBytes              int64                    `json:"tx_bytes"`
-	AgentVersion         string                   `json:"agent_version"`
-	AppliedConfigHash    string                   `json:"applied_config_hash"`
-	ApplyError           string                   `json:"apply_error,omitempty"`
-	ApplyErrorAtMS       int64                    `json:"apply_error_at_ms,omitempty"`
-	ApplyFailures        int64                    `json:"apply_failures,omitempty"`
-	ListenerError        string                   `json:"listener_error"`
-	EventSpoolError      string                   `json:"event_spool_error,omitempty"`
-	EventQueueDepth      int                      `json:"event_queue_depth,omitempty"`
-	EventDropped         int64                    `json:"event_dropped,omitempty"`
-	CacheClearGeneration int64                    `json:"cache_clear_generation,omitempty"`
-	SiteStats            []NodeSiteStat           `json:"site_stats,omitempty"`
-	MediaCounts          []NodeMediaCount         `json:"media_counts,omitempty"`
-	Retention            []NodeRetentionStatus    `json:"retention,omitempty"`
-	Observations         []NodeDynamicObservation `json:"observations,omitempty"`
-	Events               []NodeRequestEvent       `json:"events,omitempty"`
+	BootID                string                   `json:"boot_id"`
+	ReportSessionID       string                   `json:"report_session_id,omitempty"`
+	CounterEpoch          string                   `json:"counter_epoch,omitempty"`
+	SiteCounterEpoch      string                   `json:"site_counter_epoch,omitempty"`
+	Sequence              int64                    `json:"sequence"`
+	InterfaceName         string                   `json:"interface_name"`
+	RXBytes               int64                    `json:"rx_bytes"`
+	TXBytes               int64                    `json:"tx_bytes"`
+	AgentVersion          string                   `json:"agent_version"`
+	AppliedConfigHash     string                   `json:"applied_config_hash"`
+	AppliedConfigRevision int64                    `json:"applied_config_revision,omitempty"`
+	ApplyError            string                   `json:"apply_error,omitempty"`
+	ApplyErrorAtMS        int64                    `json:"apply_error_at_ms,omitempty"`
+	ApplyFailures         int64                    `json:"apply_failures,omitempty"`
+	ListenerError         string                   `json:"listener_error"`
+	EventSpoolError       string                   `json:"event_spool_error,omitempty"`
+	EventQueueDepth       int                      `json:"event_queue_depth,omitempty"`
+	EventDropped          int64                    `json:"event_dropped,omitempty"`
+	CacheClearGeneration  int64                    `json:"cache_clear_generation,omitempty"`
+	SiteStats             []NodeSiteStat           `json:"site_stats,omitempty"`
+	MediaCounts           []NodeMediaCount         `json:"media_counts,omitempty"`
+	Retention             []NodeRetentionStatus    `json:"retention,omitempty"`
+	Observations          []NodeDynamicObservation `json:"observations,omitempty"`
+	Events                []NodeRequestEvent       `json:"events,omitempty"`
 }
 
 // NodeReportResult keeps the protocol acknowledgement tied to the exact
@@ -404,6 +408,7 @@ type rowScanner interface{ Scan(...interface{}) error }
 const controlNodeSelect = `SELECT id,guid,name,address,https_port,enabled,priority,traffic_quota,billing_mode,reset_day,
 	cycle_started_at_ms,period_rx_bytes,period_tx_bytes,lifetime_rx_bytes,lifetime_tx_bytes,traffic_manual_offset_bytes,
 	last_raw_rx_bytes,last_raw_tx_bytes,last_boot_id,last_report_session_id,last_sequence,interface_name,agent_version,desired_config_hash,config_dirty,applied_config_hash,agent_apply_error,agent_apply_error_at_ms,agent_apply_failures,agent_listener_error,event_spool_error,event_queue_depth,event_dropped,
+	config_revision,desired_config_revision,applied_config_revision,
 	enrollment_token_hash,enrollment_expires_at_ms,probe_secret_ciphertext,agent_token_hash,cache_clear_generation,cache_clear_applied_generation,enrolled_at_ms,last_seen_at_ms,created_at_ms,updated_at_ms
 	FROM control_nodes`
 
@@ -413,7 +418,9 @@ func scanControlNode(scanner rowScanner, now time.Time) (ControlNode, error) {
 	err := scanner.Scan(&node.ID, &node.GUID, &node.Name, &node.Address, &node.Port, &enabled, &node.Priority, &node.TrafficQuota,
 		&node.BillingMode, &node.ResetDay, &node.CycleStartedAtMS, &node.PeriodRXBytes, &node.PeriodTXBytes,
 		&node.LifetimeRXBytes, &node.LifetimeTXBytes, &node.TrafficManualOffset, &node.lastRawRXBytes, &node.lastRawTXBytes, &node.lastBootID, &node.lastReportSessionID,
-		&node.lastSequence, &node.InterfaceName, &node.AgentVersion, &node.DesiredConfigHash, &configDirty, &node.AppliedConfigHash, &node.AgentApplyError, &node.AgentApplyErrorAtMS, &node.AgentApplyFailures, &node.AgentListenerError, &node.EventSpoolError, &node.EventQueueDepth, &node.EventDropped, &node.enrollmentTokenHash, &node.enrollmentExpiresMS, &node.probeSecretCiphertext,
+		&node.lastSequence, &node.InterfaceName, &node.AgentVersion, &node.DesiredConfigHash, &configDirty, &node.AppliedConfigHash, &node.AgentApplyError, &node.AgentApplyErrorAtMS, &node.AgentApplyFailures, &node.AgentListenerError, &node.EventSpoolError, &node.EventQueueDepth, &node.EventDropped,
+		&node.ConfigRevision, &node.DesiredConfigRevision, &node.AppliedConfigRevision,
+		&node.enrollmentTokenHash, &node.enrollmentExpiresMS, &node.probeSecretCiphertext,
 		&node.agentTokenHash, &node.CacheClearGeneration, &node.CacheClearAppliedGeneration, &node.EnrolledAtMS, &node.LastSeenAtMS, &node.CreatedAtMS, &node.UpdatedAtMS)
 	if err != nil {
 		return ControlNode{}, err
@@ -575,7 +582,94 @@ func markAgentConfigsDirtyTx(tx *sql.Tx) error {
 	if tx == nil {
 		return errors.New("nil database transaction")
 	}
-	_, err := tx.Exec("UPDATE control_nodes SET config_dirty=1,updated_at_ms=? WHERE enabled=1 AND agent_token_hash<>''", time.Now().UnixMilli())
+	_, err := tx.Exec(`UPDATE control_nodes SET
+		config_revision=config_revision+1,
+		desired_config_hash='',
+		desired_config_revision=0,
+		config_dirty=1,
+		updated_at_ms=?
+		WHERE enabled=1 AND agent_token_hash<>''`, time.Now().UnixMilli())
+	return err
+}
+
+func markAgentConfigsDirtyForNodeIDsTx(tx *sql.Tx, nodeIDs ...int64) error {
+	if tx == nil {
+		return errors.New("nil database transaction")
+	}
+	seen := make(map[int64]struct{}, len(nodeIDs))
+	args := make([]interface{}, 0, len(nodeIDs)+1)
+	placeholders := make([]string, 0, len(nodeIDs))
+	for _, nodeID := range nodeIDs {
+		if nodeID <= 0 {
+			continue
+		}
+		if _, ok := seen[nodeID]; ok {
+			continue
+		}
+		seen[nodeID] = struct{}{}
+		placeholders = append(placeholders, "?")
+		args = append(args, nodeID)
+	}
+	if len(placeholders) == 0 {
+		return nil
+	}
+	args = append([]interface{}{time.Now().UnixMilli()}, args...)
+	// #nosec G202 -- only the number of parameter placeholders is generated; all values remain bound arguments.
+	_, err := tx.Exec(`UPDATE control_nodes SET
+		config_revision=config_revision+1,
+		desired_config_hash='',
+		desired_config_revision=0,
+		config_dirty=1,
+		updated_at_ms=?
+		WHERE enabled=1 AND agent_token_hash<>'' AND id IN (`+strings.Join(placeholders, ",")+")", args...)
+	return err
+}
+
+func markAgentConfigsDirtyForSiteTx(tx *sql.Tx, siteID int64) error {
+	if tx == nil || siteID <= 0 {
+		return nil
+	}
+	rows, err := tx.Query("SELECT desired_node_id,applied_node_id FROM site_node_schedules WHERE site_id=?", siteID)
+	if err != nil {
+		return err
+	}
+	var nodeIDs []int64
+	for rows.Next() {
+		var desired, applied sql.NullInt64
+		if err := rows.Scan(&desired, &applied); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		if desired.Valid {
+			nodeIDs = append(nodeIDs, desired.Int64)
+		}
+		if applied.Valid {
+			nodeIDs = append(nodeIDs, applied.Int64)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return err
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	return markAgentConfigsDirtyForNodeIDsTx(tx, nodeIDs...)
+}
+
+// markAgentConfigDirty invalidates one enrolled Agent after an out-of-band
+// runtime input (such as a renewed Edge certificate) changes its config.
+func (d *DB) markAgentConfigDirty(nodeID int64) error {
+	if d == nil || d.db == nil || nodeID <= 0 {
+		return nil
+	}
+	_, err := d.db.Exec(`UPDATE control_nodes SET
+		config_revision=config_revision+1,
+		desired_config_hash='',
+		desired_config_revision=0,
+		config_dirty=1,
+		updated_at_ms=?
+		WHERE id=? AND enabled=1 AND agent_token_hash<>''`, time.Now().UnixMilli(), nodeID)
 	return err
 }
 
@@ -598,10 +692,18 @@ func (d *DB) UpdateNodeScheduler(mode string, manualNodeID int64, now time.Time)
 	} else {
 		manualNodeID = 0
 	}
-	if _, err := d.db.Exec("UPDATE node_scheduler_settings SET mode=?,manual_node_id=?,updated_at_ms=? WHERE id=1", mode, nullableNodeID(manualNodeID), now.UnixMilli()); err != nil {
+	tx, err := d.db.Begin()
+	if err != nil {
 		return NodeControlSnapshot{}, err
 	}
-	if _, err := d.db.Exec("UPDATE control_nodes SET config_dirty=1,updated_at_ms=? WHERE enabled=1 AND agent_token_hash<>''", now.UnixMilli()); err != nil {
+	defer tx.Rollback()
+	if _, err := tx.Exec("UPDATE node_scheduler_settings SET mode=?,manual_node_id=?,updated_at_ms=? WHERE id=1", mode, nullableNodeID(manualNodeID), now.UnixMilli()); err != nil {
+		return NodeControlSnapshot{}, err
+	}
+	if err := markAgentConfigsDirtyTx(tx); err != nil {
+		return NodeControlSnapshot{}, err
+	}
+	if err := tx.Commit(); err != nil {
 		return NodeControlSnapshot{}, err
 	}
 	return d.NodeControlSnapshot(now)
@@ -635,13 +737,11 @@ func (d *DB) UpdateControlNode(id int64, input NodeCreateInput, enabled bool, no
 	if currentResetDay != input.ResetDay {
 		cycleStart := nodeCycleStart(now, input.ResetDay, scheduleTimezone)
 		result, err = tx.Exec(`UPDATE control_nodes SET name=?,address=?,entry_mode='direct',http_port=0,https_port=?,enabled=?,priority=?,traffic_quota=?,billing_mode=?,reset_day=?,traffic_manual_offset_bytes=?,
-			cycle_started_at_ms=?,period_rx_bytes=0,period_tx_bytes=0,desired_config_hash=CASE WHEN ? THEN '' ELSE desired_config_hash END,
-			config_dirty=CASE WHEN ? THEN 1 ELSE config_dirty END,updated_at_ms=? WHERE id=?`, input.Name, input.Address,
-			input.Port, sqliteBool(enabled), input.Priority, input.TrafficQuota, input.BillingMode, input.ResetDay, input.TrafficManualOffsetBytes, cycleStart, sqliteBool(portChanged), sqliteBool(portChanged), now.UnixMilli(), id)
+			cycle_started_at_ms=?,period_rx_bytes=0,period_tx_bytes=0,updated_at_ms=? WHERE id=?`, input.Name, input.Address,
+			input.Port, sqliteBool(enabled), input.Priority, input.TrafficQuota, input.BillingMode, input.ResetDay, input.TrafficManualOffsetBytes, cycleStart, now.UnixMilli(), id)
 	} else {
-		result, err = tx.Exec(`UPDATE control_nodes SET name=?,address=?,entry_mode='direct',http_port=0,https_port=?,enabled=?,priority=?,traffic_quota=?,billing_mode=?,traffic_manual_offset_bytes=?,desired_config_hash=CASE WHEN ? THEN '' ELSE desired_config_hash END,
-			config_dirty=CASE WHEN ? THEN 1 ELSE config_dirty END,updated_at_ms=? WHERE id=?`,
-			input.Name, input.Address, input.Port, sqliteBool(enabled), input.Priority, input.TrafficQuota, input.BillingMode, input.TrafficManualOffsetBytes, sqliteBool(portChanged), sqliteBool(portChanged), now.UnixMilli(), id)
+		result, err = tx.Exec(`UPDATE control_nodes SET name=?,address=?,entry_mode='direct',http_port=0,https_port=?,enabled=?,priority=?,traffic_quota=?,billing_mode=?,traffic_manual_offset_bytes=?,updated_at_ms=? WHERE id=?`,
+			input.Name, input.Address, input.Port, sqliteBool(enabled), input.Priority, input.TrafficQuota, input.BillingMode, input.TrafficManualOffsetBytes, now.UnixMilli(), id)
 	}
 	if err != nil {
 		if isSQLiteUniqueConstraintError(err) {
@@ -657,6 +757,9 @@ func (d *DB) UpdateControlNode(id int64, input NodeCreateInput, enabled bool, no
 		return ControlNode{}, errNodeNotFound
 	}
 	if portChanged {
+		if _, err := tx.Exec(`UPDATE control_nodes SET desired_config_hash='',desired_config_revision=0 WHERE id=?`, id); err != nil {
+			return ControlNode{}, err
+		}
 		if _, err := tx.Exec(`UPDATE site_node_schedules SET
 			config_hash='',
 			config_pending_since_ms=CASE WHEN enabled=1 THEN ? ELSE 0 END,
@@ -665,8 +768,12 @@ func (d *DB) UpdateControlNode(id int64, input NodeCreateInput, enabled bool, no
 			return ControlNode{}, err
 		}
 	}
-	if portChanged || enabledChanged {
+	if enabledChanged {
 		if err := markAgentConfigsDirtyTx(tx); err != nil {
+			return ControlNode{}, err
+		}
+	} else if portChanged {
+		if err := markAgentConfigsDirtyForNodeIDsTx(tx, id); err != nil {
 			return ControlNode{}, err
 		}
 	}
@@ -709,6 +816,15 @@ func (d *DB) DeleteControlNode(id int64) error {
 	} else if err != nil {
 		return err
 	}
+	// Keep a durable cleanup handle before removing the node row. If the
+	// managed TLS directory is temporarily unavailable, the scheduler can retry
+	// cleanup without resurrecting the deleted control node.
+	if validTLSNodeGUID(guid) {
+		if _, err := tx.Exec(`INSERT INTO node_tls_cleanup_jobs(node_guid,created_at_ms,attempts,last_error,updated_at_ms)
+			VALUES(?,?,0,'',?) ON CONFLICT(node_guid) DO UPDATE SET last_error='',updated_at_ms=excluded.updated_at_ms`, guid, time.Now().UnixMilli(), time.Now().UnixMilli()); err != nil {
+			return err
+		}
+	}
 	if _, err := tx.Exec("UPDATE node_scheduler_settings SET manual_node_id=NULL,active_node_id=NULL WHERE manual_node_id=? OR active_node_id=?", id, id); err != nil {
 		return err
 	}
@@ -730,13 +846,56 @@ func (d *DB) DeleteControlNode(id int64) error {
 	if err := tx.Commit(); err != nil {
 		return err
 	}
-	// The database deletion is authoritative. TLS cleanup is deliberately
-	// best-effort after commit: an operator-owned filesystem issue must not
-	// resurrect a node that has already been removed from the control plane.
-	if err := removeManagedEdgeNodeTLS(d.dbPath, guid); err != nil {
-		log.Printf("[node] removed node %d but could not clean managed Edge TLS: %v", id, err)
+	// The database deletion is authoritative. Complete the cleanup immediately
+	// when possible; failures remain durable for the scheduler retry loop.
+	if err := d.retryNodeTLSCleanup(guid); err != nil {
+		log.Printf("[node] removed node %d but managed Edge TLS cleanup is pending: %v", id, err)
 	}
 	return nil
+}
+
+func (d *DB) retryNodeTLSCleanup(onlyGUID string) error {
+	if d == nil || d.db == nil {
+		return nil
+	}
+	query := "SELECT node_guid FROM node_tls_cleanup_jobs"
+	args := []interface{}{}
+	if strings.TrimSpace(onlyGUID) != "" {
+		query += " WHERE node_guid=?"
+		args = append(args, onlyGUID)
+	}
+	rows, err := d.db.Query(query, args...)
+	if err != nil {
+		return err
+	}
+	guids := make([]string, 0)
+	for rows.Next() {
+		var guid string
+		if err := rows.Scan(&guid); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		guids = append(guids, guid)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return err
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	var failures []error
+	for _, guid := range guids {
+		if err := removeManagedEdgeNodeTLS(d.dbPath, guid); err != nil {
+			failures = append(failures, fmt.Errorf("node %s: %w", guid, err))
+			_, _ = d.db.Exec(`UPDATE node_tls_cleanup_jobs SET attempts=attempts+1,last_error=?,updated_at_ms=? WHERE node_guid=?`, err.Error(), time.Now().UnixMilli(), guid)
+			continue
+		}
+		if _, err := d.db.Exec("DELETE FROM node_tls_cleanup_jobs WHERE node_guid=?", guid); err != nil {
+			failures = append(failures, err)
+		}
+	}
+	return errors.Join(failures...)
 }
 
 func (d *DB) AuthorizeEnrollmentToken(token string, now time.Time) error {
@@ -1168,9 +1327,9 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 	var previousApplyFailures int64
 	var cacheClearGeneration int64
 	var lastBootID, lastSessionID, desiredConfigHash, previousApplyError string
-	var configDirty int
-	err = tx.QueryRow(`SELECT id,last_sequence,last_raw_rx_bytes,last_raw_tx_bytes,last_boot_id,last_report_session_id,cache_clear_generation,desired_config_hash,config_dirty,agent_apply_error,agent_apply_failures FROM control_nodes WHERE agent_token_hash=?`, hashNodeToken(agentToken)).Scan(
-		&id, &lastSequence, &lastRX, &lastTX, &lastBootID, &lastSessionID, &cacheClearGeneration, &desiredConfigHash, &configDirty, &previousApplyError, &previousApplyFailures)
+	var configDirty, configRevision, desiredConfigRevision, appliedConfigRevision int64
+	err = tx.QueryRow(`SELECT id,last_sequence,last_raw_rx_bytes,last_raw_tx_bytes,last_boot_id,last_report_session_id,cache_clear_generation,desired_config_hash,config_dirty,agent_apply_error,agent_apply_failures,config_revision,desired_config_revision,applied_config_revision FROM control_nodes WHERE agent_token_hash=?`, hashNodeToken(agentToken)).Scan(
+		&id, &lastSequence, &lastRX, &lastTX, &lastBootID, &lastSessionID, &cacheClearGeneration, &desiredConfigHash, &configDirty, &previousApplyError, &previousApplyFailures, &configRevision, &desiredConfigRevision, &appliedConfigRevision)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nodeReportCommitResult{}, errInvalidAgentToken
 	}
@@ -1225,8 +1384,21 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 	}
 	reportedApplyError := strings.TrimSpace(report.ApplyError)
 	applyError := reportedApplyError
+	appliedHash := strings.TrimSpace(report.AppliedConfigHash)
+	desiredHash := strings.TrimSpace(desiredConfigHash)
+	clearAppliedConfig := false
+	if report.AppliedConfigRevision > 0 {
+		clearAppliedConfig = report.AppliedConfigRevision == configRevision &&
+			report.AppliedConfigRevision == desiredConfigRevision &&
+			appliedHash != "" && appliedHash == desiredHash
+	} else {
+		// Legacy Agents do not send a revision. They may acknowledge a
+		// non-blank desired hash, but can never clear a deliberate blank
+		// invalidation marker left by a newer configuration revision.
+		clearAppliedConfig = appliedHash != "" && desiredHash != "" && appliedHash == desiredHash
+	}
 	legacyDiagnostic := false
-	if applyError == "" && strings.TrimSpace(report.AppliedConfigHash) == "" {
+	if applyError == "" && appliedHash == "" {
 		// Older Agents do not know about apply_error. Preserve an existing
 		// diagnostic until a report confirms that the desired configuration was
 		// actually applied, instead of letting a legacy heartbeat erase it.
@@ -1259,7 +1431,7 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 			applyFailures = 1
 			applyErrorAtMS = now.UnixMilli()
 		}
-	} else if strings.TrimSpace(report.AppliedConfigHash) == strings.TrimSpace(desiredConfigHash) && strings.TrimSpace(desiredConfigHash) != "" {
+	} else if clearAppliedConfig {
 		// A matching applied hash is the only successful completion signal. It
 		// clears the previous failure and its counters atomically with the report.
 		applyErrorAtMS = 0
@@ -1267,10 +1439,10 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 	}
 	if _, err = tx.Exec(`UPDATE control_nodes SET period_rx_bytes=period_rx_bytes+?,period_tx_bytes=period_tx_bytes+?,
 			lifetime_rx_bytes=lifetime_rx_bytes+?,lifetime_tx_bytes=lifetime_tx_bytes+?,last_raw_rx_bytes=?,last_raw_tx_bytes=?,
-			last_boot_id=?,last_report_session_id=?,last_sequence=?,interface_name=?,agent_version=?,applied_config_hash=?,agent_apply_error=?,agent_apply_error_at_ms=?,agent_apply_failures=?,agent_listener_error=?,event_spool_error=?,event_queue_depth=?,event_dropped=?,config_dirty=CASE WHEN ? <> '' AND ? = desired_config_hash THEN 0 ELSE config_dirty END,cache_clear_applied_generation=CASE WHEN ? > cache_clear_applied_generation AND ? <= ? THEN ? ELSE cache_clear_applied_generation END,last_seen_at_ms=?,updated_at_ms=? WHERE id=?`,
+			last_boot_id=?,last_report_session_id=?,last_sequence=?,interface_name=?,agent_version=?,applied_config_hash=?,applied_config_revision=?,agent_apply_error=?,agent_apply_error_at_ms=?,agent_apply_failures=?,agent_listener_error=?,event_spool_error=?,event_queue_depth=?,event_dropped=?,config_dirty=CASE WHEN ? THEN 0 ELSE config_dirty END,cache_clear_applied_generation=CASE WHEN ? > cache_clear_applied_generation AND ? <= ? THEN ? ELSE cache_clear_applied_generation END,last_seen_at_ms=?,updated_at_ms=? WHERE id=?`,
 		deltaRX, deltaTX, deltaRX, deltaTX, report.RXBytes, report.TXBytes, counterEpoch, sessionID, report.Sequence,
-		strings.TrimSpace(report.InterfaceName), strings.TrimSpace(report.AgentVersion), strings.TrimSpace(report.AppliedConfigHash), applyError, applyErrorAtMS, applyFailures, strings.TrimSpace(report.ListenerError), strings.TrimSpace(report.EventSpoolError), report.EventQueueDepth, report.EventDropped,
-		strings.TrimSpace(report.AppliedConfigHash), strings.TrimSpace(report.AppliedConfigHash),
+		strings.TrimSpace(report.InterfaceName), strings.TrimSpace(report.AgentVersion), appliedHash, report.AppliedConfigRevision, applyError, applyErrorAtMS, applyFailures, strings.TrimSpace(report.ListenerError), strings.TrimSpace(report.EventSpoolError), report.EventQueueDepth, report.EventDropped,
+		clearAppliedConfig,
 		report.CacheClearGeneration, report.CacheClearGeneration, cacheClearGeneration, report.CacheClearGeneration,
 		now.UnixMilli(), now.UnixMilli(), id); err != nil {
 		return nodeReportCommitResult{}, err
@@ -1281,8 +1453,6 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 	// an Agent process restart). Without this, a persistent apply failure leaves
 	// config_pending_since_ms at zero and the automatic failover cooldown can
 	// never begin.
-	appliedHash := strings.TrimSpace(report.AppliedConfigHash)
-	desiredHash := strings.TrimSpace(desiredConfigHash)
 	if desiredHash != "" && appliedHash != desiredHash {
 		if _, err := tx.Exec(`UPDATE site_node_schedules SET
 			config_pending_since_ms=CASE WHEN config_pending_since_ms=0 THEN ? ELSE config_pending_since_ms END,
@@ -1494,8 +1664,11 @@ func (d *DB) recordNodeWatchHistoryEvent(event NodeRequestEvent) error {
 	}
 	_, _ = io.Copy(io.Discard, capture)
 	if history, ok := watchHistoryEventFromCapture(capture, d, *site, req, nil, event.StatusCode, time.UnixMilli(event.RecordedAtMS)); ok {
-		if !d.EnqueueWatchHistory(history) {
-			return errors.New("watch history queue is full")
+		// Agent events are acknowledged only after the derived watch history is
+		// committed. The proxy hot path may remain asynchronous, but replayed
+		// control-plane events must not be ACKed while they only exist in memory.
+		if _, err := d.writeWatchHistoryBatch([]watchHistoryEvent{history}); err != nil {
+			return fmt.Errorf("persist watch history: %w", err)
 		}
 	}
 	return nil

--- a/node_repository_test.go
+++ b/node_repository_test.go
@@ -614,14 +614,52 @@ func TestSiteNodeSchedulingIsOptInAndCanFollowGlobalNode(t *testing.T) {
 }
 
 func TestNodeReportConfigChangedIncludesDirtyAndBlankDesiredHash(t *testing.T) {
-	if !nodeReportConfigChanged(ControlNode{DesiredConfigHash: "same", ConfigDirty: true}, "same") {
+	if !nodeReportConfigChanged(ControlNode{DesiredConfigHash: "same", ConfigDirty: true}, "same", 0) {
 		t.Fatal("dirty node did not request an immediate config refresh")
 	}
-	if !nodeReportConfigChanged(ControlNode{}, "") {
+	if !nodeReportConfigChanged(ControlNode{}, "", 0) {
 		t.Fatal("blank desired hash did not request an initial config refresh")
 	}
-	if nodeReportConfigChanged(ControlNode{DesiredConfigHash: "same"}, "same") {
+	if nodeReportConfigChanged(ControlNode{DesiredConfigHash: "same"}, "same", 0) {
 		t.Fatal("matching clean hashes incorrectly requested a refresh")
+	}
+}
+
+func TestLegacyHeartbeatCannotClearNewConfigRevision(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now().UTC()
+	node, enrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "revision-race", Address: "203.0.113.201"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, agentToken, err := app.db.EnrollControlNode(enrollment, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec(`UPDATE control_nodes SET config_revision=5,desired_config_revision=5,applied_config_revision=5,
+		desired_config_hash='old-hash',applied_config_hash='old-hash',config_dirty=0 WHERE id=?`, node.ID); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := app.db.db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := markAgentConfigsDirtyTx(tx); err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	reported, err := app.db.RecordNodeReport(agentToken, NodeReport{
+		BootID: "revision-boot", ReportSessionID: "revision-session", CounterEpoch: "revision-epoch",
+		Sequence: 1, InterfaceName: "eth0", AgentVersion: "test", AppliedConfigHash: "old-hash", AppliedConfigRevision: 5,
+	}, now.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reported.ConfigDirty || reported.DesiredConfigHash != "" || reported.ConfigRevision != 6 {
+		t.Fatalf("old heartbeat cleared a newer config revision: %#v", reported)
 	}
 }
 

--- a/panel_certificate_renewal.go
+++ b/panel_certificate_renewal.go
@@ -117,11 +117,15 @@ func renewEdgeCertificatesIfDue(ctx context.Context, db *DB, manager *panelCerti
 			continue
 		}
 		nodeCtx, cancel := context.WithTimeout(ctx, edgeCertificateRenewalTimeout)
-		_, ensureErr := ensureEdgeCertificateForNode(nodeCtx, settings, token, manager, node)
+		changed, ensureErr := ensureEdgeCertificateForNode(nodeCtx, settings, token, manager, node)
 		cancel()
 		if ensureErr != nil {
 			failures = append(failures, fmt.Errorf("node %s: %w", node.Name, ensureErr))
 			log.Printf("[edge-certificate] node %s renewal failed: %v", node.Name, ensureErr)
+		} else if changed {
+			if dirtyErr := db.markAgentConfigDirty(node.ID); dirtyErr != nil {
+				failures = append(failures, fmt.Errorf("node %s mark config dirty: %w", node.Name, dirtyErr))
+			}
 		}
 	}
 	return errors.Join(failures...)
@@ -179,8 +183,11 @@ func provisionEdgeCertificateForNode(ctx context.Context, db *DB, manager *panel
 	if err != nil {
 		return errors.New("无法解密已保存的 DNS API Token")
 	}
-	_, err = ensureEdgeCertificateForNode(ctx, settings, token, manager, node)
-	return err
+	changed, err := ensureEdgeCertificateForNode(ctx, settings, token, manager, node)
+	if err != nil || !changed {
+		return err
+	}
+	return db.markAgentConfigDirty(node.ID)
 }
 
 // disableExpiredPanelTLSIfNeeded makes an expired certificate a recoverable

--- a/proxy_lifecycle.go
+++ b/proxy_lifecycle.go
@@ -90,17 +90,30 @@ func (pm *ProxyManager) StartAllEnabled() (int, error) {
 // the pending counters and is logged here, so the next tick retries the same
 // values.
 func (pm *ProxyManager) FlushTraffic() {
+	_ = pm.FlushTrafficStrict()
+}
+
+// FlushTrafficStrict is used by operations that require a durable snapshot.
+// Unlike the periodic best-effort flusher it returns every persistence error
+// so callers can abort before taking a backup of incomplete traffic state.
+func (pm *ProxyManager) FlushTrafficStrict() error {
+	if pm == nil {
+		return nil
+	}
 	pm.mu.RLock()
 	instances := make([]*ProxyInstance, 0, len(pm.proxies))
 	for _, inst := range pm.proxies {
 		instances = append(instances, inst)
 	}
 	pm.mu.RUnlock()
+	var failures []error
 	for _, inst := range instances {
 		if err := pm.flushProxyTraffic(inst); err != nil {
 			log.Printf("[%s] failed to flush traffic: %v", inst.Site.Name, err)
+			failures = append(failures, fmt.Errorf("%s: %w", inst.Site.Name, err))
 		}
 	}
+	return errors.Join(failures...)
 }
 
 // flushProxyTraffic persists inst's pending bytes and requests into the DB and

--- a/site_node_scheduler.go
+++ b/site_node_scheduler.go
@@ -73,6 +73,7 @@ type AgentSiteRoute struct {
 type AgentRuntimeConfig struct {
 	SchemaVersion        int              `json:"schema_version"`
 	ConfigHash           string           `json:"config_hash"`
+	ConfigRevision       int64            `json:"config_revision,omitempty"`
 	NodeGUID             string           `json:"node_guid"`
 	EntryMode            string           `json:"entry_mode"`
 	HTTPPort             int              `json:"http_port"`
@@ -193,10 +194,10 @@ func (d *DB) SaveSiteNodeSchedule(siteID int64, enabled bool, mode string, fixed
 	}
 	var oldEnabled int
 	var oldMode string
-	var oldFixed sql.NullInt64
+	var oldFixed, oldDesired, oldApplied sql.NullInt64
 	var oldPendingSince int64
-	lookupErr := d.db.QueryRow("SELECT enabled,mode,fixed_node_id,config_pending_since_ms FROM site_node_schedules WHERE site_id=?", siteID).
-		Scan(&oldEnabled, &oldMode, &oldFixed, &oldPendingSince)
+	lookupErr := d.db.QueryRow("SELECT enabled,mode,fixed_node_id,desired_node_id,applied_node_id,config_pending_since_ms FROM site_node_schedules WHERE site_id=?", siteID).
+		Scan(&oldEnabled, &oldMode, &oldFixed, &oldDesired, &oldApplied, &oldPendingSince)
 	if lookupErr != nil && !errors.Is(lookupErr, sql.ErrNoRows) {
 		return SiteNodeSchedule{}, lookupErr
 	}
@@ -238,7 +239,17 @@ func (d *DB) SaveSiteNodeSchedule(siteID int64, enabled bool, mode string, fixed
 	if err != nil {
 		return SiteNodeSchedule{}, err
 	}
-	if err := markAgentConfigsDirtyTx(tx); err != nil {
+	nodeIDs := []int64{fixedNodeID}
+	if oldFixed.Valid {
+		nodeIDs = append(nodeIDs, oldFixed.Int64)
+	}
+	if oldDesired.Valid {
+		nodeIDs = append(nodeIDs, oldDesired.Int64)
+	}
+	if oldApplied.Valid {
+		nodeIDs = append(nodeIDs, oldApplied.Int64)
+	}
+	if err := markAgentConfigsDirtyForNodeIDsTx(tx, nodeIDs...); err != nil {
 		return SiteNodeSchedule{}, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -361,7 +372,16 @@ func (a *App) refreshSiteAssignments(now time.Time) error {
 	if err != nil {
 		return err
 	}
-	assignmentsChanged := false
+	type assignmentUpdate struct {
+		siteID        int64
+		desired       int64
+		status        string
+		lastError     string
+		pendingSince  int64
+		desiredChange bool
+	}
+	updates := make([]assignmentUpdate, 0)
+	changedNodeIDs := make([]int64, 0)
 	for _, value := range values {
 		if !value.Enabled {
 			continue
@@ -413,25 +433,53 @@ func (a *App) refreshSiteAssignments(now time.Time) error {
 		if desired != value.DesiredNodeID {
 			status = "pending"
 		}
-		if desired != value.DesiredNodeID {
-			assignmentsChanged = true
-			if _, err := a.db.db.Exec(`UPDATE site_node_schedules SET desired_node_id=?,dns_status=?,last_error=?,config_pending_since_ms=?,updated_at_ms=? WHERE site_id=?`,
-				nullableNodeID(desired), status, lastError, now.UnixMilli(), now.UnixMilli(), value.SiteID); err != nil {
-				return err
+		desiredChanged := desired != value.DesiredNodeID
+		statusChanged := status != value.DNSStatus || lastError != value.LastError
+		if desiredChanged || statusChanged {
+			pendingSince := value.ConfigPendingSinceMS
+			if desiredChanged {
+				pendingSince = now.UnixMilli()
 			}
-		} else if status != value.DNSStatus || lastError != value.LastError {
-			if _, err := a.db.db.Exec(`UPDATE site_node_schedules SET dns_status=?,last_error=?,updated_at_ms=? WHERE site_id=?`,
-				status, lastError, now.UnixMilli(), value.SiteID); err != nil {
-				return err
+			updates = append(updates, assignmentUpdate{
+				siteID:        value.SiteID,
+				desired:       desired,
+				status:        status,
+				lastError:     lastError,
+				pendingSince:  pendingSince,
+				desiredChange: desiredChanged,
+			})
+			if desiredChanged {
+				changedNodeIDs = append(changedNodeIDs, value.DesiredNodeID, desired)
 			}
 		}
 	}
-	if assignmentsChanged {
-		if _, err := a.db.db.Exec("UPDATE control_nodes SET config_dirty=1,updated_at_ms=? WHERE enabled=1 AND agent_token_hash<>''", now.UnixMilli()); err != nil {
+	if len(updates) == 0 {
+		return nil
+	}
+	tx, err := a.db.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	assignmentsChanged := false
+	for _, update := range updates {
+		if update.desiredChange {
+			if _, err := tx.Exec(`UPDATE site_node_schedules SET desired_node_id=?,dns_status=?,last_error=?,config_pending_since_ms=?,updated_at_ms=? WHERE site_id=?`,
+				nullableNodeID(update.desired), update.status, update.lastError, update.pendingSince, now.UnixMilli(), update.siteID); err != nil {
+				return err
+			}
+			assignmentsChanged = true
+		} else if _, err := tx.Exec(`UPDATE site_node_schedules SET dns_status=?,last_error=?,updated_at_ms=? WHERE site_id=?`,
+			update.status, update.lastError, now.UnixMilli(), update.siteID); err != nil {
 			return err
 		}
 	}
-	return nil
+	if assignmentsChanged {
+		if err := markAgentConfigsDirtyForNodeIDsTx(tx, changedNodeIDs...); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
 }
 
 // agentSiteHashBase lets the runtime hash use the Site wire shape without
@@ -464,8 +512,10 @@ type agentSiteRouteHash struct {
 }
 
 type agentRuntimeConfigHash struct {
-	SchemaVersion        int                  `json:"schema_version"`
-	ConfigHash           string               `json:"config_hash"`
+	SchemaVersion int    `json:"schema_version"`
+	ConfigHash    string `json:"config_hash"`
+	// ConfigRevision is an ordering/acknowledgement field, not runtime
+	// behavior, so deliberately keep it outside both legacy and modern hashes.
 	NodeGUID             string               `json:"node_guid"`
 	EntryMode            string               `json:"entry_mode"`
 	HTTPPort             int                  `json:"http_port"`
@@ -681,12 +731,6 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 	if err := a.refreshSiteAssignments(now); err != nil {
 		return AgentRuntimeConfig{}, err
 	}
-	rows, err := a.db.db.Query(`SELECT s.id,s.public_host,s.target_url,s.playback_target_url,s.playback_mode,s.stream_hosts,s.upstream_headers
-		FROM site_node_schedules n JOIN sites s ON s.id=n.site_id
-		WHERE n.enabled=1 AND (n.desired_node_id=? OR n.applied_node_id=?) AND s.enabled=1 ORDER BY s.id`, node.ID, node.ID)
-	if err != nil {
-		return AgentRuntimeConfig{}, err
-	}
 	type pendingRoute struct {
 		route                      AgentSiteRoute
 		storedHeaders, streamHosts string
@@ -699,6 +743,24 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 	}
 	if _, probeErr := decodeNodeProbeSecret(probeSecretText); probeErr != nil {
 		return AgentRuntimeConfig{}, probeErr
+	}
+	// Hold one SQLite read/write transaction for the route snapshot and the
+	// desired-hash publication below. This prevents a site edit from being
+	// observed half-way through config construction.
+	tx, err := a.db.db.BeginTx(ctx, nil)
+	if err != nil {
+		return AgentRuntimeConfig{}, err
+	}
+	defer tx.Rollback()
+	node, err = scanControlNode(tx.QueryRow(controlNodeSelect+" WHERE id=?", node.ID), now)
+	if err != nil {
+		return AgentRuntimeConfig{}, err
+	}
+	rows, err := tx.Query(`SELECT s.id,s.public_host,s.target_url,s.playback_target_url,s.playback_mode,s.stream_hosts,s.upstream_headers
+		FROM site_node_schedules n JOIN sites s ON s.id=n.site_id
+		WHERE n.enabled=1 AND (n.desired_node_id=? OR n.applied_node_id=?) AND s.enabled=1 ORDER BY s.id`, node.ID, node.ID)
+	if err != nil {
+		return AgentRuntimeConfig{}, err
 	}
 	for rows.Next() {
 		var value pendingRoute
@@ -746,7 +808,7 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 		if len(policy.values) > 0 {
 			route.Headers = map[string][]string(policy.values)
 		}
-		site, getErr := a.db.GetSite(route.SiteID)
+		site, getErr := getSiteTx(tx, route.SiteID)
 		if getErr != nil {
 			return AgentRuntimeConfig{}, getErr
 		}
@@ -777,7 +839,7 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 	}
 	// Keep the legacy field names in the Agent wire contract during rolling
 	// upgrades. Their values now describe one HTTPS-only listener.
-	config := AgentRuntimeConfig{SchemaVersion: agentConfigSchemaVersion, NodeGUID: node.GUID, EntryMode: "direct",
+	config := AgentRuntimeConfig{SchemaVersion: agentConfigSchemaVersion, ConfigRevision: node.ConfigRevision, NodeGUID: node.GUID, EntryMode: "direct",
 		HTTPPort: 0, HTTPSPort: node.Port, DynamicKey: encodeRuntimeKey(dynamicKey), ProbeSecret: probeSecretText,
 		CacheClearGeneration: node.CacheClearGeneration, Routes: routes}
 	// Legacy Agents do not send a platform header. Do not advertise the
@@ -816,20 +878,33 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 	if err != nil {
 		return AgentRuntimeConfig{}, err
 	}
-	// A configuration fetch also records the desired hash. Keep config_dirty set
-	// until a subsequent Agent report confirms that exact hash was applied.
-	_, err = a.db.db.Exec(`UPDATE control_nodes SET
-		desired_config_hash=?,
-		config_dirty=CASE WHEN desired_config_hash<>? THEN 1 ELSE config_dirty END,
-		updated_at_ms=? WHERE id=?`, config.ConfigHash, config.ConfigHash, now.UnixMilli(), node.ID)
+	// Publish the snapshot with a compare-and-swap. If a site/node mutation
+	// increments config_revision while this response was being assembled, do
+	// not let the stale route set become the desired configuration.
+	result, err := tx.Exec(`UPDATE control_nodes SET
+		desired_config_hash=?, desired_config_revision=?,
+		config_dirty=1, updated_at_ms=?
+		WHERE id=? AND config_revision=?`, config.ConfigHash, config.ConfigRevision, now.UnixMilli(), node.ID, node.ConfigRevision)
 	if err != nil {
 		return AgentRuntimeConfig{}, err
 	}
-	_, err = a.db.db.Exec(`UPDATE site_node_schedules SET
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return AgentRuntimeConfig{}, err
+	}
+	if rowsAffected != 1 {
+		return AgentRuntimeConfig{}, errors.New("agent configuration changed while it was being built; retry")
+	}
+	if _, err := tx.Exec(`UPDATE site_node_schedules SET
 		config_pending_since_ms=CASE WHEN config_hash<>? THEN ? ELSE config_pending_since_ms END,
 		config_hash=?,updated_at_ms=? WHERE enabled=1 AND desired_node_id=?`,
-		config.ConfigHash, now.UnixMilli(), config.ConfigHash, now.UnixMilli(), node.ID)
-	return config, err
+		config.ConfigHash, now.UnixMilli(), config.ConfigHash, now.UnixMilli(), node.ID); err != nil {
+		return AgentRuntimeConfig{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return AgentRuntimeConfig{}, err
+	}
+	return config, nil
 }
 
 func (a *App) handleAgentConfig(w http.ResponseWriter, r *http.Request) {
@@ -1016,15 +1091,25 @@ func (a *App) deleteTrackedSiteDNS(ctx context.Context, schedule SiteNodeSchedul
 	if err != nil {
 		return err
 	}
-	if schedule.cfZoneID == "" {
-		return errors.New("tracked DNS zone is missing")
-	}
-	if err := cf.deleteRecord(ctx, schedule.cfZoneID, schedule.cfRecordID); err != nil {
+	if err := deleteTrackedSiteDNSRemote(ctx, cf, schedule); err != nil {
 		return err
 	}
 	_, err = a.db.db.Exec(`UPDATE site_node_schedules SET cf_zone_id='',cf_record_id='',cf_record_type='',applied_node_id=NULL,
 		applied_address='',dns_status='disabled',last_error='',updated_at_ms=? WHERE site_id=?`, time.Now().UnixMilli(), schedule.SiteID)
 	return err
+}
+
+func deleteTrackedSiteDNSRemote(ctx context.Context, cf *cloudflareClient, schedule SiteNodeSchedule) error {
+	if schedule.cfRecordID == "" {
+		return nil
+	}
+	if cf == nil {
+		return errors.New("Cloudflare DNS client is unavailable")
+	}
+	if schedule.cfZoneID == "" {
+		return errors.New("tracked DNS zone is missing")
+	}
+	return cf.deleteRecord(ctx, schedule.cfZoneID, schedule.cfRecordID)
 }
 
 func nodeDialAddress(address string, port int) (string, error) {
@@ -1190,6 +1275,9 @@ func (a *App) reconcileOneSiteSchedule(ctx context.Context, schedule SiteNodeSch
 
 func (a *App) reconcileSiteNodeScheduling(ctx context.Context) {
 	now := time.Now()
+	if err := a.db.retryNodeTLSCleanup(""); err != nil {
+		log.Printf("[node-scheduler] managed Edge TLS cleanup retry failed: %v", err)
+	}
 	if err := a.refreshSiteAssignments(now); err != nil {
 		log.Printf("[node-scheduler] refresh assignments failed: %v", err)
 		return
@@ -1259,12 +1347,31 @@ func (a *App) removeSiteNodeSchedule(ctx context.Context, siteID int64) error {
 	if err != nil && !errors.Is(err, errNodeNotFound) {
 		return err
 	}
-	if err == nil && value.cfRecordID != "" {
-		if err := a.deleteTrackedSiteDNS(ctx, value); err != nil {
+	if err != nil {
+		return nil
+	}
+	// Freeze the local schedule before touching Cloudflare. This is the first
+	// phase of the deletion saga: a failed remote delete must never leave an
+	// enabled row that the scheduler can use to recreate DNS.
+	if _, err := a.db.db.Exec(`UPDATE site_node_schedules SET enabled=0,dns_status='waiting',last_error='',updated_at_ms=? WHERE site_id=?`, time.Now().UnixMilli(), siteID); err != nil {
+		return err
+	}
+	if value.cfRecordID != "" {
+		cf, err := a.cloudflareForScheduling()
+		if err != nil {
+			_, _ = a.db.db.Exec(`UPDATE site_node_schedules SET last_error=?,updated_at_ms=? WHERE site_id=?`, err.Error(), time.Now().UnixMilli(), siteID)
+			return err
+		}
+		if err := deleteTrackedSiteDNSRemote(ctx, cf, value); err != nil {
+			_, _ = a.db.db.Exec(`UPDATE site_node_schedules SET dns_status='waiting',last_error=?,updated_at_ms=? WHERE site_id=?`, err.Error(), time.Now().UnixMilli(), siteID)
 			return err
 		}
 	}
-	_, err = a.db.db.Exec("DELETE FROM site_node_schedules WHERE site_id=?", siteID)
+	// Keep the child row as the durable deletion handle until DeleteSite's
+	// database transaction commits. This avoids the partial-commit window where
+	// Cloudflare has been cleaned but a later site-row deletion fails.
+	_, err = a.db.db.Exec(`UPDATE site_node_schedules SET enabled=0,fixed_node_id=NULL,desired_node_id=NULL,
+		applied_node_id=NULL,cf_zone_id='',cf_record_id='',cf_record_type='',applied_address='',dns_status='disabled',last_error='',updated_at_ms=? WHERE site_id=?`, time.Now().UnixMilli(), siteID)
 	return err
 }
 
@@ -1273,19 +1380,55 @@ func (a *App) prepareNodeDeletion(ctx context.Context, nodeID int64) error {
 	if err != nil {
 		return err
 	}
+	affected := make([]SiteNodeSchedule, 0)
 	for _, value := range values {
 		if value.FixedNodeID != nodeID && value.DesiredNodeID != nodeID && value.AppliedNodeID != nodeID {
 			continue
 		}
-		if value.cfRecordID != "" {
-			if err := a.deleteTrackedSiteDNS(ctx, value); err != nil {
-				return err
-			}
-		}
-		if _, err := a.db.db.Exec(`UPDATE site_node_schedules SET enabled=0,fixed_node_id=NULL,desired_node_id=NULL,
-			applied_node_id=NULL,dns_status='disabled',last_error='',updated_at_ms=? WHERE site_id=?`, time.Now().UnixMilli(), value.SiteID); err != nil {
+		affected = append(affected, value)
+	}
+	if len(affected) == 0 {
+		return nil
+	}
+	cf, err := a.cloudflareForScheduling()
+	if err != nil {
+		return err
+	}
+	// Freeze every affected row in one local transaction before the remote phase.
+	// This makes a partial Cloudflare failure safe: all rows are disabled and
+	// retain their record IDs for retry, so the scheduler cannot recreate a
+	// record that was already deleted earlier in the batch.
+	tx, err := a.db.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	for _, value := range affected {
+		if _, err := tx.Exec(`UPDATE site_node_schedules SET enabled=0,dns_status='waiting',last_error='',updated_at_ms=? WHERE site_id=?`, time.Now().UnixMilli(), value.SiteID); err != nil {
 			return err
 		}
 	}
-	return nil
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	for _, value := range affected {
+		if err := deleteTrackedSiteDNSRemote(ctx, cf, value); err != nil {
+			// Keep every row disabled and retain tracked IDs so a later delete
+			// request can resume the remote phase idempotently.
+			_, _ = a.db.db.Exec(`UPDATE site_node_schedules SET enabled=0,dns_status='waiting',last_error=?,updated_at_ms=? WHERE site_id=?`, err.Error(), time.Now().UnixMilli(), value.SiteID)
+			return err
+		}
+	}
+	tx, err = a.db.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	for _, value := range affected {
+		if _, err := tx.Exec(`UPDATE site_node_schedules SET enabled=0,fixed_node_id=NULL,desired_node_id=NULL,
+			applied_node_id=NULL,cf_zone_id='',cf_record_id='',cf_record_type='',applied_address='',dns_status='disabled',last_error='',updated_at_ms=? WHERE site_id=?`, time.Now().UnixMilli(), value.SiteID); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
 }

--- a/site_repository.go
+++ b/site_repository.go
@@ -194,11 +194,12 @@ func (d *DB) ListSites() ([]Site, error) {
 	return sites, nil
 }
 
-func (d *DB) GetSite(id int64) (*Site, error) {
+const siteSelectColumns = `id, sort_order, name, icon_name, icon_url, listen_port, public_host, path_prefix, ingress_mode, target_url, primary_line_name, playback_target_url, playback_mode, main_video_stream_mode, failover_targets, failover_lines, stream_hosts, ua_mode, custom_user_agent, custom_client, custom_version, client_ip_mode, upstream_headers, dynamic_discovery_enabled, dynamic_profile, dynamic_discovery_sources, dynamic_domain_rules, dynamic_allow_https_downgrade, dynamic_policy_revision, asset_cache_enabled, asset_cache_ttl_sec, asset_cache_max_bytes, asset_cache_rules, watch_history_enabled, account_retention_days, account_retention_started_at_ms, account_retention_last_completed_at_ms, media_movie_count, media_series_count, media_episode_count, media_count_updated_at_ms, enabled, traffic_quota, traffic_used, traffic_used_in, traffic_used_out, speed_limit, created_at, updated_at`
+
+func scanSite(scanner rowScanner) (*Site, error) {
 	var s Site
 	var enabled, dynamicEnabled, dynamicDowngrade, assetCacheEnabled, watchHistoryEnabled int
-	err := d.db.QueryRow("SELECT id, sort_order, name, icon_name, icon_url, listen_port, public_host, path_prefix, ingress_mode, target_url, primary_line_name, playback_target_url, playback_mode, main_video_stream_mode, failover_targets, failover_lines, stream_hosts, ua_mode, custom_user_agent, custom_client, custom_version, client_ip_mode, upstream_headers, dynamic_discovery_enabled, dynamic_profile, dynamic_discovery_sources, dynamic_domain_rules, dynamic_allow_https_downgrade, dynamic_policy_revision, asset_cache_enabled, asset_cache_ttl_sec, asset_cache_max_bytes, asset_cache_rules, watch_history_enabled, account_retention_days, account_retention_started_at_ms, account_retention_last_completed_at_ms, media_movie_count, media_series_count, media_episode_count, media_count_updated_at_ms, enabled, traffic_quota, traffic_used, traffic_used_in, traffic_used_out, speed_limit, created_at, updated_at FROM sites WHERE id=?", id).
-		Scan(&s.ID, &s.SortOrder, &s.Name, &s.IconName, &s.IconURL, &s.ListenPort, &s.PublicHost, &s.PathPrefix, &s.IngressMode, &s.TargetURL, &s.PrimaryLineName, &s.PlaybackTargetURL, &s.PlaybackMode, &s.MainVideoStreamMode, &s.FailoverTargets, &s.StoredFailoverLines, &s.StreamHosts, &s.UAMode, &s.CustomUserAgent, &s.CustomClient, &s.CustomVersion, &s.ClientIPMode, &s.StoredUpstreamHeaders, &dynamicEnabled, &s.DynamicProfile, &s.StoredDynamicDiscoverySources, &s.StoredDynamicDomainRules, &dynamicDowngrade, &s.DynamicPolicyRevision, &assetCacheEnabled, &s.AssetCacheTTLSec, &s.AssetCacheMaxBytes, &s.AssetCacheRules, &watchHistoryEnabled, &s.AccountRetentionDays, &s.AccountRetentionStartedMS, &s.AccountRetentionCompletedMS, &s.MediaMovieCount, &s.MediaSeriesCount, &s.MediaEpisodeCount, &s.MediaCountUpdatedMS, &enabled, &s.TrafficQuota, &s.TrafficUsed, &s.TrafficUsedIn, &s.TrafficUsedOut, &s.SpeedLimit, &s.CreatedAt, &s.UpdatedAt)
+	err := scanner.Scan(&s.ID, &s.SortOrder, &s.Name, &s.IconName, &s.IconURL, &s.ListenPort, &s.PublicHost, &s.PathPrefix, &s.IngressMode, &s.TargetURL, &s.PrimaryLineName, &s.PlaybackTargetURL, &s.PlaybackMode, &s.MainVideoStreamMode, &s.FailoverTargets, &s.StoredFailoverLines, &s.StreamHosts, &s.UAMode, &s.CustomUserAgent, &s.CustomClient, &s.CustomVersion, &s.ClientIPMode, &s.StoredUpstreamHeaders, &dynamicEnabled, &s.DynamicProfile, &s.StoredDynamicDiscoverySources, &s.StoredDynamicDomainRules, &dynamicDowngrade, &s.DynamicPolicyRevision, &assetCacheEnabled, &s.AssetCacheTTLSec, &s.AssetCacheMaxBytes, &s.AssetCacheRules, &watchHistoryEnabled, &s.AccountRetentionDays, &s.AccountRetentionStartedMS, &s.AccountRetentionCompletedMS, &s.MediaMovieCount, &s.MediaSeriesCount, &s.MediaEpisodeCount, &s.MediaCountUpdatedMS, &enabled, &s.TrafficQuota, &s.TrafficUsed, &s.TrafficUsedIn, &s.TrafficUsedOut, &s.SpeedLimit, &s.CreatedAt, &s.UpdatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -207,6 +208,17 @@ func (d *DB) GetSite(id int64) (*Site, error) {
 		return nil, fmt.Errorf("site %d: %w", s.ID, err)
 	}
 	return &s, nil
+}
+
+func (d *DB) GetSite(id int64) (*Site, error) {
+	return scanSite(d.db.QueryRow("SELECT "+siteSelectColumns+" FROM sites WHERE id=?", id))
+}
+
+func getSiteTx(tx *sql.Tx, id int64) (*Site, error) {
+	if tx == nil {
+		return nil, errors.New("nil database transaction")
+	}
+	return scanSite(tx.QueryRow("SELECT "+siteSelectColumns+" FROM sites WHERE id=?", id))
 }
 
 func (d *DB) CreateSite(name string, port int, targetURL, playbackTargetURL, playbackMode, streamHosts, uaMode string, quota int64, speedLimit int) (*Site, error) {
@@ -602,7 +614,7 @@ func (d *DB) updateSiteRecord(site Site, restoreRevision bool) error {
 		WHERE site_id=?`, nowMS, nowMS, site.ID); err != nil {
 		return err
 	}
-	if err := markAgentConfigsDirtyTx(tx); err != nil {
+	if err := markAgentConfigsDirtyForSiteTx(tx, site.ID); err != nil {
 		return err
 	}
 	return tx.Commit()
@@ -694,7 +706,7 @@ func (d *DB) SetSiteEnabled(id int64, enabled bool) error {
 		WHERE site_id=?`, value, nowMS, nowMS, id); err != nil {
 		return err
 	}
-	if err := markAgentConfigsDirtyTx(tx); err != nil {
+	if err := markAgentConfigsDirtyForSiteTx(tx, id); err != nil {
 		return err
 	}
 	return tx.Commit()


### PR DESCRIPTION
## Changes
- add revision/CAS based Agent configuration convergence
- enforce Node to Site and Host authorization for Agent reports
- make event acknowledgement durable after Watch History persistence
- harden scheduler, DNS deletion, TLS cleanup, and backup snapshot consistency

## Validation
- go test ./...
- go test -race ./...
- go vet ./...
- gosec -quiet -severity medium -confidence medium ./...
- govulncheck ./...
