### PR TITLE
fix: harden credential, agent, backup, and release flows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
 concurrency:
   group: meridian-release
   cancel-in-progress: false
+  queue: max
 
 jobs:
   verify:

--- a/backup_restore.go
+++ b/backup_restore.go
@@ -1316,6 +1316,12 @@ func reencryptRestoredSecrets(path string, oldJWT, oldHeaderKey, newJWT, newHead
 		return err
 	}
 	defer tx.Rollback()
+	// Restoring a database must never revive a JWT issued from that snapshot,
+	// including when the destination happens to use the same JWT secret. Bump
+	// every administrator session version while the staged DB is still offline.
+	if _, err := tx.Exec(`UPDATE users SET session_version=CASE WHEN session_version<1 THEN 2 ELSE session_version+1 END`); err != nil {
+		return err
+	}
 	rows, err := tx.Query("SELECT id, target_url, upstream_headers FROM sites WHERE upstream_headers <> '' AND upstream_headers <> '[]'")
 	if err != nil {
 		return err
@@ -1480,6 +1486,51 @@ func reencryptRestoredSecrets(path string, oldJWT, oldHeaderKey, newJWT, newHead
 		}
 		for _, item := range updates {
 			if _, err := tx.Exec("UPDATE control_nodes SET probe_secret_ciphertext=? WHERE id=?", item.ciphertext, item.id); err != nil {
+				return err
+			}
+		}
+	}
+	if hasWatchToken, err := backupSQLiteColumnExists(tx, "watch_sessions", "token_ciphertext"); err != nil {
+		return err
+	} else if hasWatchToken {
+		rows, err := tx.Query("SELECT id,token_ciphertext FROM watch_sessions WHERE token_ciphertext<>''")
+		if err != nil {
+			return err
+		}
+		type watchTokenUpdate struct {
+			id         int64
+			ciphertext string
+		}
+		updates := make([]watchTokenUpdate, 0)
+		for rows.Next() {
+			var item watchTokenUpdate
+			if err := rows.Scan(&item.id, &item.ciphertext); err != nil {
+				_ = rows.Close()
+				return err
+			}
+			// Prefer the destination secret first. This makes restores idempotent
+			// (and avoids re-encrypting with a fresh nonce when the source already
+			// uses the current secret), while still migrating legacy ciphertext.
+			if _, currentErr := decryptWatchHistoryTokenWithSecret(item.ciphertext, newJWT); currentErr == nil {
+				continue
+			}
+			token, oldErr := decryptWatchHistoryTokenWithSecret(item.ciphertext, oldJWT)
+			if oldErr != nil {
+				_ = rows.Close()
+				return fmt.Errorf("无法解密观看历史 Token: %w", oldErr)
+			}
+			migrated, err := encryptWatchHistoryTokenWithSecret(token, newJWT)
+			if err != nil {
+				_ = rows.Close()
+				return fmt.Errorf("无法迁移观看历史 Token: %w", err)
+			}
+			updates = append(updates, watchTokenUpdate{id: item.id, ciphertext: migrated})
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+		for _, item := range updates {
+			if _, err := tx.Exec("UPDATE watch_sessions SET token_ciphertext=? WHERE id=?", item.ciphertext, item.id); err != nil {
 				return err
 			}
 		}

--- a/backup_restore_test.go
+++ b/backup_restore_test.go
@@ -382,6 +382,25 @@ func TestReencryptRestoredSecrets(t *testing.T) {
 	newHeader := sha256.Sum256([]byte("new-upstream-header-key-material"))
 	path := filepath.Join(t.TempDir(), "backup.db")
 	makeBackupDatabase(t, path, oldJWT, oldHeader[:])
+	watchTokenCiphertext, err := encryptWatchHistoryTokenWithSecret("watch-token-value", oldJWT)
+	if err != nil {
+		t.Fatal(err)
+	}
+	watchDB, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := watchDB.Exec(`INSERT INTO media_items (site_id,upstream_item_id,created_at_ms,updated_at_ms) VALUES (1,'watch-item',1,1)`); err != nil {
+		watchDB.Close()
+		t.Fatal(err)
+	}
+	if _, err := watchDB.Exec(`INSERT INTO watch_sessions (site_id,media_item_id,session_hash,started_at_ms,last_seen_at_ms,token_ciphertext) VALUES (1,1,'watch-session',1,1,?)`, watchTokenCiphertext); err != nil {
+		watchDB.Close()
+		t.Fatal(err)
+	}
+	if err := watchDB.Close(); err != nil {
+		t.Fatal(err)
+	}
 	before, err := sql.Open("sqlite", path)
 	if err != nil {
 		t.Fatal(err)
@@ -451,6 +470,23 @@ func TestReencryptRestoredSecrets(t *testing.T) {
 	}
 	if _, err := decryptTMDBReadTokenWithSecret(tmdbCiphertext, oldJWT); err == nil {
 		t.Fatal("old JWT secret still decrypts migrated TMDB token")
+	}
+	var migratedWatchCiphertext string
+	if err := db.QueryRow("SELECT token_ciphertext FROM watch_sessions WHERE session_hash='watch-session'").Scan(&migratedWatchCiphertext); err != nil {
+		t.Fatal(err)
+	}
+	if value, err := decryptWatchHistoryTokenWithSecret(migratedWatchCiphertext, newJWT); err != nil || value != "watch-token-value" {
+		t.Fatalf("watch history token = %q, %v", value, err)
+	}
+	if _, err := decryptWatchHistoryTokenWithSecret(migratedWatchCiphertext, oldJWT); err == nil {
+		t.Fatal("old JWT secret still decrypts migrated watch history token")
+	}
+	var sessionVersion int
+	if err := db.QueryRow("SELECT session_version FROM users WHERE username='admin'").Scan(&sessionVersion); err != nil {
+		t.Fatal(err)
+	}
+	if sessionVersion != 2 {
+		t.Fatalf("restored session version=%d, want 2", sessionVersion)
 	}
 }
 

--- a/database_migrations.go
+++ b/database_migrations.go
@@ -19,7 +19,7 @@ const (
 	// databaseSchemaVersion is independent from the application and backup
 	// format versions. It is persisted in SQLite so restores can reject a
 	// database whose columns/state are newer than this binary understands.
-	databaseSchemaVersion = 37
+	databaseSchemaVersion = 38
 )
 
 func (d *DB) migrate() error {
@@ -866,6 +866,17 @@ func (d *DB) migrateOnce() error {
 	);
 	CREATE INDEX IF NOT EXISTS idx_node_site_traffic_site_time ON node_site_traffic_logs(site_id, recorded_at_ms);
 	CREATE INDEX IF NOT EXISTS idx_node_site_traffic_node_time ON node_site_traffic_logs(node_id, recorded_at_ms);`); err != nil {
+		return err
+	}
+	if _, err := conn.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS watch_history_inbox (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		payload_json TEXT NOT NULL,
+		created_at_ms INTEGER NOT NULL,
+		attempts INTEGER NOT NULL DEFAULT 0,
+		next_attempt_at_ms INTEGER NOT NULL DEFAULT 0,
+		last_error TEXT NOT NULL DEFAULT ''
+	);
+	CREATE INDEX IF NOT EXISTS idx_watch_history_inbox_due ON watch_history_inbox(next_attempt_at_ms, id);`); err != nil {
 		return err
 	}
 	var cacheSizeColumn int

--- a/edge_agent.go
+++ b/edge_agent.go
@@ -784,6 +784,68 @@ func (runtime *edgeAgentRuntime) commitSiteStats(pending edgeSiteStatsPending) {
 	}
 }
 
+// syncSiteTrafficLimits updates the live quota baseline without rebuilding
+// the proxy bundle. TrafficCycleUsage is Controller-authoritative usage for
+// the current billing cycle; keeping it outside the config hash lets normal
+// telemetry refresh the quota state without restarting every site.
+func (runtime *edgeAgentRuntime) syncSiteTrafficLimits(config AgentRuntimeConfig) {
+	if runtime == nil {
+		return
+	}
+	runtime.mu.RLock()
+	bundle := runtime.bundle
+	runtime.mu.RUnlock()
+	if bundle == nil || bundle.manager == nil || bundle.database == nil {
+		return
+	}
+	bundle.manager.mu.RLock()
+	defer bundle.manager.mu.RUnlock()
+	for _, route := range config.Routes {
+		cycleMode := route.TrafficBillingMode
+		if cycleMode != trafficBillingModeOutbound && cycleMode != trafficBillingModeBidirectional {
+			settings := bundle.database.currentSystemSettings()
+			cycleMode = trafficBillingModeLabel(settings.TrafficBillingMode)
+		}
+		cycleStart := time.Time{}
+		if route.TrafficCycleStartMS > 0 {
+			cycleStart = time.UnixMilli(route.TrafficCycleStartMS)
+		} else if route.TrafficBillingMode == "" {
+			// A legacy Controller did not send a cycle marker. Reconstruct the
+			// local default only for that wire contract; an empty marker from a
+			// current Controller means the configured cycle intentionally has no
+			// reset boundary.
+			settings := bundle.database.currentSystemSettings()
+			cycleStart = trafficCycleStart(time.Now(), settings.TrafficResetDay, timezoneLocation(settings.ScheduleTimezone))
+		}
+		cycleUsage := route.TrafficCycleUsage
+		// Older Controllers did not send a cycle baseline. Preserve their
+		// previous behavior as a compatibility fallback; current Controllers
+		// always send TrafficCycleStartMS and therefore use the authoritative
+		// cycle value above (which may legitimately be zero).
+		if route.TrafficCycleStartMS == 0 && route.TrafficBillingMode == "" {
+			cycleUsage = route.Site.TrafficUsed
+		}
+		for localID, identity := range bundle.localSites {
+			if identity.centralID != route.SiteID {
+				continue
+			}
+			inst := bundle.manager.proxies[localID]
+			if inst == nil {
+				continue
+			}
+			inst.trafficMu.Lock()
+			inst.Site.TrafficQuota = route.Site.TrafficQuota
+			inst.Site.TrafficUsed = route.Site.TrafficUsed
+			inst.Site.TrafficUsedIn = route.Site.TrafficUsedIn
+			inst.Site.TrafficUsedOut = route.Site.TrafficUsedOut
+			inst.trafficCycleStart = cycleStart
+			inst.trafficCycleMode = cycleMode
+			inst.trafficCycleUsage = cycleUsage
+			inst.trafficMu.Unlock()
+		}
+	}
+}
+
 func (runtime *edgeAgentRuntime) siteStatsSnapshot() []NodeSiteStat {
 	pending := runtime.prepareSiteStats()
 	runtime.commitSiteStats(pending)
@@ -972,9 +1034,6 @@ func buildEdgeProxy(config AgentRuntimeConfig, runtime *edgeAgentRuntime) (*edge
 		site.StoredDynamicDiscoverySources = route.DynamicSources
 		site.StoredDynamicDomainRules = route.DynamicRules
 		site.Enabled = true
-		// Node-level scheduling owns quota exhaustion. A stale local site counter
-		// must never block traffic after a DNS assignment changes nodes.
-		site.TrafficQuota = 0
 		if route.SiteID > 0 {
 			site.AssetCacheNamespace = fmt.Sprintf("site-%d-config-%s", route.SiteID, edgeAssetCacheGeneration(site, route))
 		}
@@ -1854,6 +1913,7 @@ func runEdgeAgent() error {
 			} else if configErr := validateAgentConfigEnvelope(config); configErr != nil {
 				fmt.Fprintf(os.Stderr, "Meridian Agent rejected config: %v\n", configErr)
 			} else {
+				runtime.syncSiteTrafficLimits(config)
 				// Refresh the pending payload when the Controller sends a newer
 				// hash, but do not reset an in-progress retry backoff when the
 				// same failing configuration is fetched again after a report ACK.

--- a/edge_agent_test.go
+++ b/edge_agent_test.go
@@ -146,6 +146,42 @@ func TestEdgeProxyReportsMediaCountsWithCentralSiteID(t *testing.T) {
 	}
 }
 
+func TestEdgeProxyEnforcesControllerTrafficQuotaAfterConfigRefresh(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "should-not-be-reached")
+	}))
+	defer upstream.Close()
+	runtime := &edgeAgentRuntime{stateDir: t.TempDir()}
+	settings := defaultSystemSettings()
+	cycleStart := trafficCycleStart(time.Now(), settings.TrafficResetDay, timezoneLocation(settings.ScheduleTimezone))
+	config := AgentRuntimeConfig{
+		SchemaVersion: 1, NodeGUID: "quota-node", HTTPSPort: 19090, DynamicKey: testEdgeRuntimeKey(t),
+		Routes: []AgentSiteRoute{{
+			SiteID: 74, Host: "quota.example.test", TargetURL: upstream.URL,
+			TrafficCycleUsage: 100, TrafficCycleStartMS: cycleStart.UnixMilli(), TrafficBillingMode: trafficBillingModeBidirectional,
+			Site: Site{
+				Name: "quota", PublicHost: "quota.example.test", IngressMode: ingressModeHost,
+				TargetURL: upstream.URL, PlaybackMode: "direct", MainVideoStreamMode: "proxy",
+				StreamHosts: "[]", UAMode: passthroughUAMode, ClientIPMode: clientIPModeBoth,
+				TrafficQuota: 100, TrafficUsed: 100,
+			},
+			FailoverTargets: "[]", StreamHostsRaw: "[]", DynamicSources: "[]", DynamicRules: "[]",
+		}},
+	}
+	bundle, err := buildEdgeProxy(config, runtime)
+	if err != nil {
+		t.Fatalf("build edge proxy: %v", err)
+	}
+	defer bundle.close()
+	runtime.bundle = bundle
+	runtime.syncSiteTrafficLimits(config)
+	response := httptest.NewRecorder()
+	bundle.handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "https://quota.example.test/Items", nil))
+	if response.Code != http.StatusForbidden || !strings.Contains(response.Body.String(), "traffic quota exceeded") {
+		t.Fatalf("quota response = %d %q, want 403 quota exceeded", response.Code, response.Body.String())
+	}
+}
+
 func TestEdgeTelemetryMapsRetentionAndObservationToCentralSiteID(t *testing.T) {
 	localSites := map[int64]edgeSiteIdentity{
 		3: {centralID: 91, host: "mapped.example.test"},

--- a/install.sh
+++ b/install.sh
@@ -725,16 +725,6 @@ set_panel_env() {
     install_env_file "$tmp_file" || return 1
 }
 
-write_rotated_env() {
-    local secret="$1" output="$2" env_file
-    env_file=$(env_file_path) || return 1
-    # $1 is an awk field reference, not a shell variable.
-    # shellcheck disable=SC2016
-    as_root awk -F= '$1 != "JWT_SECRET" { print }' "$env_file" > "$output" || return 1
-    printf 'JWT_SECRET=%s\n' "$secret" >> "$output" || return 1
-    chmod 0600 "$output" || return 1
-}
-
 remove_loopback_proxies() {
     local current="$1" item result="" old_ifs="$IFS"
     IFS=','
@@ -2067,7 +2057,7 @@ cleanup_password_transaction() {
     local exit_code=$?
     if [ "$exit_code" -ne 0 ] && [ "$PASSWORD_TRANSACTION" = "1" ] \
         && [ -n "$PASSWORD_SNAPSHOT_DIR" ] && [ -n "$PASSWORD_DB_PATH" ]; then
-        warn "密码修改中断，正在恢复旧密码和 JWT 配置..."
+        warn "密码修改中断，正在恢复旧密码..."
         as_root systemctl stop "$SERVICE_NAME" >/dev/null 2>&1 || true
         if ! restore_auth_snapshot "$PASSWORD_SNAPSHOT_DIR" "$PASSWORD_DB_PATH" >/dev/null 2>&1; then
             warn "自动恢复凭据失败，请使用备份手动恢复: ${LAST_BACKUP_PATH:-<unknown>}"
@@ -2082,7 +2072,7 @@ cleanup_password_transaction() {
     if [ -n "$PASSWORD_TMP_DIR" ] && [ -d "$PASSWORD_TMP_DIR" ] && [ "$PASSWORD_TMP_DIR" != "/" ]; then
         as_root rm -rf -- "$PASSWORD_TMP_DIR"
     fi
-    unset password password_again new_secret 2>/dev/null || true
+    unset password password_again 2>/dev/null || true
     return "$exit_code"
 }
 
@@ -2092,7 +2082,7 @@ abort_password_transaction() {
 }
 
 do_password() {
-    local password password_again length db_path tmp_dir snapshot_dir rotated_env new_secret mutated=0
+    local password password_again length db_path tmp_dir snapshot_dir mutated=0
     local current_binary="${INSTALL_DIR}/${BIN_NAME}"
     [ -x "$current_binary" ] || fail "Meridian 尚未安装"
     is_systemd || fail "自动修改密码要求 Meridian 由 systemd 管理"
@@ -2119,7 +2109,6 @@ do_password() {
     tmp_dir=$(mktemp -d)
     chmod 0700 "$tmp_dir"
     snapshot_dir="${tmp_dir}/snapshot"
-    rotated_env="${tmp_dir}/env.rotated"
     PASSWORD_TMP_DIR="$tmp_dir"
     PASSWORD_SNAPSHOT_DIR="$snapshot_dir"
     PASSWORD_DB_PATH="$db_path"
@@ -2135,19 +2124,17 @@ do_password() {
     trap cleanup_password_transaction EXIT
     trap abort_password_transaction INT TERM
 
-    new_secret=$(generate_secret)
-    write_rotated_env "$new_secret" "$rotated_env"
     if printf '%s\n' "$password" | as_root "$current_binary" admin reset-password --db "$db_path" --password-stdin; then
         mutated=1
     fi
     unset password password_again
     if [ "$mutated" != "1" ]; then
-        fail "管理员密码修改失败，将自动恢复旧密码与 JWT 配置"
+        fail "管理员密码修改失败，将自动恢复旧密码"
     fi
 
-    if ! install_env_file "$rotated_env" || ! fix_database_permissions "$db_path" \
+    if ! fix_database_permissions "$db_path" \
         || ! as_root systemctl restart "$SERVICE_NAME" || ! wait_for_health 20; then
-        warn "重启或健康检查失败，正在恢复旧密码与 JWT 配置..."
+        warn "重启或健康检查失败，正在恢复旧密码..."
         fail "密码修改失败，将自动执行凭据回滚"
     fi
 
@@ -2157,7 +2144,6 @@ do_password() {
     PASSWORD_DB_PATH=""
     as_root rm -rf -- "$tmp_dir"
     trap - EXIT INT TERM
-    unset new_secret
     ok "管理员密码已修改，所有旧登录令牌已失效"
 }
 

--- a/proxy_start.go
+++ b/proxy_start.go
@@ -328,7 +328,9 @@ func (pm *ProxyManager) StartSite(site Site) error {
 				requestLogEntry.BackendAddress = tracker.Get()
 			}
 			if event, ok := watchHistoryEventFromCapture(watchHistoryCapture, pm.database, site, r, inst.trustedProxies, requestLogEntry.StatusCode, requestEndedAt); ok {
-				pm.database.EnqueueWatchHistory(event)
+				if !pm.database.EnqueueWatchHistory(event) {
+					log.Printf("[watch-history] event could not be queued site=%d", event.SiteID)
+				}
 			}
 			pm.accountRetention.Observe(site, r, inst.trustedProxies, requestLogEntry.ResourceCategory, requestLogEntry.StatusCode, requestStartedAt, requestEndedAt)
 			pm.database.EnqueueRequestLog(requestLogEntry)
@@ -352,11 +354,17 @@ func (pm *ProxyManager) StartSite(site Site) error {
 		inst.reqCount.Add(1)
 		inst.pendingRequests.Add(1)
 
-		if site.TrafficQuota > 0 {
+		// The Controller can refresh quota usage on an already running Agent
+		// without rebuilding the proxy bundle. Read the live quota baseline from
+		// the instance so a scheduled route cannot retain a stale zero quota.
+		inst.trafficMu.Lock()
+		trafficQuota := inst.Site.TrafficQuota
+		inst.trafficMu.Unlock()
+		if trafficQuota > 0 {
 			currentUsed, usageErr := pm.currentTrafficCycleUsage(inst, time.Now())
 			if usageErr != nil {
 				log.Printf("[%s] failed to calculate current traffic cycle usage: %v", site.Name, usageErr)
-			} else if currentUsed >= site.TrafficQuota {
+			} else if currentUsed >= trafficQuota {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusForbidden)
 				w.Write([]byte(`{"error":"traffic quota exceeded"}`))

--- a/site_node_scheduler.go
+++ b/site_node_scheduler.go
@@ -68,6 +68,13 @@ type AgentSiteRoute struct {
 	UpstreamHeaders   string              `json:"upstream_headers_raw,omitempty"`
 	DynamicSources    string              `json:"dynamic_sources_raw,omitempty"`
 	DynamicRules      string              `json:"dynamic_rules_raw,omitempty"`
+	// TrafficCycleUsage is the Controller's authoritative usage for the
+	// currently active billing cycle. It is intentionally excluded from the
+	// runtime config hash because it changes with telemetry, while the quota
+	// itself remains part of the route identity.
+	TrafficCycleUsage   int64  `json:"traffic_cycle_usage,omitempty"`
+	TrafficCycleStartMS int64  `json:"traffic_cycle_start_ms,omitempty"`
+	TrafficBillingMode  string `json:"traffic_billing_mode,omitempty"`
 }
 
 type AgentRuntimeConfig struct {
@@ -547,6 +554,13 @@ func agentConfigHashPayload(config AgentRuntimeConfig, legacy bool) agentRuntime
 	}
 	routes := make([]agentSiteRouteHash, len(config.Routes))
 	for i, route := range config.Routes {
+		hashSite := route.Site
+		// Traffic usage is a live accounting value. It is delivered in the
+		// route so an Agent can enforce the quota, but must not participate in
+		// the runtime identity or every report would force a full proxy apply.
+		hashSite.TrafficUsed = 0
+		hashSite.TrafficUsedIn = 0
+		hashSite.TrafficUsedOut = 0
 		routes[i] = agentSiteRouteHash{
 			SiteID:            route.SiteID,
 			Host:              route.Host,
@@ -555,7 +569,7 @@ func agentConfigHashPayload(config AgentRuntimeConfig, legacy bool) agentRuntime
 			StreamHosts:       route.StreamHosts,
 			PlaybackMode:      route.PlaybackMode,
 			Headers:           route.Headers,
-			Site:              agentSiteHash{agentSiteHashBase: agentSiteHashBase(route.Site)},
+			Site:              agentSiteHash{agentSiteHashBase: agentSiteHashBase(hashSite)},
 			FailoverTargets:   route.FailoverTargets,
 			FailoverLines:     route.FailoverLines,
 			StreamHostsRaw:    route.StreamHostsRaw,
@@ -731,6 +745,9 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 	if err := a.refreshSiteAssignments(now); err != nil {
 		return AgentRuntimeConfig{}, err
 	}
+	settings := a.db.currentSystemSettings()
+	cycleStart := trafficCycleStart(now, settings.TrafficResetDay, timezoneLocation(settings.ScheduleTimezone))
+	cycleMode := trafficBillingModeLabel(settings.TrafficBillingMode)
 	type pendingRoute struct {
 		route                      AgentSiteRoute
 		storedHeaders, streamHosts string
@@ -818,10 +835,6 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 		// runtime route configuration.
 		route.Site.IconName = ""
 		route.Site.IconURL = ""
-		route.Site.TrafficQuota = 0
-		route.Site.TrafficUsed = 0
-		route.Site.TrafficUsedIn = 0
-		route.Site.TrafficUsedOut = 0
 		route.Site.MediaMovieCount = 0
 		route.Site.MediaSeriesCount = 0
 		route.Site.MediaEpisodeCount = 0
@@ -829,6 +842,14 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 		route.Site.CreatedAt = ""
 		route.Site.UpdatedAt = ""
 		route.Site.UpstreamHeaders = nil
+		route.TrafficCycleUsage, err = sumTrafficSinceForSiteTx(tx, route.SiteID, cycleStart, cycleMode)
+		if err != nil {
+			return AgentRuntimeConfig{}, fmt.Errorf("site %d traffic usage: %w", route.SiteID, err)
+		}
+		if !cycleStart.IsZero() {
+			route.TrafficCycleStartMS = cycleStart.UnixMilli()
+		}
+		route.TrafficBillingMode = cycleMode
 		route.FailoverTargets = site.FailoverTargets
 		route.FailoverLines = site.StoredFailoverLines
 		route.StreamHostsRaw = site.StreamHosts
@@ -842,18 +863,6 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 	config := AgentRuntimeConfig{SchemaVersion: agentConfigSchemaVersion, ConfigRevision: node.ConfigRevision, NodeGUID: node.GUID, EntryMode: "direct",
 		HTTPPort: 0, HTTPSPort: node.Port, DynamicKey: encodeRuntimeKey(dynamicKey), ProbeSecret: probeSecretText,
 		CacheClearGeneration: node.CacheClearGeneration, Routes: routes}
-	// Legacy Agents do not send a platform header. Do not advertise the
-	// controller's local binary to those clients: on a cross-architecture
-	// rollout that checksum would make an old arm64 Agent download an amd64
-	// executable and fail with ENOEXEC. New Agents identify their platform and
-	// receive the matching version/digest below.
-	if platform != "" {
-		manifest, manifestErr := agentReleaseManifestForPlatform(ctx, platform)
-		if manifestErr == nil {
-			config.AgentVersion = manifest.Version
-			config.AgentSHA256 = manifest.SHA256
-		}
-	}
 	if len(routes) > 0 {
 		if a.panelCertificates == nil {
 			return AgentRuntimeConfig{}, errors.New("edge TLS certificate is unavailable")
@@ -903,6 +912,17 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 	}
 	if err := tx.Commit(); err != nil {
 		return AgentRuntimeConfig{}, err
+	}
+	// Release metadata is advisory and deliberately excluded from the runtime
+	// hash. Fetch it after the SQLite transaction so a slow/unavailable GitHub
+	// request never monopolizes the controller's single database connection.
+	// Legacy Agents do not send a platform header and therefore receive no
+	// update metadata, preserving cross-architecture rollout safety.
+	if platform != "" {
+		if manifest, manifestErr := agentReleaseManifestForPlatform(ctx, platform); manifestErr == nil {
+			config.AgentVersion = manifest.Version
+			config.AgentSHA256 = manifest.SHA256
+		}
 	}
 	return config, nil
 }
@@ -1390,9 +1410,19 @@ func (a *App) prepareNodeDeletion(ctx context.Context, nodeID int64) error {
 	if len(affected) == 0 {
 		return nil
 	}
-	cf, err := a.cloudflareForScheduling()
-	if err != nil {
-		return err
+	needsCloudflare := false
+	for _, value := range affected {
+		if strings.TrimSpace(value.cfRecordID) != "" {
+			needsCloudflare = true
+			break
+		}
+	}
+	var cf *cloudflareClient
+	if needsCloudflare {
+		cf, err = a.cloudflareForScheduling()
+		if err != nil {
+			return err
+		}
 	}
 	// Freeze every affected row in one local transaction before the remote phase.
 	// This makes a partial Cloudflare failure safe: all rows are disabled and
@@ -1412,6 +1442,9 @@ func (a *App) prepareNodeDeletion(ctx context.Context, nodeID int64) error {
 		return err
 	}
 	for _, value := range affected {
+		if strings.TrimSpace(value.cfRecordID) == "" {
+			continue
+		}
 		if err := deleteTrackedSiteDNSRemote(ctx, cf, value); err != nil {
 			// Keep every row disabled and retain tracked IDs so a later delete
 			// request can resume the remote phase idempotently.

--- a/telemetry_writer.go
+++ b/telemetry_writer.go
@@ -107,6 +107,7 @@ func (d *DB) runDynamicObservationWriter() {
 			select {
 			case command = <-d.dynamicObservationQueue:
 			case <-ticker.C:
+				d.drainWatchHistoryInbox(time.Now())
 				if err := d.pruneDynamicObservations(); err != nil {
 					d.droppedDynamicObservations.Add(1)
 					log.Printf("[dynamic-observations] optional retention write failed: %v", err)
@@ -202,7 +203,20 @@ func (d *DB) runDynamicObservationWriter() {
 			}
 			skipped, err := d.writeWatchHistoryBatch(watchHistoryBatch)
 			if err != nil {
-				d.droppedWatchHistory.Add(uint64(len(watchHistoryBatch)))
+				// A transient SQLite failure must not silently discard completed
+				// playback sessions. Move valid events to the durable inbox so the
+				// maintenance pass can retry them after the database recovers.
+				queued, inboxErr := d.persistWatchHistoryInboxBatch(watchHistoryBatch)
+				validCount := len(watchHistoryBatch) - skipped
+				if validCount < 0 {
+					validCount = 0
+				}
+				if lost := validCount - queued; lost > 0 {
+					d.droppedWatchHistory.Add(uint64(lost))
+				}
+				if inboxErr != nil {
+					log.Printf("[watch-history] durable inbox write failed: %v", inboxErr)
+				}
 				log.Printf("[watch-history] optional batch write failed: %v", err)
 			} else if skipped > 0 {
 				d.droppedWatchHistory.Add(uint64(skipped))

--- a/tests/install_test.sh
+++ b/tests/install_test.sh
@@ -1137,7 +1137,6 @@ run_password_case() {
     }
     is_systemd() { return 0; }
     wait_for_health() { [ "$health_result" = success ]; }
-    install_env_file() { cp "$1" "$(env_file_path)"; }
     fix_database_permissions() { return 0; }
     snapshot_auth_files() {
         mkdir -p "$1"
@@ -1157,8 +1156,8 @@ if ! (run_password_case success) >"${TEST_ROOT}/password-success.log" 2>&1; then
     exit 1
 fi
 assert_contains "${DATA_DIR}/meridian.db" 'new-database-state'
-if grep -Fq 'old-jwt-secret' "${DATA_DIR}/.env"; then
-    echo 'FAIL: JWT secret was not rotated after password change' >&2
+if ! grep -Fq 'JWT_SECRET=old-jwt-secret' "${DATA_DIR}/.env"; then
+    echo 'FAIL: JWT secret changed during password change' >&2
     exit 1
 fi
 assert_contains "${TEST_ROOT}/password-success.log" '所有旧登录令牌已失效'

--- a/tmdb_service.go
+++ b/tmdb_service.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"mime"
 	"net/http"
 	"net/url"
@@ -121,7 +122,19 @@ func (s *tmdbService) Run(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
-		s.runOne(ctx, time.Now())
+		const tmdbJobsPerWake = 10
+		for i := 0; i < tmdbJobsPerWake; i++ {
+			processed, err := s.runOne(ctx, time.Now())
+			if err != nil {
+				// runOne records retry state for claimable jobs. Keep the worker
+				// alive so one transient database/network error cannot stop all
+				// subsequent metadata processing.
+				log.Printf("[tmdb] worker error: %v", err)
+			}
+			if !processed {
+				break
+			}
+		}
 	}
 }
 
@@ -139,49 +152,53 @@ func tmdbRetryDelay(attempts int) time.Duration {
 	return delay
 }
 
-func (s *tmdbService) runOne(ctx context.Context, now time.Time) {
+func (s *tmdbService) runOne(ctx context.Context, now time.Time) (bool, error) {
 	stored, err := s.db.tmdbSettings()
 	if err != nil || !stored.Enabled || stored.TokenCiphertext == "" || stored.CredentialState == tmdbCredentialInvalid {
-		return
+		return false, err
 	}
 	token, err := decryptTMDBReadToken(stored.TokenCiphertext)
 	if err != nil {
 		_ = s.db.markTMDBCredentialResult(tmdbCredentialInvalid, "decrypt", now.UnixMilli())
-		return
+		return false, err
 	}
 	job, found, err := s.db.claimTMDBJob(now.UnixMilli())
-	if err != nil || !found {
-		return
+	if err != nil {
+		return false, err
+	}
+	if !found {
+		return false, nil
 	}
 	if cached, ok, cacheErr := s.db.cachedTMDBMetadata(job, stored.Language, now.UnixMilli()); cacheErr == nil && ok {
-		_ = s.db.completeTMDBJob(job.ID, job.JobRevision, cached, stored.Language, now.UnixMilli())
-		return
+		return true, s.db.completeTMDBJob(job.ID, job.JobRevision, cached, stored.Language, now.UnixMilli())
 	}
 	metadata, lookupErr := s.client.lookupMedia(ctx, token, stored.Language, job)
 	if lookupErr == nil {
-		if err := s.db.completeTMDBJob(job.ID, job.JobRevision, metadata, stored.Language, now.UnixMilli()); err == nil {
+		completeErr := s.db.completeTMDBJob(job.ID, job.JobRevision, metadata, stored.Language, now.UnixMilli())
+		if completeErr == nil {
 			_ = s.db.markTMDBCredentialResult(tmdbCredentialReady, "", now.UnixMilli())
+			return true, nil
 		}
-		return
+		return true, completeErr
 	}
 	var apiErr *tmdbAPIError
 	if !errors.As(lookupErr, &apiErr) {
-		_ = s.db.retryTMDBJob(job.ID, job.JobRevision, jobAttempts(job.ID, s.db), "network", now.Add(tmdbRetryDelay(1)).UnixMilli())
-		return
+		attempts := jobAttempts(job.ID, s.db)
+		return true, s.db.retryTMDBJob(job.ID, job.JobRevision, attempts, "network", now.Add(tmdbRetryDelay(attempts)).UnixMilli())
 	}
 	switch apiErr.Code {
 	case "auth":
 		_ = s.db.markTMDBCredentialResult(tmdbCredentialInvalid, "auth", now.UnixMilli())
-		_ = s.db.retryTMDBJob(job.ID, job.JobRevision, 1, "auth", now.Add(6*time.Hour).UnixMilli())
+		return true, s.db.retryTMDBJob(job.ID, job.JobRevision, 1, "auth", now.Add(6*time.Hour).UnixMilli())
 	case "no_confident_match", "insufficient_metadata", "unsupported_media_type", "client_error", "redirect":
-		_ = s.db.finishTMDBJobWithoutMatch(job.ID, job.JobRevision, apiErr.Code, now.UnixMilli())
+		return true, s.db.finishTMDBJobWithoutMatch(job.ID, job.JobRevision, apiErr.Code, now.UnixMilli())
 	default:
 		wait := apiErr.RetryAfter
 		attempts := jobAttempts(job.ID, s.db)
 		if wait <= 0 {
 			wait = tmdbRetryDelay(attempts)
 		}
-		_ = s.db.retryTMDBJob(job.ID, job.JobRevision, attempts, apiErr.Code, now.Add(wait).UnixMilli())
+		return true, s.db.retryTMDBJob(job.ID, job.JobRevision, attempts, apiErr.Code, now.Add(wait).UnixMilli())
 	}
 }
 

--- a/traffic_repository.go
+++ b/traffic_repository.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"database/sql"
+	"errors"
 	"log"
 	"sort"
 	"strings"
@@ -266,10 +268,29 @@ func (d *DB) SumTrafficSinceBySite(start time.Time, billingMode string) (map[int
 // Directional columns remain raw so changing the billing mode never destroys
 // the information needed to recalculate the current cycle.
 func (d *DB) SumTrafficSinceForSite(siteID int64, start time.Time, billingMode string) (int64, error) {
+	return sumTrafficSinceForSiteQuery(d.db, siteID, start, billingMode)
+}
+
+// sumTrafficSinceForSiteTx is the transaction-scoped equivalent used while
+// building an Agent route snapshot. Keeping the usage read in that snapshot
+// transaction makes the quota baseline consistent with the site assignment
+// and avoids a second connection racing a telemetry flush.
+func sumTrafficSinceForSiteTx(tx *sql.Tx, siteID int64, start time.Time, billingMode string) (int64, error) {
+	if tx == nil {
+		return 0, errors.New("nil traffic transaction")
+	}
+	return sumTrafficSinceForSiteQuery(tx, siteID, start, billingMode)
+}
+
+type trafficQueryer interface {
+	QueryRow(query string, args ...any) *sql.Row
+}
+
+func sumTrafficSinceForSiteQuery(queryer trafficQueryer, siteID int64, start time.Time, billingMode string) (int64, error) {
 	var bytesIn, bytesOut int64
 	startMS := start.UnixMilli()
 	startText := start.In(time.Local).Format("2006-01-02 15:04:05")
-	err := d.db.QueryRow(`
+	err := queryer.QueryRow(`
 		WITH source AS (
 			SELECT bytes_in, bytes_out
 			FROM traffic_logs
@@ -281,7 +302,7 @@ func (d *DB) SumTrafficSinceForSite(siteID int64, start time.Time, billingMode s
 		)
 		SELECT COALESCE(SUM(bytes_in), 0), COALESCE(SUM(bytes_out), 0)
 		FROM source
-	`, siteID, startMS, startText, siteID, startMS).Scan(&bytesIn, &bytesOut)
+		`, siteID, startMS, startText, siteID, startMS).Scan(&bytesIn, &bytesOut)
 	return trafficBillableBytes(billingMode, bytesIn, bytesOut), err
 }
 

--- a/watch_history.go
+++ b/watch_history.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -30,6 +31,7 @@ const (
 	watchHistoryQueueCapacity     = 1024
 	watchHistoryBatchSize         = 64
 	watchHistoryGlobalRowLimit    = 50000
+	watchHistoryInboxLimit        = 10000
 	watchHistoryMaxIDBytes        = 256
 	watchHistoryMaxTitleBytes     = 512
 	watchHistoryMaxTextBytes      = 4096
@@ -151,11 +153,15 @@ func encryptWatchHistoryToken(token string) (string, error) {
 	if jwtSecretEphemeral {
 		return "", errors.New("watch history token storage requires a stable JWT secret")
 	}
+	return encryptWatchHistoryTokenWithSecret(token, jwtSecret)
+}
+
+func encryptWatchHistoryTokenWithSecret(token string, secret []byte) (string, error) {
 	token = strings.TrimSpace(token)
-	if token == "" || len(token) > watchHistoryMaxTokenBytes || strings.ContainsAny(token, "\r\n") {
+	if len(secret) < 32 || token == "" || len(token) > watchHistoryMaxTokenBytes || strings.ContainsAny(token, "\r\n") {
 		return "", errors.New("invalid watch history token")
 	}
-	block, err := aes.NewCipher(watchHistoryTokenKeyForSecret(jwtSecret))
+	block, err := aes.NewCipher(watchHistoryTokenKeyForSecret(secret))
 	if err != nil {
 		return "", err
 	}
@@ -172,6 +178,13 @@ func encryptWatchHistoryToken(token string) (string, error) {
 }
 
 func decryptWatchHistoryToken(ciphertext string) (string, error) {
+	if jwtSecretEphemeral {
+		return "", errors.New("watch history token storage requires a stable JWT secret")
+	}
+	return decryptWatchHistoryTokenWithSecret(ciphertext, jwtSecret)
+}
+
+func decryptWatchHistoryTokenWithSecret(ciphertext string, secret []byte) (string, error) {
 	if !strings.HasPrefix(ciphertext, watchHistoryTokenCipherPrefix) {
 		return "", errors.New("invalid watch history token ciphertext")
 	}
@@ -179,7 +192,10 @@ func decryptWatchHistoryToken(ciphertext string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	block, err := aes.NewCipher(watchHistoryTokenKeyForSecret(jwtSecret))
+	if len(secret) < 32 {
+		return "", errors.New("invalid watch history token secret")
+	}
+	block, err := aes.NewCipher(watchHistoryTokenKeyForSecret(secret))
 	if err != nil {
 		return "", err
 	}
@@ -1147,8 +1163,127 @@ func (d *DB) EnqueueWatchHistory(event watchHistoryEvent) bool {
 	case d.dynamicObservationQueue <- command:
 		return true
 	default:
+		if d.persistWatchHistoryInbox(event) {
+			return true
+		}
 		d.droppedWatchHistory.Add(1)
 		return false
+	}
+}
+
+// persistWatchHistoryInbox is the durable overflow path for the asynchronous
+// watch-history writer. Playback must not silently lose a completed session
+// merely because the in-memory queue is full or the writer is restarting.
+func (d *DB) persistWatchHistoryInbox(event watchHistoryEvent) bool {
+	inserted, err := d.persistWatchHistoryInboxBatch([]watchHistoryEvent{event})
+	return err == nil && inserted == 1
+}
+
+// persistWatchHistoryInboxBatch makes the asynchronous writer failure path
+// durable in one transaction. Invalid events are skipped because they cannot
+// be made valid by retrying; valid events remain recoverable across restarts.
+func (d *DB) persistWatchHistoryInboxBatch(events []watchHistoryEvent) (int, error) {
+	if d == nil || d.db == nil || d.edgeEphemeral {
+		return 0, errors.New("watch history inbox unavailable")
+	}
+	tx, err := d.db.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+	var count int
+	if err := tx.QueryRow("SELECT COUNT(*) FROM watch_history_inbox").Scan(&count); err != nil || count >= watchHistoryInboxLimit {
+		if err == nil {
+			err = errors.New("watch history inbox is full")
+		}
+		return 0, err
+	}
+	inserted := 0
+	createdAt := time.Now().UnixMilli()
+	for _, event := range events {
+		if !validWatchHistoryEvent(event) {
+			continue
+		}
+		payload, marshalErr := json.Marshal(event)
+		if marshalErr != nil || len(payload) > watchHistoryBodyLimit {
+			continue
+		}
+		if count+inserted >= watchHistoryInboxLimit {
+			return inserted, errors.New("watch history inbox is full")
+		}
+		if _, err := tx.Exec("INSERT INTO watch_history_inbox(payload_json,created_at_ms) VALUES(?,?,?)", string(payload), createdAt); err != nil {
+			return inserted, err
+		}
+		inserted++
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return inserted, nil
+}
+
+func (d *DB) drainWatchHistoryInbox(now time.Time) {
+	if d == nil || d.db == nil || d.edgeEphemeral {
+		return
+	}
+	rows, err := d.db.Query("SELECT id,payload_json,attempts FROM watch_history_inbox WHERE next_attempt_at_ms<=? ORDER BY id LIMIT ?", now.UnixMilli(), watchHistoryBatchSize)
+	if err != nil {
+		log.Printf("[watch-history] inbox read failed: %v", err)
+		return
+	}
+	type item struct {
+		id       int64
+		payload  string
+		attempts int
+	}
+	items := make([]item, 0, watchHistoryBatchSize)
+	for rows.Next() {
+		var value item
+		if err := rows.Scan(&value.id, &value.payload, &value.attempts); err != nil {
+			_ = rows.Close()
+			log.Printf("[watch-history] inbox row read failed: %v", err)
+			return
+		}
+		items = append(items, value)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		log.Printf("[watch-history] inbox rows failed: %v", err)
+		return
+	}
+	_ = rows.Close()
+	if len(items) == 0 {
+		return
+	}
+	events := make([]watchHistoryEvent, 0, len(items))
+	for _, value := range items {
+		var event watchHistoryEvent
+		if err := json.Unmarshal([]byte(value.payload), &event); err != nil || !validWatchHistoryEvent(event) {
+			_, _ = d.db.Exec("DELETE FROM watch_history_inbox WHERE id=?", value.id)
+			continue
+		}
+		events = append(events, event)
+	}
+	if len(events) == 0 {
+		return
+	}
+	if _, err := d.writeWatchHistoryBatch(events); err != nil {
+		for _, value := range items {
+			attempts := value.attempts + 1
+			if attempts > 8 {
+				attempts = 8
+			}
+			delay := time.Second * time.Duration(1<<uint(attempts-1))
+			if delay > 15*time.Minute {
+				delay = 15 * time.Minute
+			}
+			_, _ = d.db.Exec("UPDATE watch_history_inbox SET attempts=?,next_attempt_at_ms=?,last_error=? WHERE id=?", attempts, now.Add(delay).UnixMilli(), requestLogSafeText(err.Error(), 512), value.id)
+		}
+		log.Printf("[watch-history] inbox write failed: %v", err)
+		return
+	}
+	for _, value := range items {
+		_, _ = d.db.Exec("DELETE FROM watch_history_inbox WHERE id=?", value.id)
 	}
 }
 


### PR DESCRIPTION
## 变更
- 管理员重置密码时保留 JWT_SECRET，仅通过 session_version 使旧会话失效。
- 节点 Agent 配置下发当前计费周期用量、周期起点和计费模式；Agent 在运行实例上刷新限额，保留未上报流量。
- Manifest 网络请求移出 SQLite 事务；无 DNS 节点删除跳过 Cloudflare 初始化。
- Watch History 溢出和批量写失败进入 durable inbox，后台按退避重试。
- 恢复数据库时递增管理员会话版本并迁移 watch_sessions Token 密文。
- TMDB 使用真实退避次数并在每次唤醒处理一批任务。
- Release workflow 增加串行发布队列配置。

## 验证
- go test ./... -count=1
- go test -race ./... -count=1
- go vet ./...
- govulncheck ./...
- gosec -quiet -severity medium -confidence medium ./...
- node --check 全部 web/static/js 文件
- node --test tests/*.test.js（162 项通过）

本机未安装 bash/docker；安装脚本和 Docker 构建由 GitHub Release CI 验证。
