### PR TITLE
fix: harden agent revocation and traffic continuity

### DIFF
--- a/agent_report_guard.go
+++ b/agent_report_guard.go
@@ -336,11 +336,22 @@ func (a *App) withAgentPreAuth(next http.HandlerFunc) http.HandlerFunc {
 		identity, err := a.authenticateAgentRequest(r)
 		release()
 		if err != nil {
-			a.jsonErr(w, http.StatusUnauthorized, "invalid agent token")
+			writeAgentAuthFailure(a, w, r)
 			return
 		}
 		next(w, withAgentCredential(r, identity))
 	}
+}
+
+// writeAgentAuthFailure keeps ordinary HTTP authentication semantics while
+// giving an already-enrolled Agent an explicit revocation signal. A stale or
+// replaced Agent token must stop its data-plane listener; a missing bearer
+// token remains a normal 401 for callers that have not authenticated.
+func writeAgentAuthFailure(a *App, w http.ResponseWriter, r *http.Request) {
+	if requestBearerToken(r) != "" {
+		w.Header().Set("X-Meridian-Agent-State", "revoked")
+	}
+	a.jsonErr(w, http.StatusUnauthorized, "invalid agent token")
 }
 
 // authenticateAgentRequest performs the only credential lookups protected by

--- a/app_nodes.go
+++ b/app_nodes.go
@@ -416,7 +416,7 @@ func (a *App) handleAgentBinary(w http.ResponseWriter, r *http.Request) {
 	}
 	identity, authErr := agentIdentityForRequest(a, r)
 	if authErr != nil || (!identity.HasNode && !identity.Enrollment) {
-		a.jsonErr(w, http.StatusUnauthorized, "invalid agent token")
+		writeAgentAuthFailure(a, w, r)
 		return
 	}
 	platform, err := requestedAgentPlatform(r)
@@ -570,7 +570,7 @@ func (a *App) handleAgentManifest(w http.ResponseWriter, r *http.Request) {
 	}
 	identity, authErr := agentIdentityForRequest(a, r)
 	if authErr != nil || (!identity.HasNode && !identity.Enrollment) {
-		a.jsonErr(w, http.StatusUnauthorized, "invalid agent token")
+		writeAgentAuthFailure(a, w, r)
 		return
 	}
 	platform, err := requestedAgentPlatform(r)
@@ -617,7 +617,7 @@ func (a *App) handleAgentEnroll(w http.ResponseWriter, r *http.Request) {
 	}
 	identity, authErr := agentIdentityForRequest(a, r)
 	if authErr != nil || !identity.Enrollment {
-		a.jsonErr(w, http.StatusUnauthorized, "invalid enrollment token")
+		writeAgentAuthFailure(a, w, r)
 		return
 	}
 	node, agentToken, err := a.db.EnrollControlNode(identity.Token, time.Now())
@@ -652,7 +652,7 @@ func (a *App) handleAgentReport(w http.ResponseWriter, r *http.Request) {
 	}
 	identity, authErr := agentNodeIdentityForRequest(a, r)
 	if authErr != nil {
-		a.jsonErr(w, http.StatusUnauthorized, "invalid agent token")
+		writeAgentAuthFailure(a, w, r)
 		return
 	}
 	token := identity.Token
@@ -678,7 +678,7 @@ func (a *App) handleAgentReport(w http.ResponseWriter, r *http.Request) {
 	}
 	result, err := a.db.RecordNodeReportResult(token, report, time.Now())
 	if errors.Is(err, errInvalidAgentToken) {
-		a.jsonErr(w, http.StatusUnauthorized, "invalid agent token")
+		writeAgentAuthFailure(a, w, r)
 		return
 	}
 	if err != nil {

--- a/command_line.go
+++ b/command_line.go
@@ -290,7 +290,9 @@ func runIssueEdgeCertificateCommand(output io.Writer) error {
 			continue
 		}
 		nodeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		changed, ensureErr := ensureEdgeCertificateForNode(nodeCtx, settings, token, manager, node)
+		changed, ensureErr := ensureEdgeCertificateForNodeGuarded(nodeCtx, settings, token, manager, node, &db.nodeTLSMutationMu, func() error {
+			return verifyEdgeCertificateNodeStillEnrolled(db, node)
+		})
 		cancel()
 		if ensureErr != nil {
 			failures = append(failures, fmt.Errorf("node %s: %w", node.Name, ensureErr))

--- a/dashboard_trends.go
+++ b/dashboard_trends.go
@@ -172,9 +172,9 @@ func (pm *ProxyManager) pendingDashboardTraffic(siteID *int64) map[int64]dashboa
 		}
 		inst.trafficMu.Lock()
 		result[id] = dashboardPendingTraffic{
-			BytesIn:  inst.bytesIn.Load(),
-			BytesOut: inst.bytesOut.Load(),
-			Requests: inst.pendingRequests.Load(),
+			BytesIn:  inst.trafficBytesIn().Load(),
+			BytesOut: inst.trafficBytesOut().Load(),
+			Requests: inst.trafficPendingRequests().Load(),
 		}
 		inst.trafficMu.Unlock()
 	}

--- a/database.go
+++ b/database.go
@@ -38,6 +38,7 @@ type DB struct {
 	agentSecurityMu             sync.Mutex
 	agentSecurityLastLog        map[string]time.Time
 	systemSettings              atomic.Pointer[SystemSettings]
+	nodeTLSMutationMu           sync.Mutex
 	watchHistoryMetadataMu      sync.Mutex
 	watchHistoryMetadata        map[watchHistoryMetadataKey]watchHistoryMetadataEntry
 }

--- a/edge_agent.go
+++ b/edge_agent.go
@@ -522,6 +522,7 @@ type edgeAgentRuntime struct {
 	retention            map[int64]NodeRetentionStatus
 	observations         []NodeDynamicObservation
 	siteReported         map[int64]ProxyRuntimeStat
+	trafficCounters      map[int64]*edgeSiteTrafficCounter
 	resolver             dynamicIPResolver
 	transport            dynamicTransportFactory
 	listen               func(string, string) (net.Listener, error)
@@ -540,6 +541,23 @@ type edgeAgentRuntimeState struct {
 	siteCounterEpoch     uint64
 	siteReported         map[int64]ProxyRuntimeStat
 	listenerError        string
+}
+
+func (runtime *edgeAgentRuntime) trafficCounterFor(siteID int64) *edgeSiteTrafficCounter {
+	if runtime == nil || siteID <= 0 {
+		return nil
+	}
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	if runtime.trafficCounters == nil {
+		runtime.trafficCounters = make(map[int64]*edgeSiteTrafficCounter)
+	}
+	if counter := runtime.trafficCounters[siteID]; counter != nil {
+		return counter
+	}
+	counter := &edgeSiteTrafficCounter{}
+	runtime.trafficCounters[siteID] = counter
+	return counter
 }
 
 func (runtime *edgeAgentRuntime) queueEvent(event NodeRequestEvent) {
@@ -776,10 +794,27 @@ func (runtime *edgeAgentRuntime) commitSiteStats(pending edgeSiteStatsPending) {
 	if runtime.siteReported == nil {
 		runtime.siteReported = make(map[int64]ProxyRuntimeStat)
 	}
+	deltas := make(map[int64]ProxyRuntimeStat, len(pending.current))
 	for siteID, sent := range pending.current {
-		if current := runtime.siteReported[siteID]; current == sent || current.CumulativeBytesIn <= sent.CumulativeBytesIn && current.CumulativeBytesOut <= sent.CumulativeBytesOut {
-			runtime.siteReported[siteID] = sent
+		current := runtime.siteReported[siteID]
+		delta := ProxyRuntimeStat{SiteID: siteID}
+		if sent.CumulativeBytesIn >= current.CumulativeBytesIn {
+			delta.CumulativeBytesIn = sent.CumulativeBytesIn - current.CumulativeBytesIn
+		} else {
+			delta.CumulativeBytesIn = sent.CumulativeBytesIn
 		}
+		if sent.CumulativeBytesOut >= current.CumulativeBytesOut {
+			delta.CumulativeBytesOut = sent.CumulativeBytesOut - current.CumulativeBytesOut
+		} else {
+			delta.CumulativeBytesOut = sent.CumulativeBytesOut
+		}
+		if sent.Requests >= current.Requests {
+			delta.Requests = sent.Requests - current.Requests
+		} else {
+			delta.Requests = sent.Requests
+		}
+		deltas[siteID] = delta
+		runtime.siteReported[siteID] = sent
 	}
 	bundle := runtime.bundle
 	reported := make(map[int64]ProxyRuntimeStat, len(pending.current))
@@ -802,6 +837,13 @@ func (runtime *edgeAgentRuntime) commitSiteStats(pending edgeSiteStatsPending) {
 		}
 		if inst := bundle.manager.proxies[localID]; inst != nil {
 			inst.trafficMu.Lock()
+			if inst.trafficCycleAuthoritative {
+				delta := deltas[identity.centralID]
+				// Rebase the Controller baseline and ACK watermark together.
+				// The just-committed report must remain billable immediately;
+				// it must not disappear until the next config refresh.
+				inst.trafficCycleUsage += trafficBillableBytes(inst.trafficCycleMode, delta.CumulativeBytesIn, delta.CumulativeBytesOut)
+			}
 			inst.trafficAckedCumulativeIn = stat.CumulativeBytesIn
 			inst.trafficAckedCumulativeOut = stat.CumulativeBytesOut
 			inst.trafficMu.Unlock()
@@ -1057,6 +1099,7 @@ func buildEdgeProxy(config AgentRuntimeConfig, runtime *edgeAgentRuntime) (*edge
 	for _, route := range config.Routes {
 		site := route.Site
 		site.ID = 0
+		site.runtimeTrafficCounter = runtime.trafficCounterFor(route.SiteID)
 		// Site icons are Controller/UI metadata. The Agent's ephemeral site
 		// database has no uploaded icon pack, so carrying these fields into
 		// CreateSiteRecord would make an otherwise valid runtime config fail
@@ -1105,6 +1148,7 @@ func buildEdgeProxy(config AgentRuntimeConfig, runtime *edgeAgentRuntime) (*edge
 		created.runtimeTrafficCycleConfigured = site.runtimeTrafficCycleConfigured
 		created.runtimeTrafficAckedCumulativeIn = site.runtimeTrafficAckedCumulativeIn
 		created.runtimeTrafficAckedCumulativeOut = site.runtimeTrafficAckedCumulativeOut
+		created.runtimeTrafficCounter = site.runtimeTrafficCounter
 		siteIDs[site.PublicHost] = route.SiteID
 		localSites[created.ID] = edgeSiteIdentity{centralID: route.SiteID, host: site.PublicHost}
 		bundle.localSites[created.ID] = localSites[created.ID]
@@ -1337,17 +1381,10 @@ func (runtime *edgeAgentRuntime) apply(config AgentRuntimeConfig) (retErr error)
 	runtime.certificate = certificate
 	runtime.handler = bundle.handler
 	runtime.bundle = bundle
-	// The in-memory Edge database and proxy counters are rebuilt on every
-	// configuration apply. Keep the Controller ACK watermark for sites that are
-	// still present so the new zeroed counters represent only post-apply local
-	// traffic and cannot be charged twice against the Controller baseline.
-	retainedReports := make(map[int64]ProxyRuntimeStat, len(config.Routes))
-	for _, route := range config.Routes {
-		if stat, ok := oldState.siteReported[route.SiteID]; ok {
-			retainedReports[route.SiteID] = stat
-		}
-	}
-	runtime.siteReported = retainedReports
+	// siteReported is a Controller ACK watermark. Stable per-site counters are
+	// shared by old and new bundles, so this watermark remains valid across a
+	// routing-only hot apply.
+	runtime.siteReported = oldState.siteReported
 	runtime.mu.Unlock()
 	newServerStarted := false
 	if listenerChanged && needsListener {
@@ -1374,7 +1411,11 @@ func (runtime *edgeAgentRuntime) apply(config AgentRuntimeConfig) (retErr error)
 	runtime.mu.Lock()
 	runtime.appliedHash = config.ConfigHash
 	runtime.appliedRevision = config.ConfigRevision
-	runtime.siteCounterEpoch++
+	// A counter epoch identifies the Agent process, not a routing bundle. Keep
+	// it stable across hot applies so draining requests remain in one stream.
+	if runtime.siteCounterEpoch == 0 {
+		runtime.siteCounterEpoch = 1
+	}
 	if config.CacheClearGeneration > runtime.cacheClearGeneration {
 		runtime.cacheClearGeneration = config.CacheClearGeneration
 	}
@@ -1492,6 +1533,32 @@ func edgeSaveState(path string, state edgeAgentState) error {
 	return os.Rename(name, path)
 }
 
+type edgeAPIError struct {
+	StatusCode int
+	AgentState string
+	Message    string
+}
+
+func (e *edgeAPIError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}
+
+func isEdgeAgentRevoked(err error) bool {
+	var apiErr *edgeAPIError
+	return errors.As(err, &apiErr) && strings.EqualFold(strings.TrimSpace(apiErr.AgentState), "revoked")
+}
+
+func edgeEnrollmentTokenAvailable(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	data, err := os.ReadFile(path) // #nosec G304 -- the enrollment path is supplied by the service configuration.
+	return err == nil && strings.TrimSpace(string(data)) != ""
+}
+
 func edgeAPIRequest(ctx context.Context, client *http.Client, method, endpoint, token string, body, output any) error {
 	return edgeAPIRequestWithHeaders(ctx, client, method, endpoint, token, body, output, nil)
 }
@@ -1541,13 +1608,18 @@ func edgeAPIRequestWithHeaders(ctx context.Context, client *http.Client, method,
 	defer response.Body.Close()
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		var failure struct {
-			Error string `json:"error"`
+			Error      string `json:"error"`
+			AgentState string `json:"agent_state"`
 		}
 		_ = json.NewDecoder(io.LimitReader(response.Body, 1<<20)).Decode(&failure)
 		if failure.Error == "" {
 			failure.Error = response.Status
 		}
-		return errors.New(failure.Error)
+		state := strings.TrimSpace(response.Header.Get("X-Meridian-Agent-State"))
+		if state == "" {
+			state = failure.AgentState
+		}
+		return &edgeAPIError{StatusCode: response.StatusCode, AgentState: state, Message: failure.Error}
 	}
 	if output == nil {
 		_, err = io.Copy(io.Discard, io.LimitReader(response.Body, 1<<20))
@@ -1912,6 +1984,26 @@ func runEdgeAgent() error {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 	client := &http.Client{Timeout: 2 * time.Minute, Transport: edgeHTTPTransport(), CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	revokedMarker := *statePath + ".revoked"
+	if _, statErr := os.Stat(revokedMarker); statErr == nil {
+		if !edgeEnrollmentTokenAvailable(*tokenFile) {
+			fmt.Fprintln(os.Stderr, "Meridian Agent token was revoked; run the generated re-enrollment script to start it again.")
+			// Keep the service quiescent instead of returning into a
+			// Restart=always loop. The process has no listener or runtime at this
+			// point; an operator-provided enrollment token causes the service to be
+			// stopped and started again, at which point enrollment can proceed.
+			<-ctx.Done()
+			return nil
+		}
+		// The current state contains the credential that the Controller revoked.
+		// Remove it before loading state so a manually supplied enrollment token
+		// (or an interrupted --reenroll install) cannot accidentally keep using
+		// the stale token instead of completing enrollment.
+		if err := os.Remove(*statePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove revoked Agent state: %w", err)
+		}
+		_ = os.Remove(revokedMarker)
+	}
 	state, err := edgeLoadState(*statePath)
 	if err != nil {
 		return err
@@ -1975,11 +2067,22 @@ func runEdgeAgent() error {
 				agentPlatformHeader: []string{goruntime.GOOS + "/" + goruntime.GOARCH},
 				agentVersionHeader:  []string{appVersion},
 			}); err != nil {
+				if isEdgeAgentRevoked(err) {
+					_ = os.WriteFile(revokedMarker, []byte("revoked\n"), 0o600)
+					return nil
+				}
 				fmt.Fprintf(os.Stderr, "Meridian Agent config fetch failed: %v\n", err)
 			} else if configErr := validateAgentConfigEnvelope(config); configErr != nil {
 				fmt.Fprintf(os.Stderr, "Meridian Agent rejected config: %v\n", configErr)
 			} else {
-				runtime.syncSiteTrafficLimits(config)
+				// A new identity must be applied atomically. Updating the old
+				// bundle before apply would leak a failed candidate's quota into
+				// the still-serving configuration. Hash-stable refreshes are the
+				// only path allowed to mutate the live baseline in place.
+				appliedHash, appliedRevision, _, _, _, _ := runtime.status()
+				if agentConfigIdentityEqual(config, AgentRuntimeConfig{ConfigHash: appliedHash, ConfigRevision: appliedRevision}) {
+					runtime.syncSiteTrafficLimits(config)
+				}
 				// Refresh the pending payload when the Controller sends a newer
 				// hash, but do not reset an in-progress retry backoff when the
 				// same failing configuration is fetched again after a report ACK.
@@ -2052,6 +2155,10 @@ func runEdgeAgent() error {
 				wsErr = edgeAPIRequest(ctx, client, http.MethodPost, controller+"/api/agent/report", state.Token, report, &ack)
 			}
 			if wsErr != nil {
+				if isEdgeAgentRevoked(wsErr) {
+					_ = os.WriteFile(revokedMarker, []byte("revoked\n"), 0o600)
+					return nil
+				}
 				fmt.Fprintf(os.Stderr, "Meridian Agent report failed: %v\n", wsErr)
 			} else {
 				runtime.commitSiteStats(pendingStats)

--- a/edge_agent_test.go
+++ b/edge_agent_test.go
@@ -77,6 +77,94 @@ func TestAgentConfigIdentityRequiresRevisionAndHash(t *testing.T) {
 	}
 }
 
+func TestEdgeTrafficCounterSurvivesHotApply(t *testing.T) {
+	runtime := &edgeAgentRuntime{}
+	first := runtime.trafficCounterFor(42)
+	if first == nil {
+		t.Fatal("missing stable traffic counter")
+	}
+	first.cumulativeOut.Store(100)
+	second := runtime.trafficCounterFor(42)
+	if second != first {
+		t.Fatal("hot apply created a new counter for the same site")
+	}
+	if got := second.cumulativeOut.Load(); got != 100 {
+		t.Fatalf("stable counter cumulative bytes = %d, want 100", got)
+	}
+}
+
+func TestCommitSiteStatsRebasesAuthoritativeQuotaImmediately(t *testing.T) {
+	counter := &edgeSiteTrafficCounter{}
+	inst := &ProxyInstance{
+		Site:                      Site{ID: 1},
+		trafficCounter:            counter,
+		trafficCycleAuthoritative: true,
+		trafficCycleMode:          trafficBillingModeOutbound,
+		trafficCycleUsage:         100,
+	}
+	bundle := &edgeProxyBundle{
+		manager:    &ProxyManager{proxies: map[int64]*ProxyInstance{1: inst}},
+		localSites: map[int64]edgeSiteIdentity{1: {centralID: 42}},
+	}
+	runtime := &edgeAgentRuntime{
+		bundle:       bundle,
+		siteReported: make(map[int64]ProxyRuntimeStat),
+	}
+	counter.cumulativeOut.Store(10)
+	runtime.commitSiteStats(edgeSiteStatsPending{current: map[int64]ProxyRuntimeStat{
+		42: {SiteID: 42, CumulativeBytesOut: 10},
+	}})
+	if got := inst.trafficCycleUsage; got != 110 {
+		t.Fatalf("quota baseline after report ACK = %d, want 110", got)
+	}
+	if got := inst.trafficAckedCumulativeOut; got != 10 {
+		t.Fatalf("ACK watermark = %d, want 10", got)
+	}
+	usage, err := (&ProxyManager{}).currentTrafficCycleUsage(inst, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage != 110 {
+		t.Fatalf("effective quota usage after report ACK = %d, want 110", usage)
+	}
+}
+
+func TestEdgeAPIRequestSurfacesRevokedAgentState(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Meridian-Agent-State", "revoked")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":"invalid agent token","agent_state":"revoked"}`)
+	}))
+	defer server.Close()
+	err := edgeAPIRequest(context.Background(), server.Client(), http.MethodGet, server.URL, "stale-token", nil, nil)
+	if !isEdgeAgentRevoked(err) {
+		t.Fatalf("revoked response error = %v, want revoked agent state", err)
+	}
+}
+
+func TestEdgeEnrollmentTokenAvailabilityUsesFileContents(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "missing-token")
+	if edgeEnrollmentTokenAvailable(missing) {
+		t.Fatal("missing enrollment token was treated as available")
+	}
+	empty := filepath.Join(dir, "empty-token")
+	if err := os.WriteFile(empty, []byte("\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if edgeEnrollmentTokenAvailable(empty) {
+		t.Fatal("empty enrollment token was treated as available")
+	}
+	valid := filepath.Join(dir, "valid-token")
+	if err := os.WriteFile(valid, []byte("one-time-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !edgeEnrollmentTokenAvailable(valid) {
+		t.Fatal("non-empty enrollment token was not detected")
+	}
+}
+
 func TestBuildEdgeProxyIgnoresControllerOnlySiteIconMetadata(t *testing.T) {
 	runtime := &edgeAgentRuntime{stateDir: t.TempDir()}
 	config := AgentRuntimeConfig{

--- a/node_repository.go
+++ b/node_repository.go
@@ -663,14 +663,24 @@ func (d *DB) markAgentConfigDirty(nodeID int64) error {
 	if d == nil || d.db == nil || nodeID <= 0 {
 		return nil
 	}
-	_, err := d.db.Exec(`UPDATE control_nodes SET
+	result, err := d.db.Exec(`UPDATE control_nodes SET
 		config_revision=config_revision+1,
 		desired_config_hash='',
 		desired_config_revision=0,
 		config_dirty=1,
 		updated_at_ms=?
 		WHERE id=? AND enabled=1 AND agent_token_hash<>''`, time.Now().UnixMilli(), nodeID)
-	return err
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows != 1 {
+		return errNodeNotFound
+	}
+	return nil
 }
 
 func (d *DB) UpdateNodeScheduler(mode string, manualNodeID int64, now time.Time) (NodeControlSnapshot, error) {
@@ -805,6 +815,8 @@ func (d *DB) RefreshNodeEnrollment(id int64, now time.Time) (ControlNode, string
 }
 
 func (d *DB) DeleteControlNode(id int64) error {
+	d.nodeTLSMutationMu.Lock()
+	defer d.nodeTLSMutationMu.Unlock()
 	tx, err := d.db.Begin()
 	if err != nil {
 		return err
@@ -848,13 +860,19 @@ func (d *DB) DeleteControlNode(id int64) error {
 	}
 	// The database deletion is authoritative. Complete the cleanup immediately
 	// when possible; failures remain durable for the scheduler retry loop.
-	if err := d.retryNodeTLSCleanup(guid); err != nil {
+	if err := d.retryNodeTLSCleanupUnlocked(guid); err != nil {
 		log.Printf("[node] removed node %d but managed Edge TLS cleanup is pending: %v", id, err)
 	}
 	return nil
 }
 
 func (d *DB) retryNodeTLSCleanup(onlyGUID string) error {
+	d.nodeTLSMutationMu.Lock()
+	defer d.nodeTLSMutationMu.Unlock()
+	return d.retryNodeTLSCleanupUnlocked(onlyGUID)
+}
+
+func (d *DB) retryNodeTLSCleanupUnlocked(onlyGUID string) error {
 	if d == nil || d.db == nil {
 		return nil
 	}

--- a/panel_certificate_renewal.go
+++ b/panel_certificate_renewal.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -117,7 +118,9 @@ func renewEdgeCertificatesIfDue(ctx context.Context, db *DB, manager *panelCerti
 			continue
 		}
 		nodeCtx, cancel := context.WithTimeout(ctx, edgeCertificateRenewalTimeout)
-		changed, ensureErr := ensureEdgeCertificateForNode(nodeCtx, settings, token, manager, node)
+		changed, ensureErr := ensureEdgeCertificateForNodeGuarded(nodeCtx, settings, token, manager, node, &db.nodeTLSMutationMu, func() error {
+			return verifyEdgeCertificateNodeStillEnrolled(db, node)
+		})
 		cancel()
 		if ensureErr != nil {
 			failures = append(failures, fmt.Errorf("node %s: %w", node.Name, ensureErr))
@@ -135,6 +138,10 @@ func renewEdgeCertificatesIfDue(ctx context.Context, db *DB, manager *panelCerti
 // node's certificate. A valid pair is reused, preventing an administrator
 // retry or a scheduler tick from needlessly consuming ACME issuance quota.
 func ensureEdgeCertificateForNode(ctx context.Context, settings PanelSettings, token string, manager *panelCertificateManager, node ControlNode) (bool, error) {
+	return ensureEdgeCertificateForNodeGuarded(ctx, settings, token, manager, node, nil, nil)
+}
+
+func ensureEdgeCertificateForNodeGuarded(ctx context.Context, settings PanelSettings, token string, manager *panelCertificateManager, node ControlNode, mutationMu *sync.Mutex, verify func() error) (bool, error) {
 	if manager == nil || !edgeCertificateRequired(node) || strings.TrimSpace(node.GUID) == "" {
 		return false, nil
 	}
@@ -158,11 +165,34 @@ func ensureEdgeCertificateForNode(ctx context.Context, settings PanelSettings, t
 	if issueErr != nil {
 		return false, issueErr
 	}
+	if mutationMu != nil {
+		mutationMu.Lock()
+		defer mutationMu.Unlock()
+	}
+	if verify != nil {
+		if verifyErr := verify(); verifyErr != nil {
+			return false, verifyErr
+		}
+	}
 	if installErr := installCertificatePairAtomic(certFile, keyFile, issued.certPEM, issued.keyPEM); installErr != nil {
 		return false, installErr
 	}
 	log.Printf("[edge-certificate] certificate provisioned for node %s (%s + %s)", node.Name, wildcard, uniqueHost)
 	return true, nil
+}
+
+func verifyEdgeCertificateNodeStillEnrolled(db *DB, expected ControlNode) error {
+	if db == nil || expected.ID <= 0 || strings.TrimSpace(expected.GUID) == "" {
+		return errNodeNotFound
+	}
+	current, err := db.controlNodeByID(expected.ID, time.Now())
+	if err != nil {
+		return err
+	}
+	if current.GUID != expected.GUID || !current.Enabled || current.EnrolledAtMS <= 0 || current.agentTokenHash == "" {
+		return errors.New("node is no longer enrolled")
+	}
+	return nil
 }
 
 func provisionEdgeCertificateForNode(ctx context.Context, db *DB, manager *panelCertificateManager, node ControlNode) error {
@@ -183,7 +213,9 @@ func provisionEdgeCertificateForNode(ctx context.Context, db *DB, manager *panel
 	if err != nil {
 		return errors.New("无法解密已保存的 DNS API Token")
 	}
-	changed, err := ensureEdgeCertificateForNode(ctx, settings, token, manager, node)
+	changed, err := ensureEdgeCertificateForNodeGuarded(ctx, settings, token, manager, node, &db.nodeTLSMutationMu, func() error {
+		return verifyEdgeCertificateNodeStillEnrolled(db, node)
+	})
 	if err != nil || !changed {
 		return err
 	}

--- a/proxy_lifecycle.go
+++ b/proxy_lifecycle.go
@@ -133,16 +133,16 @@ func (pm *ProxyManager) flushProxyTraffic(inst *ProxyInstance) error {
 // pending counters are zeroed first, the baseline moves only after the DB
 // transaction commits, and all counters are restored verbatim on any error.
 func (pm *ProxyManager) flushProxyTrafficLocked(inst *ProxyInstance) error {
-	in := inst.bytesIn.Swap(0)
-	out := inst.bytesOut.Swap(0)
-	requests := inst.pendingRequests.Swap(0)
+	in := inst.trafficBytesIn().Swap(0)
+	out := inst.trafficBytesOut().Swap(0)
+	requests := inst.trafficPendingRequests().Swap(0)
 	if in == 0 && out == 0 && requests == 0 {
 		return nil
 	}
 	if err := pm.database.addTrafficWithRequests(inst.Site.ID, in, out, requests); err != nil {
-		inst.bytesIn.Add(in)
-		inst.bytesOut.Add(out)
-		inst.pendingRequests.Add(requests)
+		inst.trafficBytesIn().Add(in)
+		inst.trafficBytesOut().Add(out)
+		inst.trafficPendingRequests().Add(requests)
 		return err
 	}
 	delta := in + out
@@ -155,7 +155,7 @@ func (pm *ProxyManager) flushProxyTrafficLocked(inst *ProxyInstance) error {
 	settings := pm.database.currentSystemSettings()
 	cycleStart := trafficCycleStart(time.Now(), settings.TrafficResetDay, timezoneLocation(settings.ScheduleTimezone))
 	cycleMode := trafficBillingModeLabel(settings.TrafficBillingMode)
-	if inst.trafficCycleMode == cycleMode && inst.trafficCycleStart.Equal(cycleStart) {
+	if !inst.trafficCycleAuthoritative && inst.trafficCycleMode == cycleMode && inst.trafficCycleStart.Equal(cycleStart) {
 		inst.trafficCycleUsage += trafficBillableBytes(cycleMode, in, out)
 	}
 	return nil
@@ -172,13 +172,13 @@ func (pm *ProxyManager) currentTrafficCycleUsage(inst *ProxyInstance, now time.T
 	// billing mode, and persisted baseline. Never replace those values with the
 	// Agent's local in-memory database defaults.
 	if inst.trafficCycleAuthoritative && (inst.trafficCycleMode == trafficBillingModeOutbound || inst.trafficCycleMode == trafficBillingModeBidirectional) {
-		localIn := inst.cumulativeBytesIn.Load() - inst.trafficAckedCumulativeIn
-		localOut := inst.cumulativeBytesOut.Load() - inst.trafficAckedCumulativeOut
+		localIn := inst.trafficCumulativeIn().Load() - inst.trafficAckedCumulativeIn
+		localOut := inst.trafficCumulativeOut().Load() - inst.trafficAckedCumulativeOut
 		if localIn < 0 {
-			localIn = inst.cumulativeBytesIn.Load()
+			localIn = inst.trafficCumulativeIn().Load()
 		}
 		if localOut < 0 {
-			localOut = inst.cumulativeBytesOut.Load()
+			localOut = inst.trafficCumulativeOut().Load()
 		}
 		return inst.trafficCycleUsage + trafficBillableBytes(inst.trafficCycleMode, localIn, localOut), nil
 	}
@@ -193,10 +193,10 @@ func (pm *ProxyManager) currentTrafficCycleUsage(inst *ProxyInstance, now time.T
 		inst.trafficCycleStart = cycleStart
 		inst.trafficCycleMode = cycleMode
 		inst.trafficCycleUsage = persisted
-		inst.trafficAckedCumulativeIn = inst.cumulativeBytesIn.Load()
-		inst.trafficAckedCumulativeOut = inst.cumulativeBytesOut.Load()
+		inst.trafficAckedCumulativeIn = inst.trafficCumulativeIn().Load()
+		inst.trafficAckedCumulativeOut = inst.trafficCumulativeOut().Load()
 	}
-	return inst.trafficCycleUsage + trafficBillableBytes(cycleMode, inst.bytesIn.Load(), inst.bytesOut.Load()), nil
+	return inst.trafficCycleUsage + trafficBillableBytes(cycleMode, inst.trafficBytesIn().Load(), inst.trafficBytesOut().Load()), nil
 }
 
 func (inst *ProxyInstance) persistedDirections() (int64, int64) {
@@ -332,13 +332,13 @@ func (pm *ProxyManager) SiteTrafficHistory(site Site, hours int) (*TrafficHistor
 	snap.Running = inst.isOperational()
 	persistedIn, persistedOut = inst.persistedDirections()
 	snap.PersistedTraffic = trafficBillableBytes(billingMode, persistedIn, persistedOut)
-	snap.BytesIn = inst.bytesIn.Load()
-	snap.BytesOut = inst.bytesOut.Load()
-	snap.CumulativeBytesIn = inst.cumulativeBytesIn.Load()
-	snap.CumulativeBytesOut = inst.cumulativeBytesOut.Load()
+	snap.BytesIn = inst.trafficBytesIn().Load()
+	snap.BytesOut = inst.trafficBytesOut().Load()
+	snap.CumulativeBytesIn = inst.trafficCumulativeIn().Load()
+	snap.CumulativeBytesOut = inst.trafficCumulativeOut().Load()
 	snap.TrafficUsed = snap.PersistedTraffic + trafficBillableBytes(billingMode, snap.BytesIn, snap.BytesOut)
-	snap.Requests = inst.reqCount.Load()
-	logs = mergePendingIntoLogs(logs, site.ID, snap.BytesIn, snap.BytesOut, inst.pendingRequests.Load())
+	snap.Requests = inst.trafficRequests().Load()
+	logs = mergePendingIntoLogs(logs, site.ID, snap.BytesIn, snap.BytesOut, inst.trafficPendingRequests().Load())
 	return &TrafficHistory{Snapshot: snap, Logs: logs, BillingMode: billingMode}, nil
 }
 
@@ -355,12 +355,12 @@ func (pm *ProxyManager) overlaySiteTrafficLocked(s Site, st *SiteTraffic) {
 		persistedIn, persistedOut := inst.persistedDirections()
 		billingMode := pm.database.currentSystemSettings().TrafficBillingMode
 		st.PersistedTraffic = trafficBillableBytes(billingMode, persistedIn, persistedOut)
-		st.BytesIn = inst.bytesIn.Load()
-		st.BytesOut = inst.bytesOut.Load()
-		st.CumulativeBytesIn = inst.cumulativeBytesIn.Load()
-		st.CumulativeBytesOut = inst.cumulativeBytesOut.Load()
+		st.BytesIn = inst.trafficBytesIn().Load()
+		st.BytesOut = inst.trafficBytesOut().Load()
+		st.CumulativeBytesIn = inst.trafficCumulativeIn().Load()
+		st.CumulativeBytesOut = inst.trafficCumulativeOut().Load()
 		st.TrafficUsed = st.PersistedTraffic + trafficBillableBytes(billingMode, st.BytesIn, st.BytesOut)
-		st.Requests = inst.reqCount.Load()
+		st.Requests = inst.trafficRequests().Load()
 		inst.trafficMu.Unlock()
 	}
 }
@@ -499,7 +499,7 @@ func (pm *ProxyManager) GetSiteRuntime(id int64) (requests int64, startedAt time
 	if !ok {
 		return 0, time.Time{}, false, false
 	}
-	return inst.reqCount.Load(), inst.startedAt, inst.isOperational(), inst.portServing.Load()
+	return inst.trafficRequests().Load(), inst.startedAt, inst.isOperational(), inst.portServing.Load()
 }
 
 // GracefulShutdown stops all proxies gracefully

--- a/proxy_manager.go
+++ b/proxy_manager.go
@@ -55,9 +55,69 @@ type ProxyInstance struct {
 	trafficAckedCumulativeIn  int64
 	trafficAckedCumulativeOut int64
 	trafficCycleAuthoritative bool
-	trustedProxies            []*net.IPNet
-	dynamicState              *dynamicSiteState
-	failoverState             *upstreamFailoverState
+	// trafficCounter is shared by every bundle that represents the same
+	// controller site. Config hot-apply replaces routing bundles while active
+	// requests from the old bundle drain; sharing these counters keeps that
+	// traffic in one continuous accounting stream.
+	trafficCounter *edgeSiteTrafficCounter
+	trustedProxies []*net.IPNet
+	dynamicState   *dynamicSiteState
+	failoverState  *upstreamFailoverState
+}
+
+// edgeSiteTrafficCounter is the stable, per-controller-site counter owned by
+// an Agent runtime. It deliberately lives outside ProxyInstance so a routing
+// bundle can be replaced without resetting counters or losing bytes from
+// requests that are still draining on the previous bundle.
+type edgeSiteTrafficCounter struct {
+	bytesIn        atomic.Int64
+	bytesOut       atomic.Int64
+	cumulativeIn   atomic.Int64
+	cumulativeOut  atomic.Int64
+	requests       atomic.Int64
+	pendingRequest atomic.Int64
+}
+
+func (inst *ProxyInstance) trafficBytesIn() *atomic.Int64 {
+	if inst != nil && inst.trafficCounter != nil {
+		return &inst.trafficCounter.bytesIn
+	}
+	return &inst.bytesIn
+}
+
+func (inst *ProxyInstance) trafficBytesOut() *atomic.Int64 {
+	if inst != nil && inst.trafficCounter != nil {
+		return &inst.trafficCounter.bytesOut
+	}
+	return &inst.bytesOut
+}
+
+func (inst *ProxyInstance) trafficCumulativeIn() *atomic.Int64 {
+	if inst != nil && inst.trafficCounter != nil {
+		return &inst.trafficCounter.cumulativeIn
+	}
+	return &inst.cumulativeBytesIn
+}
+
+func (inst *ProxyInstance) trafficCumulativeOut() *atomic.Int64 {
+	if inst != nil && inst.trafficCounter != nil {
+		return &inst.trafficCounter.cumulativeOut
+	}
+	return &inst.cumulativeBytesOut
+}
+
+func (inst *ProxyInstance) trafficRequests() *atomic.Int64 {
+	if inst != nil && inst.trafficCounter != nil {
+		return &inst.trafficCounter.requests
+	}
+	return &inst.reqCount
+}
+
+func (inst *ProxyInstance) trafficPendingRequests() *atomic.Int64 {
+	if inst != nil && inst.trafficCounter != nil {
+		return &inst.trafficCounter.pendingRequest
+	}
+	return &inst.pendingRequests
 }
 
 type ProxyManager struct {
@@ -104,7 +164,7 @@ func (pm *ProxyManager) ProxyRuntimeStats() []ProxyRuntimeStat {
 		if inst == nil || inst.Site.ID <= 0 {
 			continue
 		}
-		stats = append(stats, ProxyRuntimeStat{SiteID: inst.Site.ID, CumulativeBytesIn: inst.cumulativeBytesIn.Load(), CumulativeBytesOut: inst.cumulativeBytesOut.Load(), Requests: inst.reqCount.Load()})
+		stats = append(stats, ProxyRuntimeStat{SiteID: inst.Site.ID, CumulativeBytesIn: inst.trafficCumulativeIn().Load(), CumulativeBytesOut: inst.trafficCumulativeOut().Load(), Requests: inst.trafficRequests().Load()})
 	}
 	return stats
 }

--- a/proxy_start.go
+++ b/proxy_start.go
@@ -116,6 +116,7 @@ func (pm *ProxyManager) StartSite(site Site) error {
 		trustedProxies: append([]*net.IPNet(nil), pm.trustedProxies...),
 		dynamicState:   dynamicState,
 		failoverState:  newUpstreamFailoverState(),
+		trafficCounter: site.runtimeTrafficCounter,
 	}
 	installed := false
 	defer func() {
@@ -361,8 +362,8 @@ func (pm *ProxyManager) StartSite(site Site) error {
 			requestCancel()
 		}()
 		r = r.WithContext(requestCtx)
-		inst.reqCount.Add(1)
-		inst.pendingRequests.Add(1)
+		inst.trafficRequests().Add(1)
+		inst.trafficPendingRequests().Add(1)
 
 		// The Controller can refresh quota usage on an already running Agent
 		// without rebuilding the proxy bundle. Read the live quota baseline from
@@ -387,13 +388,13 @@ func (pm *ProxyManager) StartSite(site Site) error {
 				rw = &rateLimitedWriter{
 					ResponseWriter: w,
 					bytesPerSec:    speedLimitBytes,
-					written:        &inst.bytesOut,
-					cumulative:     &inst.cumulativeBytesOut,
+					written:        inst.trafficBytesOut(),
+					cumulative:     inst.trafficCumulativeOut(),
 					start:          time.Now(),
 					ctx:            r.Context(),
 				}
 			} else {
-				rw = &meteredWriter{ResponseWriter: w, written: &inst.bytesOut, cumulative: &inst.cumulativeBytesOut}
+				rw = &meteredWriter{ResponseWriter: w, written: inst.trafficBytesOut(), cumulative: inst.trafficCumulativeOut()}
 			}
 			if dynamicIssuer == nil {
 				writeDynamicCapabilityUnavailable(rw)
@@ -438,9 +439,9 @@ func (pm *ProxyManager) StartSite(site Site) error {
 			if hit, err := pm.assetCache.read(cacheReq, time.Now()); err == nil && hit != nil {
 				var cacheWriter http.ResponseWriter
 				if speedLimitBytes > 0 {
-					cacheWriter = &rateLimitedWriter{ResponseWriter: w, bytesPerSec: speedLimitBytes, written: &inst.bytesOut, cumulative: &inst.cumulativeBytesOut, start: time.Now(), ctx: r.Context()}
+					cacheWriter = &rateLimitedWriter{ResponseWriter: w, bytesPerSec: speedLimitBytes, written: inst.trafficBytesOut(), cumulative: inst.trafficCumulativeOut(), start: time.Now(), ctx: r.Context()}
 				} else {
-					cacheWriter = &meteredWriter{ResponseWriter: w, written: &inst.bytesOut, cumulative: &inst.cumulativeBytesOut}
+					cacheWriter = &meteredWriter{ResponseWriter: w, written: inst.trafficBytesOut(), cumulative: inst.trafficCumulativeOut()}
 				}
 				serveAssetCacheHit(cacheWriter, r, hit)
 				return
@@ -449,7 +450,7 @@ func (pm *ProxyManager) StartSite(site Site) error {
 		}
 
 		if r.Body != nil {
-			r.Body = &meteredReader{ReadCloser: r.Body, read: &inst.bytesIn, cumulative: &inst.cumulativeBytesIn}
+			r.Body = &meteredReader{ReadCloser: r.Body, read: inst.trafficBytesIn(), cumulative: inst.trafficCumulativeIn()}
 		}
 		if len(failoverTargets) > 1 {
 			if err := prepareFailoverPlaybackInfoBody(r, redirectPolicy.limits.MaxBodyBytes); err != nil {
@@ -477,13 +478,13 @@ func (pm *ProxyManager) StartSite(site Site) error {
 			rw = &rateLimitedWriter{
 				ResponseWriter: w,
 				bytesPerSec:    speedLimitBytes,
-				written:        &inst.bytesOut,
-				cumulative:     &inst.cumulativeBytesOut,
+				written:        inst.trafficBytesOut(),
+				cumulative:     inst.trafficCumulativeOut(),
 				start:          time.Now(),
 				ctx:            r.Context(),
 			}
 		} else {
-			rw = &meteredWriter{ResponseWriter: w, written: &inst.bytesOut, cumulative: &inst.cumulativeBytesOut}
+			rw = &meteredWriter{ResponseWriter: w, written: inst.trafficBytesOut(), cumulative: inst.trafficCumulativeOut()}
 		}
 		proxy.ServeHTTP(rw, r) // #nosec G704 -- forwarding to the administrator-configured, validated upstream is the product's purpose.
 	})

--- a/review_regression_test.go
+++ b/review_regression_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
@@ -532,6 +533,49 @@ func TestReviewAgentReportCannotModifyUnauthorizedSite(t *testing.T) {
 	}, now.Add(time.Second))
 	if err != nil || len(result.DiscardedEventIDs) != 1 || result.DiscardedEventIDs[0] != 12 {
 		t.Fatalf("mismatched Site/Host event was accepted: result=%#v err=%v", result, err)
+	}
+}
+
+func TestReviewScheduledSiteRemovalInvalidatesOwningAgent(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now().UTC()
+	node, enrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "remove-owner", Address: "203.0.113.91", Port: 9090}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := app.db.EnrollControlNode(enrollment, now); err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "remove-site", PublicHost: "remove.example.test", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:18080"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.SaveSiteNodeSchedule(site.ID, true, "fixed", node.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec(`UPDATE site_node_schedules SET desired_node_id=?,applied_node_id=?,config_hash='applied' WHERE site_id=?`, node.ID, node.ID, site.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.db.db.QueryRow("SELECT config_dirty FROM control_nodes WHERE id=?", node.ID).Scan(new(int)); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.removeSiteNodeSchedule(context.Background(), site.ID); err != nil {
+		t.Fatal(err)
+	}
+	var dirty int
+	var desiredHash string
+	if err := app.db.db.QueryRow("SELECT config_dirty,desired_config_hash FROM control_nodes WHERE id=?", node.ID).Scan(&dirty, &desiredHash); err != nil {
+		t.Fatal(err)
+	}
+	if dirty != 1 || desiredHash != "" {
+		t.Fatalf("owning Agent was not invalidated on site removal: dirty=%d hash=%q", dirty, desiredHash)
+	}
+	var enabled int
+	if err := app.db.db.QueryRow("SELECT enabled FROM site_node_schedules WHERE site_id=?", site.ID).Scan(&enabled); err != nil {
+		t.Fatal(err)
+	}
+	if enabled != 0 {
+		t.Fatalf("site schedule remained enabled after removal: %d", enabled)
 	}
 }
 

--- a/site_node_scheduler.go
+++ b/site_node_scheduler.go
@@ -939,7 +939,7 @@ func (a *App) handleAgentConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	config, err := a.buildAgentConfigForRequest(r.Context(), requestBearerToken(r), time.Now(), platform, r.Header.Get(agentVersionHeader))
 	if errors.Is(err, errInvalidAgentToken) {
-		a.jsonErr(w, http.StatusUnauthorized, "invalid agent token")
+		writeAgentAuthFailure(a, w, r)
 		return
 	}
 	if err != nil {
@@ -1370,10 +1370,22 @@ func (a *App) removeSiteNodeSchedule(ctx context.Context, siteID int64) error {
 	if err != nil {
 		return nil
 	}
-	// Freeze the local schedule before touching Cloudflare. This is the first
-	// phase of the deletion saga: a failed remote delete must never leave an
-	// enabled row that the scheduler can use to recreate DNS.
-	if _, err := a.db.db.Exec(`UPDATE site_node_schedules SET enabled=0,dns_status='waiting',last_error='',updated_at_ms=? WHERE site_id=?`, time.Now().UnixMilli(), siteID); err != nil {
+	// Freeze the local schedule before touching Cloudflare. Invalidate every
+	// Agent that currently owns the site before clearing its node references;
+	// otherwise the old Agent would not learn that the route was removed until
+	// its periodic config poll.
+	tx, err := a.db.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if err := markAgentConfigsDirtyForNodeIDsTx(tx, value.FixedNodeID, value.DesiredNodeID, value.AppliedNodeID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`UPDATE site_node_schedules SET enabled=0,dns_status='waiting',last_error='',updated_at_ms=? WHERE site_id=?`, time.Now().UnixMilli(), siteID); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
 		return err
 	}
 	if value.cfRecordID != "" {
@@ -1434,6 +1446,9 @@ func (a *App) prepareNodeDeletion(ctx context.Context, nodeID int64) error {
 	}
 	defer tx.Rollback()
 	for _, value := range affected {
+		if err := markAgentConfigsDirtyForNodeIDsTx(tx, value.FixedNodeID, value.DesiredNodeID, value.AppliedNodeID); err != nil {
+			return err
+		}
 		if _, err := tx.Exec(`UPDATE site_node_schedules SET enabled=0,dns_status='waiting',last_error='',updated_at_ms=? WHERE site_id=?`, time.Now().UnixMilli(), value.SiteID); err != nil {
 			return err
 		}

--- a/site_repository.go
+++ b/site_repository.go
@@ -80,6 +80,7 @@ type Site struct {
 	runtimeTrafficCycleConfigured    bool
 	runtimeTrafficAckedCumulativeIn  int64
 	runtimeTrafficAckedCumulativeOut int64
+	runtimeTrafficCounter            *edgeSiteTrafficCounter
 }
 
 func hydrateSiteConfiguration(site *Site, dynamicEnabled, dynamicDowngrade, assetCacheEnabled, watchHistoryEnabled int) error {

--- a/websocket_proxy.go
+++ b/websocket_proxy.go
@@ -160,11 +160,11 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request, target, primaryTarg
 	// download direction is paced, matching rateLimitedWriter on the HTTP path.
 	done := make(chan struct{}, 2)
 	go func() {
-		_, _ = io.Copy(&tunnelWriter{dst: upstreamConn, counter: &inst.bytesIn, cumulative: &inst.cumulativeBytesIn, start: time.Now()}, clientBuf)
+		_, _ = io.Copy(&tunnelWriter{dst: upstreamConn, counter: inst.trafficBytesIn(), cumulative: inst.trafficCumulativeIn(), start: time.Now()}, clientBuf)
 		done <- struct{}{}
 	}()
 	go func() {
-		_, _ = io.Copy(&tunnelWriter{dst: clientConn, counter: &inst.bytesOut, cumulative: &inst.cumulativeBytesOut, bytesPerSec: speedLimitBytes, start: time.Now()}, upstreamReader)
+		_, _ = io.Copy(&tunnelWriter{dst: clientConn, counter: inst.trafficBytesOut(), cumulative: inst.trafficCumulativeOut(), bytesPerSec: speedLimitBytes, start: time.Now()}, upstreamReader)
 		done <- struct{}{}
 	}()
 	// The first closed direction must tear down its counterpart, then both copy


### PR DESCRIPTION
Harden revoked Agent shutdown, preserve per-site traffic across hot apply, atomically rebase quota ACK state, invalidate schedule owners before site removal, guard Edge certificate races, and add regression tests. Validation: go test ./..., go test -race ./..., go vet ./..., govulncheck ./..., gosec.