### PR TITLE
fix: preserve Agent telemetry through node transitions

### DIFF
--- a/agent_report_guard.go
+++ b/agent_report_guard.go
@@ -3,6 +3,7 @@ package main
 import (
 	"container/list"
 	"context"
+	"errors"
 	"math"
 	"net/http"
 	"strconv"
@@ -336,7 +337,7 @@ func (a *App) withAgentPreAuth(next http.HandlerFunc) http.HandlerFunc {
 		identity, err := a.authenticateAgentRequest(r)
 		release()
 		if err != nil {
-			writeAgentAuthFailure(a, w, r)
+			writeAgentAuthenticationError(a, w, r, err)
 			return
 		}
 		next(w, withAgentCredential(r, identity))
@@ -354,6 +355,18 @@ func writeAgentAuthFailure(a *App, w http.ResponseWriter, r *http.Request) {
 	a.jsonErr(w, http.StatusUnauthorized, "invalid agent token")
 }
 
+// writeAgentAuthenticationError deliberately reserves the Agent revocation
+// signal for a credential that was conclusively rejected. A transient SQLite
+// or filesystem failure must remain retryable: an Agent persists `revoked`
+// and would otherwise take itself permanently offline after one failed lookup.
+func writeAgentAuthenticationError(a *App, w http.ResponseWriter, r *http.Request, err error) {
+	if errors.Is(err, errInvalidAgentToken) || errors.Is(err, errInvalidNodeToken) {
+		writeAgentAuthFailure(a, w, r)
+		return
+	}
+	a.jsonErr(w, http.StatusServiceUnavailable, "agent authentication temporarily unavailable")
+}
+
 // authenticateAgentRequest performs the only credential lookups protected by
 // the global pre-auth concurrency budget. Enrollment credentials are retained
 // because the binary, manifest, and enroll endpoints intentionally accept the
@@ -369,9 +382,13 @@ func (a *App) authenticateAgentRequest(r *http.Request) (agentCredentialIdentity
 	now := time.Now()
 	if node, err := a.db.nodeByAgentToken(token, now); err == nil {
 		return agentCredentialIdentity{Token: token, Node: node, HasNode: true}, nil
+	} else if !errors.Is(err, errInvalidAgentToken) {
+		return agentCredentialIdentity{}, err
 	}
 	if err := a.db.AuthorizeEnrollmentToken(token, now); err == nil {
 		return agentCredentialIdentity{Token: token, Enrollment: true}, nil
+	} else if !errors.Is(err, errInvalidNodeToken) {
+		return agentCredentialIdentity{}, err
 	}
 	return agentCredentialIdentity{}, errInvalidAgentToken
 }
@@ -385,7 +402,10 @@ func agentIdentityForRequest(a *App, r *http.Request) (agentCredentialIdentity, 
 
 func agentNodeIdentityForRequest(a *App, r *http.Request) (agentCredentialIdentity, error) {
 	identity, err := agentIdentityForRequest(a, r)
-	if err != nil || !identity.HasNode || identity.Enrollment {
+	if err != nil {
+		return agentCredentialIdentity{}, err
+	}
+	if !identity.HasNode || identity.Enrollment {
 		return agentCredentialIdentity{}, errInvalidAgentToken
 	}
 	return identity, nil

--- a/agent_report_guard_test.go
+++ b/agent_report_guard_test.go
@@ -57,6 +57,35 @@ func TestAgentPreAuthAuthenticatesBeforeBodyDecode(t *testing.T) {
 	}
 }
 
+func TestAgentPreAuthDatabaseFailureIsRetryableNotRevoked(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now()
+	_, enrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "preauth-db-failure", Address: "203.0.113.81"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, token, err := app.db.EnrollControlNode(enrollment, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := app.db.db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	handler := app.withAgentPreAuth(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("request reached endpoint after authentication storage failure")
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/agent/config", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, req)
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("database failure status=%d, want 503", response.Code)
+	}
+	if state := response.Header().Get("X-Meridian-Agent-State"); state != "" {
+		t.Fatalf("database failure emitted Agent state %q, want no revocation", state)
+	}
+}
+
 func TestAgentPreAuthCannotBeBypassedByEndpointRotation(t *testing.T) {
 	app := &App{}
 	handler := app.withAgentPreAuth(func(w http.ResponseWriter, _ *http.Request) {

--- a/app_nodes.go
+++ b/app_nodes.go
@@ -415,7 +415,11 @@ func (a *App) handleAgentBinary(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	identity, authErr := agentIdentityForRequest(a, r)
-	if authErr != nil || (!identity.HasNode && !identity.Enrollment) {
+	if authErr != nil {
+		writeAgentAuthenticationError(a, w, r, authErr)
+		return
+	}
+	if !identity.HasNode && !identity.Enrollment {
 		writeAgentAuthFailure(a, w, r)
 		return
 	}
@@ -569,7 +573,11 @@ func (a *App) handleAgentManifest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	identity, authErr := agentIdentityForRequest(a, r)
-	if authErr != nil || (!identity.HasNode && !identity.Enrollment) {
+	if authErr != nil {
+		writeAgentAuthenticationError(a, w, r, authErr)
+		return
+	}
+	if !identity.HasNode && !identity.Enrollment {
 		writeAgentAuthFailure(a, w, r)
 		return
 	}
@@ -616,7 +624,11 @@ func (a *App) handleAgentEnroll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	identity, authErr := agentIdentityForRequest(a, r)
-	if authErr != nil || !identity.Enrollment {
+	if authErr != nil {
+		writeAgentAuthenticationError(a, w, r, authErr)
+		return
+	}
+	if !identity.Enrollment {
 		writeAgentAuthFailure(a, w, r)
 		return
 	}
@@ -652,7 +664,7 @@ func (a *App) handleAgentReport(w http.ResponseWriter, r *http.Request) {
 	}
 	identity, authErr := agentNodeIdentityForRequest(a, r)
 	if authErr != nil {
-		writeAgentAuthFailure(a, w, r)
+		writeAgentAuthenticationError(a, w, r, authErr)
 		return
 	}
 	token := identity.Token
@@ -688,6 +700,10 @@ func (a *App) handleAgentReport(w http.ResponseWriter, r *http.Request) {
 	configChanged := nodeReportConfigChanged(result.Node, report.AppliedConfigHash, report.AppliedConfigRevision)
 	a.jsonOK(w, map[string]interface{}{
 		"accepted": true, "node_id": result.Node.ID, "next_report_seconds": 15,
+		"accepted_site_ids": result.AcceptedSiteIDs, "discarded_site_ids": result.DiscardedSiteIDs,
+		"accepted_media_site_ids": result.AcceptedMediaSiteIDs, "discarded_media_site_ids": result.DiscardedMediaSiteIDs,
+		"accepted_retention_site_ids": result.AcceptedRetentionSiteIDs, "discarded_retention_site_ids": result.DiscardedRetentionSiteIDs,
+		"accepted_observation_site_ids": result.AcceptedObservationSiteIDs, "discarded_observation_site_ids": result.DiscardedObservationSiteIDs,
 		"accepted_event_ids": result.AcceptedEventIDs, "accepted_event_uids": result.AcceptedEventUIDs,
 		"discarded_event_ids": result.DiscardedEventIDs, "discarded_event_uids": result.DiscardedEventUIDs,
 		"config_hash":    result.Node.DesiredConfigHash,
@@ -779,6 +795,10 @@ func (a *App) handleAgentWebSocket(ws *websocket.Conn) {
 		}
 		ack := map[string]interface{}{
 			"accepted": true, "node_id": result.Node.ID, "next_report_seconds": 15,
+			"accepted_site_ids": result.AcceptedSiteIDs, "discarded_site_ids": result.DiscardedSiteIDs,
+			"accepted_media_site_ids": result.AcceptedMediaSiteIDs, "discarded_media_site_ids": result.DiscardedMediaSiteIDs,
+			"accepted_retention_site_ids": result.AcceptedRetentionSiteIDs, "discarded_retention_site_ids": result.DiscardedRetentionSiteIDs,
+			"accepted_observation_site_ids": result.AcceptedObservationSiteIDs, "discarded_observation_site_ids": result.DiscardedObservationSiteIDs,
 			"accepted_event_ids": result.AcceptedEventIDs, "accepted_event_uids": result.AcceptedEventUIDs,
 			"discarded_event_ids": result.DiscardedEventIDs, "discarded_event_uids": result.DiscardedEventUIDs,
 			"config_hash":    result.Node.DesiredConfigHash,

--- a/database_migrations.go
+++ b/database_migrations.go
@@ -20,7 +20,7 @@ const (
 	// databaseSchemaVersion is independent from the application and backup
 	// format versions. It is persisted in SQLite so restores can reject a
 	// database whose columns/state are newer than this binary understands.
-	databaseSchemaVersion = 39
+	databaseSchemaVersion = 40
 )
 
 func (d *DB) migrate() error {
@@ -443,6 +443,16 @@ func (d *DB) migrateOnce() error {
 		PRIMARY KEY(site_id,node_id)
 	);
 	CREATE INDEX IF NOT EXISTS idx_site_node_probe_failures_until ON site_node_probe_failures(site_id,failed_until_ms);
+	-- A completed DNS move leaves the former node authorized only long enough
+	-- to report already-admitted stream traffic. This is Controller-owned
+	-- lifecycle state, never an external TLS/DNS namespace.
+	CREATE TABLE IF NOT EXISTS site_node_drains (
+		site_id INTEGER PRIMARY KEY REFERENCES sites(id) ON DELETE CASCADE,
+		node_id INTEGER NOT NULL REFERENCES control_nodes(id) ON DELETE CASCADE,
+		expires_at_ms INTEGER NOT NULL,
+		created_at_ms INTEGER NOT NULL
+	);
+	CREATE INDEX IF NOT EXISTS idx_site_node_drains_node_expiry ON site_node_drains(node_id,expires_at_ms);
 	CREATE TABLE IF NOT EXISTS node_tls_cleanup_jobs (
 		node_guid TEXT PRIMARY KEY,
 		created_at_ms INTEGER NOT NULL,

--- a/edge_agent.go
+++ b/edge_agent.go
@@ -483,14 +483,12 @@ func (b *edgeProxyBundle) close() {
 	}
 }
 
-func (b *edgeProxyBundle) drain(grace time.Duration) {
+func (b *edgeProxyBundle) drain(ctx context.Context) {
 	if b == nil {
 		return
 	}
 	if b.manager != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), grace)
 		b.manager.DrainShutdown(ctx)
-		cancel()
 	}
 	if b.database != nil {
 		b.database.Close()
@@ -506,6 +504,9 @@ type edgeAgentRuntime struct {
 	certificate          *tls.Certificate
 	server               *http.Server
 	bundle               *edgeProxyBundle
+	drainContext         context.Context
+	drainCancel          context.CancelFunc
+	drainingBundles      map[*edgeProxyBundle]struct{}
 	appliedHash          string
 	appliedRevision      int64
 	siteCounterEpoch     uint64
@@ -523,9 +524,38 @@ type edgeAgentRuntime struct {
 	observations         []NodeDynamicObservation
 	siteReported         map[int64]ProxyRuntimeStat
 	trafficCounters      map[int64]*edgeSiteTrafficCounter
-	resolver             dynamicIPResolver
-	transport            dynamicTransportFactory
-	listen               func(string, string) (net.Listener, error)
+	// trafficHosts keeps the Controller host alongside the process-stable
+	// counter. A route can disappear from the current bundle while an admitted
+	// stream is still draining; its counter must remain reportable.
+	trafficHosts map[int64]string
+	resolver     dynamicIPResolver
+	transport    dynamicTransportFactory
+	listen       func(string, string) (net.Listener, error)
+}
+
+// beginBundleDrain rejects new work on an old generation but gives streams
+// admitted before a hot apply an unbounded lifetime. Runtime shutdown/revoke
+// cancels this context and therefore remains an immediate security boundary.
+func (runtime *edgeAgentRuntime) beginBundleDrain(bundle *edgeProxyBundle) {
+	if runtime == nil || bundle == nil {
+		return
+	}
+	runtime.mu.Lock()
+	if runtime.drainContext == nil || runtime.drainCancel == nil {
+		runtime.drainContext, runtime.drainCancel = context.WithCancel(context.Background())
+	}
+	if runtime.drainingBundles == nil {
+		runtime.drainingBundles = make(map[*edgeProxyBundle]struct{})
+	}
+	runtime.drainingBundles[bundle] = struct{}{}
+	ctx := runtime.drainContext
+	runtime.mu.Unlock()
+	go func() {
+		bundle.drain(ctx)
+		runtime.mu.Lock()
+		delete(runtime.drainingBundles, bundle)
+		runtime.mu.Unlock()
+	}()
 }
 
 type edgeAgentRuntimeState struct {
@@ -543,7 +573,7 @@ type edgeAgentRuntimeState struct {
 	listenerError        string
 }
 
-func (runtime *edgeAgentRuntime) trafficCounterFor(siteID int64) *edgeSiteTrafficCounter {
+func (runtime *edgeAgentRuntime) trafficCounterFor(siteID int64, hosts ...string) *edgeSiteTrafficCounter {
 	if runtime == nil || siteID <= 0 {
 		return nil
 	}
@@ -551,6 +581,12 @@ func (runtime *edgeAgentRuntime) trafficCounterFor(siteID int64) *edgeSiteTraffi
 	defer runtime.mu.Unlock()
 	if runtime.trafficCounters == nil {
 		runtime.trafficCounters = make(map[int64]*edgeSiteTrafficCounter)
+	}
+	if len(hosts) > 0 && strings.TrimSpace(hosts[0]) != "" {
+		if runtime.trafficHosts == nil {
+			runtime.trafficHosts = make(map[int64]string)
+		}
+		runtime.trafficHosts[siteID] = requestPublicHost(hosts[0])
 	}
 	if counter := runtime.trafficCounters[siteID]; counter != nil {
 		return counter
@@ -679,34 +715,72 @@ func (runtime *edgeAgentRuntime) prepareTelemetry() edgeTelemetryPending {
 	return pending
 }
 
-func (runtime *edgeAgentRuntime) commitTelemetry(pending edgeTelemetryPending) {
+func acknowledgedSiteIDs(accepted, discarded []int64) map[int64]bool {
+	result := make(map[int64]bool, len(accepted)+len(discarded))
+	for _, siteID := range accepted {
+		if siteID > 0 {
+			result[siteID] = true
+		}
+	}
+	for _, siteID := range discarded {
+		if siteID > 0 {
+			// A discarded item is an explicit, final Controller disposition. It
+			// is safe to remove locally; an HTTP success without this field is not.
+			result[siteID] = true
+		}
+	}
+	return result
+}
+
+func (runtime *edgeAgentRuntime) commitTelemetryWithACK(pending edgeTelemetryPending, mediaACK, retentionACK, observationACK map[int64]bool) {
 	if runtime == nil {
 		return
 	}
 	runtime.telemetryMu.Lock()
 	defer runtime.telemetryMu.Unlock()
 	for _, sent := range pending.media {
-		if current, ok := runtime.mediaCounts[sent.SiteID]; ok && current == sent {
-			delete(runtime.mediaCounts, sent.SiteID)
+		if mediaACK[sent.SiteID] {
+			if current, ok := runtime.mediaCounts[sent.SiteID]; ok && current == sent {
+				delete(runtime.mediaCounts, sent.SiteID)
+			}
 		}
 	}
 	for _, sent := range pending.retention {
-		if current, ok := runtime.retention[sent.SiteID]; ok && current == sent {
-			delete(runtime.retention, sent.SiteID)
+		if retentionACK[sent.SiteID] {
+			if current, ok := runtime.retention[sent.SiteID]; ok && current == sent {
+				delete(runtime.retention, sent.SiteID)
+			}
 		}
 	}
 	if len(pending.observations) > 0 && len(runtime.observations) >= len(pending.observations) {
-		matches := true
-		for i := range pending.observations {
-			if runtime.observations[i] != pending.observations[i] {
-				matches = false
-				break
+		remaining := runtime.observations[:0]
+		for index, current := range runtime.observations {
+			if index < len(pending.observations) && current == pending.observations[index] && observationACK[current.SiteID] {
+				continue
 			}
+			remaining = append(remaining, current)
 		}
-		if matches {
-			runtime.observations = append([]NodeDynamicObservation(nil), runtime.observations[len(pending.observations):]...)
-		}
+		runtime.observations = append([]NodeDynamicObservation(nil), remaining...)
 	}
+}
+
+// commitTelemetry is retained for local diagnostic snapshots and tests. A
+// network report must use commitTelemetryWithACK so it cannot silently lose a
+// category the Controller did not accept.
+func (runtime *edgeAgentRuntime) commitTelemetry(pending edgeTelemetryPending) {
+	media := make(map[int64]bool, len(pending.media))
+	retention := make(map[int64]bool, len(pending.retention))
+	observations := make(map[int64]bool, len(pending.observations))
+	for _, value := range pending.media {
+		media[value.SiteID] = true
+	}
+	for _, value := range pending.retention {
+		retention[value.SiteID] = true
+	}
+	for _, value := range pending.observations {
+		observations[value.SiteID] = true
+	}
+	runtime.commitTelemetryWithACK(pending, media, retention, observations)
 }
 
 func (runtime *edgeAgentRuntime) telemetrySnapshot() (media []NodeMediaCount, retention []NodeRetentionStatus, observations []NodeDynamicObservation) {
@@ -727,40 +801,51 @@ func (runtime *edgeAgentRuntime) prepareSiteStats() edgeSiteStatsPending {
 	}
 	runtime.mu.RLock()
 	bundle := runtime.bundle
-	runtime.mu.RUnlock()
-	if bundle == nil || bundle.manager == nil {
-		return pending
-	}
-	current := bundle.manager.ProxyRuntimeStats()
-	cacheSizes, _, cacheErr := bundle.manager.AssetCacheSizes()
-	if cacheErr != nil {
-		// A cache size read is best-effort telemetry. Treating a read failure as
-		// zero would overwrite an accurate Controller value with a false reset.
-		log.Printf("[agent] read asset cache sizes: %v", cacheErr)
-		cacheSizes = nil
-	}
-	// Baselines are keyed by the Controller's stable SiteID. The in-memory
-	// Edge database is rebuilt whenever configuration changes, so its local
-	// auto-increment IDs must never be used as long-lived identities.
-	pending.current = make(map[int64]ProxyRuntimeStat, len(current))
-	requestStats := runtime.stats.snapshot()
-	byHost := make(map[string]NodeSiteStat, len(requestStats))
-	for _, value := range requestStats {
-		byHost[value.Host] = value
-	}
-	runtime.mu.RLock()
 	previous := make(map[int64]ProxyRuntimeStat, len(runtime.siteReported))
 	for siteID, value := range runtime.siteReported {
 		previous[siteID] = value
 	}
+	counters := make(map[int64]*edgeSiteTrafficCounter, len(runtime.trafficCounters))
+	hosts := make(map[int64]string, len(runtime.trafficHosts))
+	for siteID, counter := range runtime.trafficCounters {
+		counters[siteID] = counter
+		hosts[siteID] = runtime.trafficHosts[siteID]
+	}
 	runtime.mu.RUnlock()
-	pending.stats = make([]NodeSiteStat, 0, len(current))
-	for _, value := range current {
-		identity, ok := bundle.localSites[value.SiteID]
-		if !ok {
+
+	// Request metadata and cache size belong to the current bundle, but byte
+	// counters deliberately do not. The latter are process-stable so a route
+	// removed during a draining connection still gets a final report.
+	requestStats := runtime.stats.snapshot()
+	byHost := make(map[string]NodeSiteStat, len(requestStats))
+	for _, value := range requestStats {
+		byHost[requestPublicHost(value.Host)] = value
+	}
+	cacheSizes := map[int64]int64(nil)
+	cacheErr := error(nil)
+	if bundle != nil && bundle.manager != nil {
+		cacheSizes, _, cacheErr = bundle.manager.AssetCacheSizes()
+		if cacheErr != nil {
+			log.Printf("[agent] read asset cache sizes: %v", cacheErr)
+			cacheSizes = nil
+		}
+	}
+	pending.current = make(map[int64]ProxyRuntimeStat, len(counters))
+	pending.stats = make([]NodeSiteStat, 0, len(counters))
+	for centralID, counter := range counters {
+		if centralID <= 0 || counter == nil {
 			continue
 		}
-		centralID := identity.centralID
+		host := requestPublicHost(hosts[centralID])
+		if host == "" {
+			continue
+		}
+		value := ProxyRuntimeStat{
+			SiteID:             centralID,
+			Requests:           counter.requests.Load(),
+			CumulativeBytesIn:  counter.cumulativeIn.Load(),
+			CumulativeBytesOut: counter.cumulativeOut.Load(),
+		}
 		pending.current[centralID] = value
 		prior := previous[centralID]
 		inDelta, outDelta := value.CumulativeBytesIn-prior.CumulativeBytesIn, value.CumulativeBytesOut-prior.CumulativeBytesOut
@@ -770,13 +855,12 @@ func (runtime *edgeAgentRuntime) prepareSiteStats() edgeSiteStatsPending {
 		if outDelta < 0 {
 			outDelta = value.CumulativeBytesOut
 		}
-		observed := byHost[identity.host]
-		observed.Host = identity.host
+		observed := byHost[host]
+		observed.SiteID = centralID
+		observed.Host = host
 		observed.RequestCount = value.Requests
 		observed.BytesIn, observed.BytesOut = inDelta, outDelta
 		observed.CumulativeBytesIn, observed.CumulativeBytesOut = value.CumulativeBytesIn, value.CumulativeBytesOut
-		// Asset cache namespaces are keyed by the Controller's stable SiteID,
-		// while value.SiteID belongs to the Agent's ephemeral in-memory DB.
 		if cacheErr == nil {
 			observed.CacheSizeBytes = cacheSizes[centralID]
 			observed.CacheSizeValid = true
@@ -786,7 +870,7 @@ func (runtime *edgeAgentRuntime) prepareSiteStats() edgeSiteStatsPending {
 	return pending
 }
 
-func (runtime *edgeAgentRuntime) commitSiteStats(pending edgeSiteStatsPending) {
+func (runtime *edgeAgentRuntime) commitSiteStatsWithACK(pending edgeSiteStatsPending, acknowledged map[int64]bool) {
 	if runtime == nil || len(pending.current) == 0 {
 		return
 	}
@@ -796,6 +880,9 @@ func (runtime *edgeAgentRuntime) commitSiteStats(pending edgeSiteStatsPending) {
 	}
 	deltas := make(map[int64]ProxyRuntimeStat, len(pending.current))
 	for siteID, sent := range pending.current {
+		if !acknowledged[siteID] {
+			continue
+		}
 		current := runtime.siteReported[siteID]
 		delta := ProxyRuntimeStat{SiteID: siteID}
 		if sent.CumulativeBytesIn >= current.CumulativeBytesIn {
@@ -817,8 +904,8 @@ func (runtime *edgeAgentRuntime) commitSiteStats(pending edgeSiteStatsPending) {
 		runtime.siteReported[siteID] = sent
 	}
 	bundle := runtime.bundle
-	reported := make(map[int64]ProxyRuntimeStat, len(pending.current))
-	for siteID := range pending.current {
+	reported := make(map[int64]ProxyRuntimeStat, len(deltas))
+	for siteID := range deltas {
 		reported[siteID] = runtime.siteReported[siteID]
 	}
 	runtime.mu.Unlock()
@@ -849,6 +936,14 @@ func (runtime *edgeAgentRuntime) commitSiteStats(pending edgeSiteStatsPending) {
 			inst.trafficMu.Unlock()
 		}
 	}
+}
+
+func (runtime *edgeAgentRuntime) commitSiteStats(pending edgeSiteStatsPending) {
+	acknowledged := make(map[int64]bool, len(pending.current))
+	for siteID := range pending.current {
+		acknowledged[siteID] = true
+	}
+	runtime.commitSiteStatsWithACK(pending, acknowledged)
 }
 
 // syncSiteTrafficLimits updates the live quota baseline without rebuilding
@@ -1099,7 +1194,7 @@ func buildEdgeProxy(config AgentRuntimeConfig, runtime *edgeAgentRuntime) (*edge
 	for _, route := range config.Routes {
 		site := route.Site
 		site.ID = 0
-		site.runtimeTrafficCounter = runtime.trafficCounterFor(route.SiteID)
+		site.runtimeTrafficCounter = runtime.trafficCounterFor(route.SiteID, route.Host)
 		// Site icons are Controller/UI metadata. The Agent's ephemeral site
 		// database has no uploaded icon pack, so carrying these fields into
 		// CreateSiteRecord would make an otherwise valid runtime config fail
@@ -1404,7 +1499,7 @@ func (runtime *edgeAgentRuntime) apply(config AgentRuntimeConfig) (retErr error)
 				runtime.stopServer()
 			}
 			rollbackErr := runtime.rollbackApply(oldState, listenerChanged, false, err)
-			go bundle.drain(15 * time.Second)
+			runtime.beginBundleDrain(bundle)
 			return rollbackErr
 		}
 	}
@@ -1422,10 +1517,9 @@ func (runtime *edgeAgentRuntime) apply(config AgentRuntimeConfig) (retErr error)
 	runtime.listenerError = ""
 	runtime.mu.Unlock()
 	if oldState.bundle != nil {
-		// A config refresh must not cancel requests that were admitted by the
-		// previous bundle. Stop accepting new requests on it, let active streams
-		// drain, and only force-close them after the bounded grace period.
-		go oldState.bundle.drain(15 * time.Second)
+		// Hot config changes are not a security revocation. Existing playback and
+		// WebSocket streams finish naturally; close() cancels them on shutdown.
+		runtime.beginBundleDrain(oldState.bundle)
 	}
 	return nil
 }
@@ -1476,7 +1570,13 @@ func (runtime *edgeAgentRuntime) close() {
 	runtime.mu.Lock()
 	bundle := runtime.bundle
 	runtime.bundle = nil
+	cancel := runtime.drainCancel
+	runtime.drainCancel = nil
+	runtime.drainContext = nil
 	runtime.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
 	bundle.close()
 }
 
@@ -1549,6 +1649,22 @@ func (e *edgeAPIError) Error() string {
 func isEdgeAgentRevoked(err error) bool {
 	var apiErr *edgeAPIError
 	return errors.As(err, &apiErr) && strings.EqualFold(strings.TrimSpace(apiErr.AgentState), "revoked")
+}
+
+// edgeQuiesceRevoked closes the data plane before recording the durable
+// marker. If the disk is unavailable, returning would let systemd restart the
+// same revoked credential forever; stay inert until an operator stops or
+// repairs the service instead.
+func edgeQuiesceRevoked(ctx context.Context, runtime *edgeAgentRuntime, marker string) error {
+	if runtime != nil {
+		runtime.close()
+	}
+	if err := os.WriteFile(marker, []byte("revoked\n"), 0o600); err != nil {
+		fmt.Fprintf(os.Stderr, "Meridian Agent is revoked but cannot persist revoked state: %v; remaining offline until stopped\n", err)
+		<-ctx.Done()
+		return nil
+	}
+	return nil
 }
 
 func edgeEnrollmentTokenAvailable(path string) bool {
@@ -1629,12 +1745,20 @@ func edgeAPIRequestWithHeaders(ctx context.Context, client *http.Client, method,
 }
 
 type edgeReportAck struct {
-	AcceptedEventIDs   []int64  `json:"accepted_event_ids"`
-	AcceptedEventUIDs  []string `json:"accepted_event_uids"`
-	DiscardedEventIDs  []int64  `json:"discarded_event_ids"`
-	DiscardedEventUIDs []string `json:"discarded_event_uids"`
-	ConfigHash         string   `json:"config_hash"`
-	ConfigChanged      bool     `json:"config_changed"`
+	AcceptedSiteIDs             []int64  `json:"accepted_site_ids"`
+	DiscardedSiteIDs            []int64  `json:"discarded_site_ids"`
+	AcceptedMediaSiteIDs        []int64  `json:"accepted_media_site_ids"`
+	DiscardedMediaSiteIDs       []int64  `json:"discarded_media_site_ids"`
+	AcceptedRetentionSiteIDs    []int64  `json:"accepted_retention_site_ids"`
+	DiscardedRetentionSiteIDs   []int64  `json:"discarded_retention_site_ids"`
+	AcceptedObservationSiteIDs  []int64  `json:"accepted_observation_site_ids"`
+	DiscardedObservationSiteIDs []int64  `json:"discarded_observation_site_ids"`
+	AcceptedEventIDs            []int64  `json:"accepted_event_ids"`
+	AcceptedEventUIDs           []string `json:"accepted_event_uids"`
+	DiscardedEventIDs           []int64  `json:"discarded_event_ids"`
+	DiscardedEventUIDs          []string `json:"discarded_event_uids"`
+	ConfigHash                  string   `json:"config_hash"`
+	ConfigChanged               bool     `json:"config_changed"`
 }
 
 type edgeWSReportClient struct {
@@ -2068,8 +2192,7 @@ func runEdgeAgent() error {
 				agentVersionHeader:  []string{appVersion},
 			}); err != nil {
 				if isEdgeAgentRevoked(err) {
-					_ = os.WriteFile(revokedMarker, []byte("revoked\n"), 0o600)
-					return nil
+					return edgeQuiesceRevoked(ctx, runtime, revokedMarker)
 				}
 				fmt.Fprintf(os.Stderr, "Meridian Agent config fetch failed: %v\n", err)
 			} else if configErr := validateAgentConfigEnvelope(config); configErr != nil {
@@ -2156,13 +2279,17 @@ func runEdgeAgent() error {
 			}
 			if wsErr != nil {
 				if isEdgeAgentRevoked(wsErr) {
-					_ = os.WriteFile(revokedMarker, []byte("revoked\n"), 0o600)
-					return nil
+					return edgeQuiesceRevoked(ctx, runtime, revokedMarker)
 				}
 				fmt.Fprintf(os.Stderr, "Meridian Agent report failed: %v\n", wsErr)
 			} else {
-				runtime.commitSiteStats(pendingStats)
-				runtime.commitTelemetry(pendingTelemetry)
+				runtime.commitSiteStatsWithACK(pendingStats, acknowledgedSiteIDs(ack.AcceptedSiteIDs, ack.DiscardedSiteIDs))
+				runtime.commitTelemetryWithACK(
+					pendingTelemetry,
+					acknowledgedSiteIDs(ack.AcceptedMediaSiteIDs, ack.DiscardedMediaSiteIDs),
+					acknowledgedSiteIDs(ack.AcceptedRetentionSiteIDs, ack.DiscardedRetentionSiteIDs),
+					acknowledgedSiteIDs(ack.AcceptedObservationSiteIDs, ack.DiscardedObservationSiteIDs),
+				)
 				accepted := make(map[int64]bool, len(ack.AcceptedEventIDs))
 				for _, id := range ack.AcceptedEventIDs {
 					accepted[id] = true

--- a/edge_agent_test.go
+++ b/edge_agent_test.go
@@ -93,6 +93,79 @@ func TestEdgeTrafficCounterSurvivesHotApply(t *testing.T) {
 	}
 }
 
+func TestEdgeSiteStatsRetainRemovedRouteUntilControllerAcknowledgesIt(t *testing.T) {
+	runtime := &edgeAgentRuntime{}
+	counter := runtime.trafficCounterFor(42, "tail.example.test")
+	counter.cumulativeIn.Store(123)
+	counter.cumulativeOut.Store(456)
+	counter.requests.Store(7)
+	pending := runtime.prepareSiteStats()
+	if len(pending.stats) != 1 || pending.stats[0].SiteID != 42 || pending.stats[0].CumulativeBytesOut != 456 {
+		t.Fatalf("tail route stats=%#v, want stable removed-route report", pending.stats)
+	}
+	runtime.commitSiteStatsWithACK(pending, nil)
+	if _, ok := runtime.siteReported[42]; ok {
+		t.Fatal("unacknowledged tail stats advanced local watermark")
+	}
+	runtime.commitSiteStatsWithACK(pending, map[int64]bool{42: true})
+	if got := runtime.siteReported[42].CumulativeBytesOut; got != 456 {
+		t.Fatalf("acknowledged tail watermark=%d, want 456", got)
+	}
+}
+
+func TestEdgeTelemetryNeedsCategoryAcknowledgement(t *testing.T) {
+	runtime := &edgeAgentRuntime{mediaCounts: map[int64]NodeMediaCount{7: {SiteID: 7, MovieCount: 1, ObservedAtMS: 1}}}
+	pending := runtime.prepareTelemetry()
+	runtime.commitTelemetryWithACK(pending, nil, nil, nil)
+	if _, ok := runtime.mediaCounts[7]; !ok {
+		t.Fatal("unacknowledged telemetry was discarded")
+	}
+	runtime.commitTelemetryWithACK(pending, map[int64]bool{7: true}, nil, nil)
+	if _, ok := runtime.mediaCounts[7]; ok {
+		t.Fatal("acknowledged telemetry remained pending")
+	}
+}
+
+func TestEdgeRevocationMarkerFailureStaysQuiescent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := edgeQuiesceRevoked(ctx, &edgeAgentRuntime{}, filepath.Join(t.TempDir(), "missing", "agent.revoked")); err != nil {
+		t.Fatalf("quiesce revoked: %v", err)
+	}
+}
+
+func TestEdgeHotReloadDrainDoesNotForceCloseActiveRequest(t *testing.T) {
+	instance := &ProxyInstance{}
+	instance.activeRequests.Add(1)
+	bundle := &edgeProxyBundle{manager: &ProxyManager{proxies: map[int64]*ProxyInstance{1: instance}}}
+	runtime := &edgeAgentRuntime{}
+	runtime.beginBundleDrain(bundle)
+	deadline := time.Now().Add(time.Second)
+	for {
+		runtime.mu.RLock()
+		_, draining := runtime.drainingBundles[bundle]
+		runtime.mu.RUnlock()
+		if draining || time.Now().After(deadline) {
+			if !draining {
+				t.Fatal("hot reload drain ended before its active request completed")
+			}
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	instance.activeRequests.Done()
+	for time.Now().Before(deadline) {
+		runtime.mu.RLock()
+		_, draining := runtime.drainingBundles[bundle]
+		runtime.mu.RUnlock()
+		if !draining {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("hot reload drain did not finish after active request completed")
+}
+
 func TestCommitSiteStatsRebasesAuthoritativeQuotaImmediately(t *testing.T) {
 	counter := &edgeSiteTrafficCounter{}
 	inst := &ProxyInstance{

--- a/node_repository.go
+++ b/node_repository.go
@@ -155,14 +155,25 @@ type NodeReport struct {
 // validation/commit decision made by the controller. Handlers must not infer
 // ACKs from their original request slice after invalid events are filtered.
 type NodeReportResult struct {
-	Node               ControlNode
-	AcceptedEventIDs   []int64
-	AcceptedEventUIDs  []string
-	DiscardedEventIDs  []int64
-	DiscardedEventUIDs []string
+	Node                        ControlNode
+	AcceptedSiteIDs             []int64
+	DiscardedSiteIDs            []int64
+	AcceptedMediaSiteIDs        []int64
+	DiscardedMediaSiteIDs       []int64
+	AcceptedRetentionSiteIDs    []int64
+	DiscardedRetentionSiteIDs   []int64
+	AcceptedObservationSiteIDs  []int64
+	DiscardedObservationSiteIDs []int64
+	AcceptedEventIDs            []int64
+	AcceptedEventUIDs           []string
+	DiscardedEventIDs           []int64
+	DiscardedEventUIDs          []string
 }
 
 type NodeSiteStat struct {
+	// SiteID is the Controller-stable identity. Host is retained for protocol
+	// compatibility and must agree with SiteID when both are supplied.
+	SiteID             int64  `json:"site_id,omitempty"`
 	Host               string `json:"host"`
 	RequestCount       int64  `json:"request_count"`
 	LastRequestAtMS    int64  `json:"last_request_at_ms"`
@@ -1002,7 +1013,7 @@ func validateNodeReport(report NodeReport) error {
 		}
 	}
 	for _, stat := range report.SiteStats {
-		if strings.TrimSpace(stat.Host) == "" || len(stat.Host) > 255 || stat.RequestCount < 0 || stat.LastRequestAtMS < 0 || stat.LastStatus < 0 || stat.LastStatus > 999 || stat.BytesIn < 0 || stat.BytesOut < 0 || stat.CumulativeBytesIn < 0 || stat.CumulativeBytesOut < 0 || stat.CacheSizeBytes < 0 {
+		if stat.SiteID < 0 || strings.TrimSpace(stat.Host) == "" || len(stat.Host) > 255 || stat.RequestCount < 0 || stat.LastRequestAtMS < 0 || stat.LastStatus < 0 || stat.LastStatus > 999 || stat.BytesIn < 0 || stat.BytesOut < 0 || stat.CumulativeBytesIn < 0 || stat.CumulativeBytesOut < 0 || stat.CacheSizeBytes < 0 {
 			return errors.New("invalid site stats")
 		}
 	}
@@ -1037,17 +1048,19 @@ type authorizedNodeSite struct {
 }
 
 // authorizedNodeSitesTx is the single source of truth for report-side site
-// authorization. A site remains authorized during a scheduler transition
-// while either desired_node_id or applied_node_id points at the reporting node.
-func authorizedNodeSitesTx(tx *sql.Tx, nodeID int64) (map[int64]authorizedNodeSite, error) {
+// authorization. A site remains authorized while desired/applied points at the
+// reporting node and, after a completed DNS move, through its bounded drain
+// window so admitted streams can report their final traffic.
+func authorizedNodeSitesTx(tx *sql.Tx, nodeID, nowMS int64) (map[int64]authorizedNodeSite, error) {
 	rows, err := tx.Query(`
 		SELECT s.id, LOWER(TRIM(s.public_host))
 		FROM site_node_schedules n
 		JOIN sites s ON s.id=n.site_id
+		LEFT JOIN site_node_drains d ON d.site_id=n.site_id
 		WHERE n.enabled=1
 		  AND s.enabled=1
-		  AND (n.desired_node_id=? OR n.applied_node_id=?)
-	`, nodeID, nodeID)
+		  AND (n.desired_node_id=? OR n.applied_node_id=? OR (d.node_id=? AND d.expires_at_ms>?))
+	`, nodeID, nodeID, nodeID, nowMS)
 	if err != nil {
 		return nil, err
 	}
@@ -1072,6 +1085,22 @@ func authorizedNodeSiteHost(sites map[int64]authorizedNodeSite, siteID int64, ho
 	return normalized != "" && strings.EqualFold(normalized, site.PublicHost)
 }
 
+// authorizedNodeSiteForStat accepts legacy Host-only reports but requires the
+// supplied host to match when a current Agent includes its stable SiteID.
+func authorizedNodeSiteForStat(sites map[int64]authorizedNodeSite, stat NodeSiteStat) (authorizedNodeSite, bool) {
+	if stat.SiteID > 0 {
+		site, ok := sites[stat.SiteID]
+		return site, ok && authorizedNodeSiteHost(sites, stat.SiteID, stat.Host)
+	}
+	host := requestPublicHost(strings.TrimSpace(stat.Host))
+	for _, site := range sites {
+		if strings.EqualFold(site.PublicHost, host) {
+			return site, true
+		}
+	}
+	return authorizedNodeSite{}, false
+}
+
 func (d *DB) authorizedNodeSitesForAgentToken(token string) (int64, map[int64]authorizedNodeSite, error) {
 	tx, err := d.db.Begin()
 	if err != nil {
@@ -1084,7 +1113,7 @@ func (d *DB) authorizedNodeSitesForAgentToken(token string) (int64, map[int64]au
 	} else if err != nil {
 		return 0, nil, err
 	}
-	sites, err := authorizedNodeSitesTx(tx, nodeID)
+	sites, err := authorizedNodeSitesTx(tx, nodeID, time.Now().UnixMilli())
 	if err != nil {
 		return 0, nil, err
 	}
@@ -1209,17 +1238,11 @@ func (d *DB) recordNodeRequestEventTx(tx *sql.Tx, nodeID int64, event NodeReques
 }
 
 func recordNodeSiteTrafficTx(tx *sql.Tx, nodeID int64, counterEpoch string, stat NodeSiteStat, nowMS int64, allowedSites map[int64]authorizedNodeSite) error {
-	var siteID int64
-	host := requestPublicHost(strings.TrimSpace(stat.Host))
-	for id, site := range allowedSites {
-		if strings.EqualFold(site.PublicHost, host) {
-			siteID = id
-			break
-		}
-	}
-	if siteID <= 0 {
+	site, ok := authorizedNodeSiteForStat(allowedSites, stat)
+	if !ok {
 		return nil
 	}
+	siteID := site.ID
 	currentIn, currentOut := stat.CumulativeBytesIn, stat.CumulativeBytesOut
 	if currentIn == 0 && stat.BytesIn > 0 {
 		currentIn = stat.BytesIn
@@ -1301,12 +1324,32 @@ func recordNodeSiteTrafficTx(tx *sql.Tx, nodeID int64, counterEpoch string, stat
 }
 
 type nodeReportCommitResult struct {
-	node              ControlNode
-	acceptedNew       []NodeRequestEvent
-	acceptedDuplicate []NodeRequestEvent
-	pendingEffects    []NodeRequestEvent
-	discardedIDs      []int64
-	discardedUIDs     []string
+	node                        ControlNode
+	acceptedSiteIDs             []int64
+	discardedSiteIDs            []int64
+	acceptedMediaSiteIDs        []int64
+	discardedMediaSiteIDs       []int64
+	acceptedRetentionSiteIDs    []int64
+	discardedRetentionSiteIDs   []int64
+	acceptedObservationSiteIDs  []int64
+	discardedObservationSiteIDs []int64
+	acceptedNew                 []NodeRequestEvent
+	acceptedDuplicate           []NodeRequestEvent
+	pendingEffects              []NodeRequestEvent
+	discardedIDs                []int64
+	discardedUIDs               []string
+}
+
+func appendUniqueNodeSiteID(ids *[]int64, siteID int64) {
+	if siteID <= 0 {
+		return
+	}
+	for _, existing := range *ids {
+		if existing == siteID {
+			return
+		}
+	}
+	*ids = append(*ids, siteID)
 }
 
 func appendNodeEventIdentity(ids *[]int64, uids *[]string, event NodeRequestEvent) {
@@ -1358,7 +1401,7 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 	// Authorization and every report mutation use one transaction. A scheduler
 	// transition therefore resolves as either authorized-and-committed or
 	// unauthorized-and-discarded; ACKs are never inferred from a preflight.
-	allowedSites, err := authorizedNodeSitesTx(tx, id)
+	allowedSites, err := authorizedNodeSitesTx(tx, id, now.UnixMilli())
 	if err != nil {
 		return nodeReportCommitResult{}, err
 	}
@@ -1490,20 +1533,18 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 		if host == "" || len(host) > 255 || stat.RequestCount < 0 || stat.LastRequestAtMS < 0 || stat.LastStatus < 0 || stat.LastStatus > 999 {
 			continue
 		}
-		var scheduleID int64
+		authorizedSite, authorized := authorizedNodeSiteForStat(allowedSites, stat)
+		if !authorized {
+			d.recordAgentSecurityRejection(id, stat.SiteID, "site-stats")
+			appendUniqueNodeSiteID(&result.discardedSiteIDs, stat.SiteID)
+			continue
+		}
+		scheduleID := authorizedSite.ID
 		var previousBoot string
 		var previousCount int64
-		err := tx.QueryRow(`SELECT n.site_id,n.agent_boot_id,n.agent_request_count FROM site_node_schedules n JOIN sites s ON s.id=n.site_id WHERE n.enabled=1 AND s.enabled=1 AND (n.desired_node_id=? OR n.applied_node_id=?) AND lower(s.public_host)=?`, id, id, host).Scan(&scheduleID, &previousBoot, &previousCount)
-		if errors.Is(err, sql.ErrNoRows) {
-			d.recordAgentSecurityRejection(id, 0, "site-stats")
-			continue
-		}
+		err := tx.QueryRow(`SELECT agent_boot_id,agent_request_count FROM site_node_schedules WHERE site_id=?`, scheduleID).Scan(&previousBoot, &previousCount)
 		if err != nil {
 			return nodeReportCommitResult{}, err
-		}
-		if !authorizedNodeSiteHost(allowedSites, scheduleID, host) {
-			d.recordAgentSecurityRejection(id, scheduleID, "site-stats")
-			continue
 		}
 		count := stat.RequestCount
 		if previousBoot != sessionID || count < previousCount {
@@ -1519,34 +1560,41 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 		if err := recordNodeSiteTrafficTx(tx, id, siteCounterEpoch, stat, now.UnixMilli(), allowedSites); err != nil {
 			return nodeReportCommitResult{}, err
 		}
+		appendUniqueNodeSiteID(&result.acceptedSiteIDs, scheduleID)
 	}
 
 	for _, count := range report.MediaCounts {
 		if _, allowed := allowedSites[count.SiteID]; !allowed {
 			d.recordAgentSecurityRejection(id, count.SiteID, "media-counts")
+			appendUniqueNodeSiteID(&result.discardedMediaSiteIDs, count.SiteID)
 			continue
 		}
 		if _, err := tx.Exec(`UPDATE sites SET media_movie_count=?,media_series_count=?,media_episode_count=?,media_count_updated_at_ms=? WHERE id=? AND media_count_updated_at_ms<?`, count.MovieCount, count.SeriesCount, count.EpisodeCount, count.ObservedAtMS, count.SiteID, count.ObservedAtMS); err != nil {
 			return nodeReportCommitResult{}, err
 		}
+		appendUniqueNodeSiteID(&result.acceptedMediaSiteIDs, count.SiteID)
 	}
 	for _, status := range report.Retention {
 		if _, allowed := allowedSites[status.SiteID]; !allowed {
 			d.recordAgentSecurityRejection(id, status.SiteID, "retention")
+			appendUniqueNodeSiteID(&result.discardedRetentionSiteIDs, status.SiteID)
 			continue
 		}
 		if _, err := tx.Exec(`UPDATE sites SET account_retention_started_at_ms=?,account_retention_last_completed_at_ms=?,updated_at=CURRENT_TIMESTAMP WHERE id=? AND account_retention_days>0 AND account_retention_started_at_ms=?`, status.CompletedAtMS, status.CompletedAtMS, status.SiteID, status.ExpectedStartedAtMS); err != nil {
 			return nodeReportCommitResult{}, err
 		}
+		appendUniqueNodeSiteID(&result.acceptedRetentionSiteIDs, status.SiteID)
 	}
 	for _, observation := range report.Observations {
 		if _, allowed := allowedSites[observation.SiteID]; !allowed {
 			d.recordAgentSecurityRejection(id, observation.SiteID, "observation")
+			appendUniqueNodeSiteID(&result.discardedObservationSiteIDs, observation.SiteID)
 			continue
 		}
 		if _, err := tx.Exec(`INSERT INTO dynamic_observations(site_id,canonical_authority,source,decision,reason_code,first_seen_ms,last_seen_ms,count) VALUES(?,?,?,?,?,?,?,1) ON CONFLICT(site_id,canonical_authority,source,decision,reason_code) DO UPDATE SET last_seen_ms=excluded.last_seen_ms,count=count+1`, observation.SiteID, observation.CanonicalAuthority, observation.Source, observation.Decision, observation.ReasonCode, observation.ObservedAtMS, observation.ObservedAtMS); err != nil {
 			return nodeReportCommitResult{}, err
 		}
+		appendUniqueNodeSiteID(&result.acceptedObservationSiteIDs, observation.SiteID)
 	}
 
 	for _, event := range report.Events {
@@ -1637,6 +1685,14 @@ func (d *DB) RecordNodeReportResult(agentToken string, report NodeReport, now ti
 		return NodeReportResult{}, err
 	}
 	result := NodeReportResult{Node: committed.node}
+	result.AcceptedSiteIDs = committed.acceptedSiteIDs
+	result.DiscardedSiteIDs = committed.discardedSiteIDs
+	result.AcceptedMediaSiteIDs = committed.acceptedMediaSiteIDs
+	result.DiscardedMediaSiteIDs = committed.discardedMediaSiteIDs
+	result.AcceptedRetentionSiteIDs = committed.acceptedRetentionSiteIDs
+	result.DiscardedRetentionSiteIDs = committed.discardedRetentionSiteIDs
+	result.AcceptedObservationSiteIDs = committed.acceptedObservationSiteIDs
+	result.DiscardedObservationSiteIDs = committed.discardedObservationSiteIDs
 	for _, event := range committed.acceptedNew {
 		appendNodeEventIdentity(&result.AcceptedEventIDs, &result.AcceptedEventUIDs, event)
 	}

--- a/review_regression_test.go
+++ b/review_regression_test.go
@@ -493,6 +493,7 @@ func TestReviewAgentReportCannotModifyUnauthorizedSite(t *testing.T) {
 	unauthorizedUID := strings.Repeat("b", 32)
 	result, err := app.db.RecordNodeReportResult(tokenA, NodeReport{
 		BootID: "auth-session", ReportSessionID: "auth-session", CounterEpoch: "kernel:eth0", Sequence: 1, InterfaceName: "eth0",
+		SiteStats:    []NodeSiteStat{{SiteID: siteB.ID, Host: siteB.PublicHost, RequestCount: 1, LastRequestAtMS: now.UnixMilli(), LastStatus: 200}},
 		MediaCounts:  []NodeMediaCount{{SiteID: siteB.ID, MovieCount: 99, SeriesCount: 88, EpisodeCount: 77, ObservedAtMS: now.UnixMilli()}},
 		Observations: []NodeDynamicObservation{{SiteID: siteB.ID, CanonicalAuthority: "https://auth-b.example.com:443", Source: dynamicObservationSourceRedirect, Decision: dynamicObservationDecisionAllowed, ReasonCode: dynamicObservationReasonRedirectAllowed, ObservedAtMS: now.UnixMilli()}},
 		Events: []NodeRequestEvent{
@@ -508,6 +509,9 @@ func TestReviewAgentReportCannotModifyUnauthorizedSite(t *testing.T) {
 	}
 	if len(result.DiscardedEventUIDs) != 1 || result.DiscardedEventUIDs[0] != unauthorizedUID {
 		t.Fatalf("unauthorized event UID was not discarded: %#v", result)
+	}
+	if len(result.DiscardedSiteIDs) != 1 || result.DiscardedSiteIDs[0] != siteB.ID || len(result.DiscardedMediaSiteIDs) != 1 || result.DiscardedMediaSiteIDs[0] != siteB.ID || len(result.DiscardedObservationSiteIDs) != 1 || result.DiscardedObservationSiteIDs[0] != siteB.ID {
+		t.Fatalf("controller did not return explicit telemetry dispositions: %#v", result)
 	}
 	var movieCount int
 	if err := app.db.db.QueryRow("SELECT media_movie_count FROM sites WHERE id=?", siteB.ID).Scan(&movieCount); err != nil {
@@ -533,6 +537,52 @@ func TestReviewAgentReportCannotModifyUnauthorizedSite(t *testing.T) {
 	}, now.Add(time.Second))
 	if err != nil || len(result.DiscardedEventIDs) != 1 || result.DiscardedEventIDs[0] != 12 {
 		t.Fatalf("mismatched Site/Host event was accepted: result=%#v err=%v", result, err)
+	}
+}
+
+func TestReviewCompletedDNSMoveKeepsTailTrafficAuthorizedOnlyDuringDrain(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now().UTC()
+	oldNode, oldEnrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "drain-old", Address: "203.0.113.70", Port: 9090}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newNode, newEnrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "drain-new", Address: "203.0.113.71", Port: 9090}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, oldToken, err := app.db.EnrollControlNode(oldEnrollment, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := app.db.EnrollControlNode(newEnrollment, now); err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "drain-site", PublicHost: "drain.example.test", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:18080"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.SaveSiteNodeSchedule(site.ID, true, "fixed", newNode.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec(`UPDATE site_node_schedules SET desired_node_id=?,applied_node_id=? WHERE site_id=?`, newNode.ID, newNode.ID, site.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec(`INSERT INTO site_node_drains(site_id,node_id,expires_at_ms,created_at_ms) VALUES(?,?,?,?)`, site.ID, oldNode.ID, now.Add(time.Minute).UnixMilli(), now.UnixMilli()); err != nil {
+		t.Fatal(err)
+	}
+	report := NodeReport{BootID: "drain", ReportSessionID: "drain", CounterEpoch: "epoch", SiteCounterEpoch: "drain:1", Sequence: 1, InterfaceName: "eth0", SiteStats: []NodeSiteStat{{SiteID: site.ID, Host: site.PublicHost, RequestCount: 1, LastRequestAtMS: now.UnixMilli(), LastStatus: 200, BytesOut: 100, CumulativeBytesOut: 100}}}
+	result, err := app.db.RecordNodeReportResult(oldToken, report, now)
+	if err != nil || len(result.AcceptedSiteIDs) != 1 || result.AcceptedSiteIDs[0] != site.ID {
+		t.Fatalf("draining tail report=%#v err=%v, want accepted", result, err)
+	}
+	if _, err := app.db.db.Exec(`UPDATE site_node_drains SET expires_at_ms=? WHERE site_id=?`, now.Add(-time.Second).UnixMilli(), site.ID); err != nil {
+		t.Fatal(err)
+	}
+	report.Sequence = 2
+	result, err = app.db.RecordNodeReportResult(oldToken, report, now.Add(time.Second))
+	if err != nil || len(result.DiscardedSiteIDs) != 1 || result.DiscardedSiteIDs[0] != site.ID {
+		t.Fatalf("expired drain report=%#v err=%v, want discarded", result, err)
 	}
 }
 

--- a/site_node_scheduler.go
+++ b/site_node_scheduler.go
@@ -24,7 +24,14 @@ import (
 	"time"
 )
 
-const agentConfigSchemaVersion = 1
+const (
+	agentConfigSchemaVersion = 1
+	// siteNodeDrainWindow gives an already-admitted stream several report
+	// intervals to finish and publish its final cumulative counters after DNS
+	// points at the replacement node. New requests are prevented by the new
+	// Agent configuration; this is telemetry authorization only.
+	siteNodeDrainWindow = 2 * time.Minute
+)
 
 type SiteNodeSchedule struct {
 	SiteID               int64  `json:"site_id"`
@@ -775,7 +782,8 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 	}
 	rows, err := tx.Query(`SELECT s.id,s.public_host,s.target_url,s.playback_target_url,s.playback_mode,s.stream_hosts,s.upstream_headers
 		FROM site_node_schedules n JOIN sites s ON s.id=n.site_id
-		WHERE n.enabled=1 AND (n.desired_node_id=? OR n.applied_node_id=?) AND s.enabled=1 ORDER BY s.id`, node.ID, node.ID)
+		WHERE n.enabled=1 AND s.enabled=1 AND (n.desired_node_id=? OR n.applied_node_id=?)
+		ORDER BY s.id`, node.ID, node.ID)
 	if err != nil {
 		return AgentRuntimeConfig{}, err
 	}
@@ -1287,14 +1295,43 @@ func (a *App) reconcileOneSiteSchedule(ctx context.Context, schedule SiteNodeSch
 	if err != nil {
 		return err
 	}
-	_, err = a.db.db.Exec(`UPDATE site_node_schedules SET applied_node_id=?,cf_zone_id=?,cf_record_id=?,cf_record_type=?,
+	// DNS is an external side effect and is complete at this point. Publish the
+	// replacement and both Agent invalidations atomically. The previous applied
+	// node retains only a bounded drain route so existing streams can report a
+	// final counter; it is not left to the next sixty-second config poll.
+	tx, beginErr := a.db.db.BeginTx(ctx, nil)
+	if beginErr != nil {
+		return beginErr
+	}
+	defer tx.Rollback()
+	if schedule.AppliedNodeID != node.ID {
+		if schedule.AppliedNodeID > 0 {
+			if _, err = tx.Exec(`INSERT INTO site_node_drains(site_id,node_id,expires_at_ms,created_at_ms) VALUES(?,?,?,?)
+				ON CONFLICT(site_id) DO UPDATE SET node_id=excluded.node_id,expires_at_ms=excluded.expires_at_ms,created_at_ms=excluded.created_at_ms`,
+				schedule.SiteID, schedule.AppliedNodeID, now.Add(siteNodeDrainWindow).UnixMilli(), now.UnixMilli()); err != nil {
+				return err
+			}
+		}
+		if err = markAgentConfigsDirtyForNodeIDsTx(tx, schedule.AppliedNodeID, node.ID); err != nil {
+			return err
+		}
+	}
+	if _, err = tx.Exec(`UPDATE site_node_schedules SET applied_node_id=?,cf_zone_id=?,cf_record_id=?,cf_record_type=?,
 		applied_address=?,dns_status='active',last_error='',updated_at_ms=? WHERE site_id=?`, node.ID, zoneID, recordID,
-		recordType, ip.String(), now.UnixMilli(), schedule.SiteID)
-	return err
+		recordType, ip.String(), now.UnixMilli(), schedule.SiteID); err != nil {
+		return err
+	}
+	if err = tx.Commit(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (a *App) reconcileSiteNodeScheduling(ctx context.Context) {
 	now := time.Now()
+	if _, err := a.db.db.Exec("DELETE FROM site_node_drains WHERE expires_at_ms<=?", now.UnixMilli()); err != nil {
+		log.Printf("[node-scheduler] expire node drains: %v", err)
+	}
 	if err := a.db.retryNodeTLSCleanup(""); err != nil {
 		log.Printf("[node-scheduler] managed Edge TLS cleanup retry failed: %v", err)
 	}


### PR DESCRIPTION
Fix Agent credential error semantics, acknowledged telemetry delivery, tail-traffic reporting, graceful hot reload drainage, DNS handoff invalidation, and revoked-state quiescence.\n\nValidation: go test ./... -count=1 -timeout 5m, focused go test -race, go vet ./..., govulncheck ./..., gosec, and 162 frontend tests.