### PR TITLE
fix: harden telemetry persistence and agent traffic state

### DIFF
--- a/app_sites.go
+++ b/app_sites.go
@@ -1050,22 +1050,16 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := a.db.DeleteSite(id); err != nil {
-			// The row survived the delete, so an enabled site must not be left
-			// without a running instance: restart it from a fresh read (which
-			// includes the traffic StopSite flushed). Failures in the restore
-			// are reported explicitly instead of claiming success.
-			restored, getErr := a.db.GetSite(id)
-			if getErr != nil {
-				a.jsonErr(w, 500, fmt.Sprintf("delete site: %v; site stopped and reload failed: %v", err, getErr))
+			// StopSite, schedule freeze, and remote DNS cleanup are already past
+			// their irreversible boundary. Never restart an enabled row here: that
+			// would make the local proxy look healthy while its schedule/DNS state
+			// has been removed. Keep the row disabled as an explicit retry handle.
+			if disableErr := a.db.SetSiteEnabled(id, false); disableErr != nil {
+				a.jsonErr(w, http.StatusInternalServerError, fmt.Sprintf("delete site: %v; disable cleanup-pending site: %v", err, disableErr))
 				return
 			}
-			if restored.Enabled {
-				if restartErr := a.pm.StartSite(*restored); restartErr != nil {
-					a.jsonErr(w, 500, fmt.Sprintf("delete site: %v; restore instance: %v", err, restartErr))
-					return
-				}
-			}
-			a.jsonErr(w, 500, err.Error())
+			a.pm.UnregisterSiteHost(id)
+			a.jsonErr(w, http.StatusServiceUnavailable, fmt.Sprintf("delete deferred; site disabled; retry deletion: %v", err))
 			return
 		}
 		a.pm.UnregisterSiteHost(id)

--- a/backup_restore.go
+++ b/backup_restore.go
@@ -1535,6 +1535,67 @@ func reencryptRestoredSecrets(path string, oldJWT, oldHeaderKey, newJWT, newHead
 			}
 		}
 	}
+	// Durable inbox rows can outlive the process that captured them. Their
+	// serialized watch-history events may contain Emby tokens encrypted with the
+	// source controller's JWT secret, so migrate them alongside watch_sessions.
+	if hasInboxPayload, err := backupSQLiteColumnExists(tx, "watch_history_inbox", "payload_json"); err != nil {
+		return err
+	} else if hasInboxPayload {
+		rows, err := tx.Query("SELECT id,payload_json FROM watch_history_inbox WHERE payload_json<>''")
+		if err != nil {
+			return err
+		}
+		type inboxTokenUpdate struct {
+			id      int64
+			payload string
+		}
+		updates := make([]inboxTokenUpdate, 0)
+		for rows.Next() {
+			var id int64
+			var payload string
+			if err := rows.Scan(&id, &payload); err != nil {
+				_ = rows.Close()
+				return err
+			}
+			var event watchHistoryEvent
+			if err := json.Unmarshal([]byte(payload), &event); err != nil {
+				// The inbox drain path already treats malformed payloads as
+				// discardable; do not make an otherwise valid backup unrecoverable.
+				continue
+			}
+			if event.TokenCiphertext == "" {
+				continue
+			}
+			if _, currentErr := decryptWatchHistoryTokenWithSecret(event.TokenCiphertext, newJWT); currentErr == nil {
+				continue
+			}
+			token, oldErr := decryptWatchHistoryTokenWithSecret(event.TokenCiphertext, oldJWT)
+			if oldErr != nil {
+				_ = rows.Close()
+				return fmt.Errorf("无法解密观看历史收件箱 Token: %w", oldErr)
+			}
+			migrated, err := encryptWatchHistoryTokenWithSecret(token, newJWT)
+			if err != nil {
+				_ = rows.Close()
+				return fmt.Errorf("无法迁移观看历史收件箱 Token: %w", err)
+			}
+			event.TokenCiphertext = migrated
+			encoded, err := json.Marshal(event)
+			if err != nil {
+				_ = rows.Close()
+				return err
+			}
+			updates = append(updates, inboxTokenUpdate{id: id, payload: string(encoded)})
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+		for _, item := range updates {
+			if _, err := tx.Exec("UPDATE watch_history_inbox SET payload_json=? WHERE id=?", item.payload, item.id); err != nil {
+				return err
+			}
+		}
+	}
 	return tx.Commit()
 }
 

--- a/backup_restore_test.go
+++ b/backup_restore_test.go
@@ -386,6 +386,13 @@ func TestReencryptRestoredSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	inboxEvent, err := json.Marshal(watchHistoryEvent{
+		SiteID: 1, SessionHash: "inbox-session", UpstreamItemID: "inbox-item",
+		EventType: "stop", ObservedAtMS: 2, TokenCiphertext: watchTokenCiphertext,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	watchDB, err := sql.Open("sqlite", path)
 	if err != nil {
 		t.Fatal(err)
@@ -395,6 +402,10 @@ func TestReencryptRestoredSecrets(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := watchDB.Exec(`INSERT INTO watch_sessions (site_id,media_item_id,session_hash,started_at_ms,last_seen_at_ms,token_ciphertext) VALUES (1,1,'watch-session',1,1,?)`, watchTokenCiphertext); err != nil {
+		watchDB.Close()
+		t.Fatal(err)
+	}
+	if _, err := watchDB.Exec(`INSERT INTO watch_history_inbox (site_id,session_hash,observed_at_ms,payload_json,created_at_ms) VALUES (1,'inbox-session',2,?,2)`, string(inboxEvent)); err != nil {
 		watchDB.Close()
 		t.Fatal(err)
 	}
@@ -480,6 +491,20 @@ func TestReencryptRestoredSecrets(t *testing.T) {
 	}
 	if _, err := decryptWatchHistoryTokenWithSecret(migratedWatchCiphertext, oldJWT); err == nil {
 		t.Fatal("old JWT secret still decrypts migrated watch history token")
+	}
+	var migratedInboxPayload string
+	if err := db.QueryRow("SELECT payload_json FROM watch_history_inbox WHERE session_hash='inbox-session'").Scan(&migratedInboxPayload); err != nil {
+		t.Fatal(err)
+	}
+	var migratedInboxEvent watchHistoryEvent
+	if err := json.Unmarshal([]byte(migratedInboxPayload), &migratedInboxEvent); err != nil {
+		t.Fatal(err)
+	}
+	if value, err := decryptWatchHistoryTokenWithSecret(migratedInboxEvent.TokenCiphertext, newJWT); err != nil || value != "watch-token-value" {
+		t.Fatalf("watch history inbox token = %q, %v", value, err)
+	}
+	if _, err := decryptWatchHistoryTokenWithSecret(migratedInboxEvent.TokenCiphertext, oldJWT); err == nil {
+		t.Fatal("old JWT secret still decrypts migrated watch history inbox token")
 	}
 	var sessionVersion int
 	if err := db.QueryRow("SELECT session_version FROM users WHERE username='admin'").Scan(&sessionVersion); err != nil {

--- a/database.go
+++ b/database.go
@@ -21,6 +21,7 @@ type DB struct {
 
 	dynamicObservationQueue     chan dynamicObservationCommand
 	dynamicObservationDone      chan struct{}
+	watchHistoryInboxWake       chan struct{}
 	dynamicObservationGate      sync.RWMutex
 	dynamicObservationCloseOnce sync.Once
 	dynamicObservationClosed    atomic.Bool
@@ -70,6 +71,7 @@ func openDB(path string) (*DB, error) {
 	}
 	d.dynamicObservationQueue = make(chan dynamicObservationCommand, dynamicObservationQueueCapacity+requestLogQueueCapacity+watchHistoryQueueCapacity)
 	d.dynamicObservationDone = make(chan struct{})
+	d.watchHistoryInboxWake = make(chan struct{}, 1)
 	go d.runDynamicObservationWriter()
 	return d, nil
 }

--- a/database_migrations.go
+++ b/database_migrations.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -19,7 +20,7 @@ const (
 	// databaseSchemaVersion is independent from the application and backup
 	// format versions. It is persisted in SQLite so restores can reject a
 	// database whose columns/state are newer than this binary understands.
-	databaseSchemaVersion = 38
+	databaseSchemaVersion = 39
 )
 
 func (d *DB) migrate() error {
@@ -870,6 +871,9 @@ func (d *DB) migrateOnce() error {
 	}
 	if _, err := conn.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS watch_history_inbox (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		site_id INTEGER NOT NULL DEFAULT 0,
+		session_hash TEXT NOT NULL DEFAULT '',
+		observed_at_ms INTEGER NOT NULL DEFAULT 0,
 		payload_json TEXT NOT NULL,
 		created_at_ms INTEGER NOT NULL,
 		attempts INTEGER NOT NULL DEFAULT 0,
@@ -878,6 +882,56 @@ func (d *DB) migrateOnce() error {
 	);
 	CREATE INDEX IF NOT EXISTS idx_watch_history_inbox_due ON watch_history_inbox(next_attempt_at_ms, id);`); err != nil {
 		return err
+	}
+	for _, migration := range []struct{ column, sql string }{
+		{"site_id", "ALTER TABLE watch_history_inbox ADD COLUMN site_id INTEGER NOT NULL DEFAULT 0"},
+		{"session_hash", "ALTER TABLE watch_history_inbox ADD COLUMN session_hash TEXT NOT NULL DEFAULT ''"},
+		{"observed_at_ms", "ALTER TABLE watch_history_inbox ADD COLUMN observed_at_ms INTEGER NOT NULL DEFAULT 0"},
+	} {
+		var found int
+		if err := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM pragma_table_info('watch_history_inbox') WHERE name=?", migration.column).Scan(&found); err != nil {
+			return err
+		}
+		if found == 0 {
+			if _, err := conn.ExecContext(ctx, migration.sql); err != nil {
+				return err
+			}
+		}
+	}
+	// Recover metadata for inbox rows created before the columns existed. Rows
+	// that are malformed remain marked with site_id=0 and will be discarded by
+	// the normal inbox validator rather than being assigned to an arbitrary site.
+	rows, err := conn.QueryContext(ctx, "SELECT id,payload_json FROM watch_history_inbox WHERE site_id=0 OR session_hash='' OR observed_at_ms=0")
+	if err != nil {
+		return err
+	}
+	type inboxMetadata struct {
+		id    int64
+		event watchHistoryEvent
+	}
+	metadata := make([]inboxMetadata, 0)
+	for rows.Next() {
+		var item inboxMetadata
+		var payload string
+		if err := rows.Scan(&item.id, &payload); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		if err := json.Unmarshal([]byte(payload), &item.event); err == nil && item.event.SiteID > 0 && item.event.SessionHash != "" && item.event.ObservedAtMS > 0 {
+			metadata = append(metadata, item)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return err
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	for _, item := range metadata {
+		if _, err := conn.ExecContext(ctx, "UPDATE watch_history_inbox SET site_id=?,session_hash=?,observed_at_ms=? WHERE id=?", item.event.SiteID, item.event.SessionHash, item.event.ObservedAtMS, item.id); err != nil {
+			return err
+		}
 	}
 	var cacheSizeColumn int
 	if err := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM pragma_table_info('node_site_counters') WHERE name='cache_size_bytes'").Scan(&cacheSizeColumn); err != nil {

--- a/edge_agent.go
+++ b/edge_agent.go
@@ -773,13 +773,38 @@ func (runtime *edgeAgentRuntime) commitSiteStats(pending edgeSiteStatsPending) {
 		return
 	}
 	runtime.mu.Lock()
-	defer runtime.mu.Unlock()
 	if runtime.siteReported == nil {
 		runtime.siteReported = make(map[int64]ProxyRuntimeStat)
 	}
 	for siteID, sent := range pending.current {
 		if current := runtime.siteReported[siteID]; current == sent || current.CumulativeBytesIn <= sent.CumulativeBytesIn && current.CumulativeBytesOut <= sent.CumulativeBytesOut {
 			runtime.siteReported[siteID] = sent
+		}
+	}
+	bundle := runtime.bundle
+	reported := make(map[int64]ProxyRuntimeStat, len(pending.current))
+	for siteID := range pending.current {
+		reported[siteID] = runtime.siteReported[siteID]
+	}
+	runtime.mu.Unlock()
+	// Move the ACK watermark into the live instances immediately. Otherwise a
+	// successful report would remain part of the local delta until the next
+	// config refresh and could be charged twice against a quota.
+	if bundle == nil || bundle.manager == nil {
+		return
+	}
+	bundle.manager.mu.RLock()
+	defer bundle.manager.mu.RUnlock()
+	for localID, identity := range bundle.localSites {
+		stat, ok := reported[identity.centralID]
+		if !ok {
+			continue
+		}
+		if inst := bundle.manager.proxies[localID]; inst != nil {
+			inst.trafficMu.Lock()
+			inst.trafficAckedCumulativeIn = stat.CumulativeBytesIn
+			inst.trafficAckedCumulativeOut = stat.CumulativeBytesOut
+			inst.trafficMu.Unlock()
 		}
 	}
 }
@@ -798,11 +823,18 @@ func (runtime *edgeAgentRuntime) syncSiteTrafficLimits(config AgentRuntimeConfig
 	if bundle == nil || bundle.manager == nil || bundle.database == nil {
 		return
 	}
+	runtime.mu.RLock()
+	ackedReports := make(map[int64]ProxyRuntimeStat, len(runtime.siteReported))
+	for siteID, stat := range runtime.siteReported {
+		ackedReports[siteID] = stat
+	}
+	runtime.mu.RUnlock()
 	bundle.manager.mu.RLock()
 	defer bundle.manager.mu.RUnlock()
 	for _, route := range config.Routes {
 		cycleMode := route.TrafficBillingMode
-		if cycleMode != trafficBillingModeOutbound && cycleMode != trafficBillingModeBidirectional {
+		controllerCycle := cycleMode == trafficBillingModeOutbound || cycleMode == trafficBillingModeBidirectional || route.TrafficCycleStartMS != 0
+		if !controllerCycle {
 			settings := bundle.database.currentSystemSettings()
 			cycleMode = trafficBillingModeLabel(settings.TrafficBillingMode)
 		}
@@ -841,6 +873,10 @@ func (runtime *edgeAgentRuntime) syncSiteTrafficLimits(config AgentRuntimeConfig
 			inst.trafficCycleStart = cycleStart
 			inst.trafficCycleMode = cycleMode
 			inst.trafficCycleUsage = cycleUsage
+			inst.trafficCycleAuthoritative = controllerCycle
+			acked := ackedReports[route.SiteID]
+			inst.trafficAckedCumulativeIn = acked.CumulativeBytesIn
+			inst.trafficAckedCumulativeOut = acked.CumulativeBytesOut
 			inst.trafficMu.Unlock()
 		}
 	}
@@ -1012,6 +1048,12 @@ func buildEdgeProxy(config AgentRuntimeConfig, runtime *edgeAgentRuntime) (*edge
 	siteIDs := make(map[string]int64, len(config.Routes))
 	localSites := make(map[int64]edgeSiteIdentity, len(config.Routes))
 	runtimeSites := make(map[string]Site, len(config.Routes))
+	runtime.mu.RLock()
+	ackedReports := make(map[int64]ProxyRuntimeStat, len(runtime.siteReported))
+	for siteID, stat := range runtime.siteReported {
+		ackedReports[siteID] = stat
+	}
+	runtime.mu.RUnlock()
 	for _, route := range config.Routes {
 		site := route.Site
 		site.ID = 0
@@ -1034,6 +1076,15 @@ func buildEdgeProxy(config AgentRuntimeConfig, runtime *edgeAgentRuntime) (*edge
 		site.StoredDynamicDiscoverySources = route.DynamicSources
 		site.StoredDynamicDomainRules = route.DynamicRules
 		site.Enabled = true
+		if route.TrafficBillingMode == trafficBillingModeOutbound || route.TrafficBillingMode == trafficBillingModeBidirectional || route.TrafficCycleStartMS != 0 {
+			site.runtimeTrafficCycleConfigured = true
+			site.runtimeTrafficCycleUsage = route.TrafficCycleUsage
+			site.runtimeTrafficCycleStartMS = route.TrafficCycleStartMS
+			site.runtimeTrafficBillingMode = route.TrafficBillingMode
+			acked := ackedReports[route.SiteID]
+			site.runtimeTrafficAckedCumulativeIn = acked.CumulativeBytesIn
+			site.runtimeTrafficAckedCumulativeOut = acked.CumulativeBytesOut
+		}
 		if route.SiteID > 0 {
 			site.AssetCacheNamespace = fmt.Sprintf("site-%d-config-%s", route.SiteID, edgeAssetCacheGeneration(site, route))
 		}
@@ -1045,6 +1096,15 @@ func buildEdgeProxy(config AgentRuntimeConfig, runtime *edgeAgentRuntime) (*edge
 			return fail(updateErr)
 		}
 		created.AssetCacheNamespace = site.AssetCacheNamespace
+		// CreateSiteRecord hydrates the persisted fields from the ephemeral
+		// database, so copy the controller-authoritative quota snapshot back onto
+		// the runtime-only fields before StartSite installs the proxy instance.
+		created.runtimeTrafficCycleUsage = site.runtimeTrafficCycleUsage
+		created.runtimeTrafficCycleStartMS = site.runtimeTrafficCycleStartMS
+		created.runtimeTrafficBillingMode = site.runtimeTrafficBillingMode
+		created.runtimeTrafficCycleConfigured = site.runtimeTrafficCycleConfigured
+		created.runtimeTrafficAckedCumulativeIn = site.runtimeTrafficAckedCumulativeIn
+		created.runtimeTrafficAckedCumulativeOut = site.runtimeTrafficAckedCumulativeOut
 		siteIDs[site.PublicHost] = route.SiteID
 		localSites[created.ID] = edgeSiteIdentity{centralID: route.SiteID, host: site.PublicHost}
 		bundle.localSites[created.ID] = localSites[created.ID]
@@ -1278,10 +1338,16 @@ func (runtime *edgeAgentRuntime) apply(config AgentRuntimeConfig) (retErr error)
 	runtime.handler = bundle.handler
 	runtime.bundle = bundle
 	// The in-memory Edge database and proxy counters are rebuilt on every
-	// configuration apply. Drop per-site report baselines as well; the
-	// Controller binds site traffic to AppliedConfigHash, so the next report
-	// must describe the new runtime epoch from zero.
-	runtime.siteReported = make(map[int64]ProxyRuntimeStat)
+	// configuration apply. Keep the Controller ACK watermark for sites that are
+	// still present so the new zeroed counters represent only post-apply local
+	// traffic and cannot be charged twice against the Controller baseline.
+	retainedReports := make(map[int64]ProxyRuntimeStat, len(config.Routes))
+	for _, route := range config.Routes {
+		if stat, ok := oldState.siteReported[route.SiteID]; ok {
+			retainedReports[route.SiteID] = stat
+		}
+	}
+	runtime.siteReported = retainedReports
 	runtime.mu.Unlock()
 	newServerStarted := false
 	if listenerChanged && needsListener {

--- a/edge_agent_test.go
+++ b/edge_agent_test.go
@@ -173,8 +173,9 @@ func TestEdgeProxyEnforcesControllerTrafficQuotaAfterConfigRefresh(t *testing.T)
 		t.Fatalf("build edge proxy: %v", err)
 	}
 	defer bundle.close()
+	runtime.mu.Lock()
 	runtime.bundle = bundle
-	runtime.syncSiteTrafficLimits(config)
+	runtime.mu.Unlock()
 	response := httptest.NewRecorder()
 	bundle.handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "https://quota.example.test/Items", nil))
 	if response.Code != http.StatusForbidden || !strings.Contains(response.Body.String(), "traffic quota exceeded") {

--- a/main_test.go
+++ b/main_test.go
@@ -5263,10 +5263,10 @@ func TestSiteUpdateRestartsPreStoppedInstanceWhenRecordUpdateFails(t *testing.T)
 	}
 }
 
-// DELETE restarts the stopped enabled site when the row deletion fails: the
-// instance is never left stopped while the enabled row survives. The failure
-// is injected with a trigger that aborts row deletion after the stop flush.
-func TestDeleteSiteRestartsInstanceWhenDeleteFails(t *testing.T) {
+// DELETE leaves a disabled cleanup-pending row when the final delete fails
+// after schedule/DNS cleanup. The row is retained as a retry handle and the
+// proxy is not restarted with stale routing state.
+func TestDeleteSiteLeavesCleanupPendingWhenDeleteFails(t *testing.T) {
 	app := newTestApp(t)
 	port := freePort(t)
 	site, err := app.db.CreateSite("del-restore", port, "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 0, 0)
@@ -5294,8 +5294,8 @@ func TestDeleteSiteRestartsInstanceWhenDeleteFails(t *testing.T) {
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodDelete, "/api/sites/"+jsonNumber64(site.ID), nil)
 	app.handleSiteByID(rr, req)
-	if rr.Code != http.StatusInternalServerError {
-		t.Fatalf("DELETE status = %d, want 500; body=%s", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("DELETE status = %d, want 503; body=%s", rr.Code, rr.Body.String())
 	}
 	if !strings.Contains(rr.Body.String(), "delete blocked") {
 		t.Fatalf("DELETE error must report the delete failure: %s", rr.Body.String())
@@ -5305,26 +5305,17 @@ func TestDeleteSiteRestartsInstanceWhenDeleteFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetSite: %v", err)
 	}
-	if !reloaded.Enabled {
-		t.Fatal("site row was mutated despite the failed delete")
+	if reloaded.Enabled {
+		t.Fatal("site row must be disabled while cleanup is pending")
 	}
 	if reloaded.TrafficUsed != 15 {
 		t.Fatalf("traffic_used = %d, want 15 (the stop flush persisted pending bytes)", reloaded.TrafficUsed)
 	}
-	if !app.pm.IsRunning(site.ID) {
-		t.Fatal("the stopped instance was not restarted after the failed delete")
+	if app.pm.IsRunning(site.ID) {
+		t.Fatal("the stopped instance must remain stopped until deletion is retried")
 	}
-	app.pm.mu.RLock()
-	restarted := app.pm.proxies[site.ID]
-	app.pm.mu.RUnlock()
-	if restarted == nil || restarted == inst {
-		t.Fatal("expected a fresh instance for the surviving row")
-	}
-	if got := restarted.persistedTraffic.Load(); got != 15 {
-		t.Fatalf("restarted persistedTraffic = %d, want 15", got)
-	}
-	if in, out := restarted.bytesIn.Load(), restarted.bytesOut.Load(); in != 0 || out != 0 {
-		t.Fatalf("restarted pending counters = in:%d out:%d, want 0/0", in, out)
+	if _, ok := app.pm.PublicHostSiteID(site.PublicHost); ok {
+		t.Fatal("stale public host registration survived cleanup-pending deletion")
 	}
 }
 

--- a/proxy_lifecycle.go
+++ b/proxy_lifecycle.go
@@ -166,12 +166,25 @@ func (pm *ProxyManager) flushProxyTrafficLocked(inst *ProxyInstance) error {
 // once per reset boundary or billing-mode change, then advanced by successful
 // traffic flushes while trafficMu prevents a swap/query race.
 func (pm *ProxyManager) currentTrafficCycleUsage(inst *ProxyInstance, now time.Time) (int64, error) {
+	inst.trafficMu.Lock()
+	defer inst.trafficMu.Unlock()
+	// An Agent route carries the Controller's authoritative cycle boundary,
+	// billing mode, and persisted baseline. Never replace those values with the
+	// Agent's local in-memory database defaults.
+	if inst.trafficCycleAuthoritative && (inst.trafficCycleMode == trafficBillingModeOutbound || inst.trafficCycleMode == trafficBillingModeBidirectional) {
+		localIn := inst.cumulativeBytesIn.Load() - inst.trafficAckedCumulativeIn
+		localOut := inst.cumulativeBytesOut.Load() - inst.trafficAckedCumulativeOut
+		if localIn < 0 {
+			localIn = inst.cumulativeBytesIn.Load()
+		}
+		if localOut < 0 {
+			localOut = inst.cumulativeBytesOut.Load()
+		}
+		return inst.trafficCycleUsage + trafficBillableBytes(inst.trafficCycleMode, localIn, localOut), nil
+	}
 	settings := pm.database.currentSystemSettings()
 	cycleStart := trafficCycleStart(now, settings.TrafficResetDay, timezoneLocation(settings.ScheduleTimezone))
 	cycleMode := trafficBillingModeLabel(settings.TrafficBillingMode)
-
-	inst.trafficMu.Lock()
-	defer inst.trafficMu.Unlock()
 	if inst.trafficCycleMode != cycleMode || !inst.trafficCycleStart.Equal(cycleStart) {
 		persisted, err := pm.database.SumTrafficSinceForSite(inst.Site.ID, cycleStart, cycleMode)
 		if err != nil {
@@ -180,6 +193,8 @@ func (pm *ProxyManager) currentTrafficCycleUsage(inst *ProxyInstance, now time.T
 		inst.trafficCycleStart = cycleStart
 		inst.trafficCycleMode = cycleMode
 		inst.trafficCycleUsage = persisted
+		inst.trafficAckedCumulativeIn = inst.cumulativeBytesIn.Load()
+		inst.trafficAckedCumulativeOut = inst.cumulativeBytesOut.Load()
 	}
 	return inst.trafficCycleUsage + trafficBillableBytes(cycleMode, inst.bytesIn.Load(), inst.bytesOut.Load()), nil
 }

--- a/proxy_manager.go
+++ b/proxy_manager.go
@@ -39,22 +39,25 @@ type ProxyInstance struct {
 	// single-site history snapshot and the live overlay in global snapshots.
 	// Lock order is pm.mu -> trafficMu; helpers that take trafficMu (e.g.
 	// flushProxyTraffic) must never be called from code that already holds it.
-	trafficMu          sync.Mutex
-	bytesIn            atomic.Int64
-	bytesOut           atomic.Int64
-	cumulativeBytesIn  atomic.Int64
-	cumulativeBytesOut atomic.Int64
-	persistedBytesIn   atomic.Int64
-	persistedBytesOut  atomic.Int64
-	reqCount           atomic.Int64
-	pendingRequests    atomic.Int64
-	persistedTraffic   atomic.Int64
-	trafficCycleStart  time.Time
-	trafficCycleMode   string
-	trafficCycleUsage  int64
-	trustedProxies     []*net.IPNet
-	dynamicState       *dynamicSiteState
-	failoverState      *upstreamFailoverState
+	trafficMu                 sync.Mutex
+	bytesIn                   atomic.Int64
+	bytesOut                  atomic.Int64
+	cumulativeBytesIn         atomic.Int64
+	cumulativeBytesOut        atomic.Int64
+	persistedBytesIn          atomic.Int64
+	persistedBytesOut         atomic.Int64
+	reqCount                  atomic.Int64
+	pendingRequests           atomic.Int64
+	persistedTraffic          atomic.Int64
+	trafficCycleStart         time.Time
+	trafficCycleMode          string
+	trafficCycleUsage         int64
+	trafficAckedCumulativeIn  int64
+	trafficAckedCumulativeOut int64
+	trafficCycleAuthoritative bool
+	trustedProxies            []*net.IPNet
+	dynamicState              *dynamicSiteState
+	failoverState             *upstreamFailoverState
 }
 
 type ProxyManager struct {

--- a/proxy_start.go
+++ b/proxy_start.go
@@ -129,6 +129,16 @@ func (pm *ProxyManager) StartSite(site Site) error {
 	inst.persistedTraffic.Store(site.TrafficUsed)
 	inst.persistedBytesIn.Store(site.TrafficUsedIn)
 	inst.persistedBytesOut.Store(site.TrafficUsedOut)
+	if site.runtimeTrafficCycleConfigured {
+		inst.trafficCycleUsage = site.runtimeTrafficCycleUsage
+		inst.trafficCycleMode = site.runtimeTrafficBillingMode
+		if site.runtimeTrafficCycleStartMS > 0 {
+			inst.trafficCycleStart = time.UnixMilli(site.runtimeTrafficCycleStartMS)
+		}
+		inst.trafficAckedCumulativeIn = site.runtimeTrafficAckedCumulativeIn
+		inst.trafficAckedCumulativeOut = site.runtimeTrafficAckedCumulativeOut
+		inst.trafficCycleAuthoritative = true
+	}
 	if inst.persistedBytesIn.Load() == 0 && inst.persistedBytesOut.Load() == 0 && site.TrafficUsed > 0 {
 		legacyIn, legacyOut := legacyTrafficDirections(site.TrafficUsed)
 		inst.persistedBytesIn.Store(legacyIn)

--- a/site_repository.go
+++ b/site_repository.go
@@ -72,6 +72,14 @@ type Site struct {
 	// SQLite rows whenever a configuration is applied, so cache identity must
 	// come from the controller rather than the local row ID.
 	AssetCacheNamespace string `json:"-"`
+	// Agent runtime-only quota state. These values are populated from the
+	// Controller's route snapshot and never persisted in the site row.
+	runtimeTrafficCycleUsage         int64
+	runtimeTrafficCycleStartMS       int64
+	runtimeTrafficBillingMode        string
+	runtimeTrafficCycleConfigured    bool
+	runtimeTrafficAckedCumulativeIn  int64
+	runtimeTrafficAckedCumulativeOut int64
 }
 
 func hydrateSiteConfiguration(site *Site, dynamicEnabled, dynamicDowngrade, assetCacheEnabled, watchHistoryEnabled int) error {

--- a/telemetry_writer.go
+++ b/telemetry_writer.go
@@ -92,6 +92,8 @@ func (d *DB) runDynamicObservationWriter() {
 	defer close(d.dynamicObservationDone)
 	ticker := time.NewTicker(dynamicObservationMaintenanceInterval)
 	defer ticker.Stop()
+	inboxTicker := time.NewTicker(5 * time.Second)
+	defer inboxTicker.Stop()
 
 	batch := make([]queuedDynamicObservation, 0, dynamicObservationBatchSize)
 	requestBatch := make([]queuedRequestLog, 0, requestLogBatchSize)
@@ -119,6 +121,12 @@ func (d *DB) runDynamicObservationWriter() {
 				if err := d.pruneWatchHistory(); err != nil {
 					log.Printf("[watch-history] optional retention write failed: %v", err)
 				}
+				continue
+			case <-inboxTicker.C:
+				d.drainWatchHistoryInbox(time.Now())
+				continue
+			case <-d.watchHistoryInboxWake:
+				d.drainWatchHistoryInbox(time.Now())
 				continue
 			}
 		}
@@ -271,6 +279,7 @@ func (d *DB) runDynamicObservationWriter() {
 
 		switch command.kind {
 		case dynamicObservationCommandFlush:
+			d.drainWatchHistoryInbox(time.Now())
 			command.result <- nil
 		case dynamicObservationCommandClear:
 			_, err := d.db.Exec("DELETE FROM dynamic_observations WHERE site_id=?", command.siteID)

--- a/watch_history.go
+++ b/watch_history.go
@@ -1179,6 +1179,16 @@ func (d *DB) persistWatchHistoryInbox(event watchHistoryEvent) bool {
 	return err == nil && inserted == 1
 }
 
+func (d *DB) signalWatchHistoryInboxWake() {
+	if d == nil || d.watchHistoryInboxWake == nil {
+		return
+	}
+	select {
+	case d.watchHistoryInboxWake <- struct{}{}:
+	default:
+	}
+}
+
 // persistWatchHistoryInboxBatch makes the asynchronous writer failure path
 // durable in one transaction. Invalid events are skipped because they cannot
 // be made valid by retrying; valid events remain recoverable across restarts.
@@ -1209,15 +1219,28 @@ func (d *DB) persistWatchHistoryInboxBatch(events []watchHistoryEvent) (int, err
 			continue
 		}
 		if count+inserted >= watchHistoryInboxLimit {
+			// Commit the rows already inserted before reporting that the
+			// remaining batch could not fit. Returning a positive count without
+			// committing would make callers believe events were durable when the
+			// deferred rollback had discarded them.
+			if err := tx.Commit(); err != nil {
+				return 0, err
+			}
+			d.signalWatchHistoryInboxWake()
 			return inserted, errors.New("watch history inbox is full")
 		}
-		if _, err := tx.Exec("INSERT INTO watch_history_inbox(payload_json,created_at_ms) VALUES(?,?,?)", string(payload), createdAt); err != nil {
+		if _, err := tx.Exec(`INSERT INTO watch_history_inbox(
+			site_id,session_hash,observed_at_ms,payload_json,created_at_ms
+		) VALUES(?,?,?,?,?)`, event.SiteID, event.SessionHash, event.ObservedAtMS, string(payload), createdAt); err != nil {
 			return inserted, err
 		}
 		inserted++
 	}
 	if err := tx.Commit(); err != nil {
 		return 0, err
+	}
+	if inserted > 0 {
+		d.signalWatchHistoryInboxWake()
 	}
 	return inserted, nil
 }
@@ -1737,6 +1760,12 @@ func (d *DB) clearWatchHistoryRows(siteID int64) error {
 	}
 	defer tx.Rollback()
 	if siteID > 0 {
+		// The inbox is a second durable event channel. Clear it in the same
+		// transaction so an event queued before this command cannot recreate
+		// history after the API reports success.
+		if _, err := tx.Exec("DELETE FROM watch_history_inbox WHERE site_id=? OR site_id=0", siteID); err != nil {
+			return err
+		}
 		if _, err := tx.Exec("DELETE FROM tmdb_jobs WHERE media_item_id IN (SELECT id FROM media_items WHERE site_id=?)", siteID); err != nil {
 			return err
 		}
@@ -1752,6 +1781,9 @@ func (d *DB) clearWatchHistoryRows(siteID int64) error {
 			return err
 		}
 	} else {
+		if _, err := tx.Exec("DELETE FROM watch_history_inbox"); err != nil {
+			return err
+		}
 		if _, err := tx.Exec("DELETE FROM tmdb_jobs"); err != nil {
 			return err
 		}
@@ -1777,10 +1809,14 @@ func (d *DB) deleteWatchHistoryRow(historyID int64) error {
 		return err
 	}
 	defer tx.Rollback()
-	var mediaItemID int64
-	if err := tx.QueryRow("SELECT media_item_id FROM watch_sessions WHERE id=?", historyID).Scan(&mediaItemID); errors.Is(err, sql.ErrNoRows) {
+	var mediaItemID, siteID int64
+	var sessionHash string
+	if err := tx.QueryRow("SELECT media_item_id,site_id,session_hash FROM watch_sessions WHERE id=?", historyID).Scan(&mediaItemID, &siteID, &sessionHash); errors.Is(err, sql.ErrNoRows) {
 		return sql.ErrNoRows
 	} else if err != nil {
+		return err
+	}
+	if _, err := tx.Exec("DELETE FROM watch_history_inbox WHERE site_id=? AND session_hash=?", siteID, sessionHash); err != nil {
 		return err
 	}
 	if _, err := tx.Exec("DELETE FROM watch_sessions WHERE id=?", historyID); err != nil {

--- a/watch_history_test.go
+++ b/watch_history_test.go
@@ -830,6 +830,55 @@ func TestEnqueueWatchHistoryNeverBlocksWhenQueueIsFull(t *testing.T) {
 	}
 }
 
+func TestPersistWatchHistoryInboxBatchCommitsAndUsesMetadata(t *testing.T) {
+	database := openWatchHistoryTestDB(t)
+	event := watchHistoryTestEvent(7, "inbox", time.Now().UnixMilli(), 100)
+	inserted, err := database.persistWatchHistoryInboxBatch([]watchHistoryEvent{event})
+	if err != nil || inserted != 1 {
+		t.Fatalf("persist inbox: inserted=%d err=%v", inserted, err)
+	}
+	var siteID int64
+	var sessionHash string
+	var observedAt int64
+	var payload string
+	if err := database.db.QueryRow("SELECT site_id,session_hash,observed_at_ms,payload_json FROM watch_history_inbox").Scan(&siteID, &sessionHash, &observedAt, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if siteID != event.SiteID || sessionHash != event.SessionHash || observedAt != event.ObservedAtMS || payload == "" {
+		t.Fatalf("inbox metadata = %d/%q/%d/%q, want event metadata", siteID, sessionHash, observedAt, payload)
+	}
+}
+
+func TestPersistWatchHistoryInboxBatchCommitsPartialBatchAtLimit(t *testing.T) {
+	database := openWatchHistoryTestDB(t)
+	payload := `{"SiteID":1,"SessionHash":"legacy","ObservedAtMS":1}`
+	tx, err := database.db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < watchHistoryInboxLimit-1; i++ {
+		if _, err := tx.Exec("INSERT INTO watch_history_inbox(site_id,session_hash,observed_at_ms,payload_json,created_at_ms) VALUES(1,'legacy',1,?,1)", payload); err != nil {
+			_ = tx.Rollback()
+			t.Fatal(err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	events := []watchHistoryEvent{watchHistoryTestEvent(1, "first", 2, 100), watchHistoryTestEvent(1, "second", 3, 100)}
+	inserted, err := database.persistWatchHistoryInboxBatch(events)
+	if inserted != 1 || err == nil {
+		t.Fatalf("partial inbox batch = inserted:%d err:%v, want one committed row and full error", inserted, err)
+	}
+	var count int
+	if err := database.db.QueryRow("SELECT COUNT(*) FROM watch_history_inbox").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != watchHistoryInboxLimit {
+		t.Fatalf("inbox count=%d, want %d", count, watchHistoryInboxLimit)
+	}
+}
+
 func TestClearAndDeleteWatchHistoryRemoveChildrenWithoutForeignKeys(t *testing.T) {
 	database := openWatchHistoryTestDB(t)
 	site := createWatchHistoryTestSite(t, database, true)
@@ -845,6 +894,17 @@ func TestClearAndDeleteWatchHistoryRemoveChildrenWithoutForeignKeys(t *testing.T
 	}
 	if err := database.ClearWatchHistory(site.ID); err != nil {
 		t.Fatal(err)
+	}
+	queued := watchHistoryTestEvent(site.ID, "queued-before-clear", nowMS, 100)
+	if !database.persistWatchHistoryInbox(queued) {
+		t.Fatal("persist inbox event")
+	}
+	if err := database.ClearWatchHistory(site.ID); err != nil {
+		t.Fatal(err)
+	}
+	var inboxCount int
+	if err := database.db.QueryRow("SELECT COUNT(*) FROM watch_history_inbox WHERE site_id=?", site.ID).Scan(&inboxCount); err != nil || inboxCount != 0 {
+		t.Fatalf("inbox after clear: count=%d err=%v", inboxCount, err)
 	}
 	for _, table := range []string{"watch_sessions", "media_items", "tmdb_jobs", "tmdb_cache"} {
 		var count int


### PR DESCRIPTION
This change hardens the v1.9.61 audit findings before the next formal release.

- Make watch-history inbox batches durable at capacity and persist site/session metadata.
- Clear pending inbox rows with history deletion and re-encrypt queued tokens during restore.
- Wake and drain the inbox writer promptly instead of waiting for the maintenance cycle.
- Preserve Controller-authoritative Agent traffic quotas across config applies and ACK watermarks.
- Keep failed site deletion disabled and retryable instead of restarting a site after schedule/DNS cleanup.
- Add regression coverage for quota enforcement, inbox durability, history clearing, and backup token migration.

Validation: go test ./..., go test -race ./..., go vet ./..., govulncheck ./..., gosec -quiet -severity medium -confidence medium ./..., ShellCheck, Node tests, and go build ./....