### PR TITLE
fix: harden agent route lifecycle and telemetry drains

### DIFF
--- a/backup_restore.go
+++ b/backup_restore.go
@@ -1840,6 +1840,9 @@ func writeRestorePendingFromPaths(dbPath string, manifest backupManifest, entrie
 	if err := os.Rename(tmp, pending); err != nil {
 		return 0, err
 	}
+	if err := syncDirectory(filepath.Dir(pending)); err != nil {
+		return 0, err
+	}
 	return resetIngressCount, nil
 }
 
@@ -2505,6 +2508,9 @@ func applyPendingRestore(dbPath string) (*restoreAppliedState, error) {
 	if err := os.Rename(filepath.Join(pending, backupDatabaseEntry), dbPath); err != nil { // #nosec G703 G304 -- source is the fixed database archive entry in pending.
 		return nil, err
 	}
+	if err := syncDirectory(filepath.Dir(dbPath)); err != nil {
+		return nil, err
+	}
 	if markerIncludesTLS(marker) {
 		panelPairRestored := false
 		var pairErr error
@@ -2544,6 +2550,9 @@ func rollbackRestoreFiles(dbPath, rollback string) error {
 		source := filepath.Join(rollback, backupDatabaseEntry+suffix)
 		if _, err := os.Stat(source); err == nil { // #nosec G703 G304 -- source is the fixed rollback database entry.
 			if err := os.Rename(source, dbPath+suffix); err != nil {
+				return err
+			}
+			if err := syncDirectory(filepath.Dir(dbPath)); err != nil {
 				return err
 			}
 		} else if suffix == "" {

--- a/database_migrations.go
+++ b/database_migrations.go
@@ -20,7 +20,7 @@ const (
 	// databaseSchemaVersion is independent from the application and backup
 	// format versions. It is persisted in SQLite so restores can reject a
 	// database whose columns/state are newer than this binary understands.
-	databaseSchemaVersion = 40
+	databaseSchemaVersion = 42
 )
 
 func (d *DB) migrate() error {
@@ -447,12 +447,26 @@ func (d *DB) migrateOnce() error {
 	-- to report already-admitted stream traffic. This is Controller-owned
 	-- lifecycle state, never an external TLS/DNS namespace.
 	CREATE TABLE IF NOT EXISTS site_node_drains (
-		site_id INTEGER PRIMARY KEY REFERENCES sites(id) ON DELETE CASCADE,
+		site_id INTEGER NOT NULL REFERENCES sites(id) ON DELETE CASCADE,
 		node_id INTEGER NOT NULL REFERENCES control_nodes(id) ON DELETE CASCADE,
+		public_host TEXT NOT NULL DEFAULT '',
 		expires_at_ms INTEGER NOT NULL,
-		created_at_ms INTEGER NOT NULL
+		created_at_ms INTEGER NOT NULL,
+		PRIMARY KEY(site_id,node_id)
 	);
 	CREATE INDEX IF NOT EXISTS idx_site_node_drains_node_expiry ON site_node_drains(node_id,expires_at_ms);
+	-- Former public hosts remain accepted for a short period while an Agent
+	-- drains a previously applied route. This is separate from DNS/node drains
+	-- because a site rename can happen without a node move.
+	CREATE TABLE IF NOT EXISTS site_node_host_aliases (
+		site_id INTEGER NOT NULL REFERENCES sites(id) ON DELETE CASCADE,
+		node_id INTEGER NOT NULL REFERENCES control_nodes(id) ON DELETE CASCADE,
+		public_host TEXT NOT NULL,
+		expires_at_ms INTEGER NOT NULL,
+		created_at_ms INTEGER NOT NULL,
+		PRIMARY KEY(site_id,node_id,public_host)
+	);
+	CREATE INDEX IF NOT EXISTS idx_site_node_host_aliases_node_expiry ON site_node_host_aliases(node_id,expires_at_ms);
 	CREATE TABLE IF NOT EXISTS node_tls_cleanup_jobs (
 		node_guid TEXT PRIMARY KEY,
 		created_at_ms INTEGER NOT NULL,
@@ -460,6 +474,12 @@ func (d *DB) migrateOnce() error {
 		last_error TEXT NOT NULL DEFAULT '',
 		updated_at_ms INTEGER NOT NULL
 	);
+	CREATE TABLE IF NOT EXISTS agent_route_revocations (
+		node_id INTEGER NOT NULL REFERENCES control_nodes(id) ON DELETE CASCADE,
+		site_id INTEGER NOT NULL REFERENCES sites(id) ON DELETE CASCADE,
+		created_at_ms INTEGER NOT NULL,
+		PRIMARY KEY(node_id,site_id)
+	) WITHOUT ROWID;
 	`); err != nil {
 		return err
 	}
@@ -823,6 +843,9 @@ func (d *DB) migrateOnce() error {
 	) WITHOUT ROWID; CREATE INDEX IF NOT EXISTS idx_node_request_events_received ON node_request_events(received_at_ms);`); err != nil {
 		return err
 	}
+	if err := ensureSiteNodeDrainsSchema(ctx, conn); err != nil {
+		return err
+	}
 	var eventUIDColumnCount int
 	if err := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM pragma_table_info('node_request_events') WHERE name=?", "event_uid").Scan(&eventUIDColumnCount); err != nil {
 		return err
@@ -1145,6 +1168,62 @@ func ensurePanelSettingsListenPortSchema(ctx context.Context, conn *sql.Conn) er
 		if _, err := conn.ExecContext(ctx, migration.sql); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// ensureSiteNodeDrainsSchema upgrades the original site_id-only drain table to
+// a per-site/per-node ledger. A fast A→B→C sequence must retain both A and B
+// until their admitted streams have delivered a final snapshot. The migration
+// also captures the former public host for late request events.
+func ensureSiteNodeDrainsSchema(ctx context.Context, conn *sql.Conn) error {
+	rows, err := conn.QueryContext(ctx, "PRAGMA table_info('site_node_drains')")
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	var sitePK, nodePK int
+	hasPublicHost := false
+	for rows.Next() {
+		var cid int
+		var name, columnType string
+		var notNull, pk int
+		var defaultValue any
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &pk); err != nil {
+			return err
+		}
+		switch name {
+		case "site_id":
+			sitePK = pk
+		case "node_id":
+			nodePK = pk
+		case "public_host":
+			hasPublicHost = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if sitePK == 1 && nodePK == 2 && hasPublicHost {
+		return nil
+	}
+	if _, err := conn.ExecContext(ctx, `
+		CREATE TABLE site_node_drains_new (
+			site_id INTEGER NOT NULL REFERENCES sites(id) ON DELETE CASCADE,
+			node_id INTEGER NOT NULL REFERENCES control_nodes(id) ON DELETE CASCADE,
+			public_host TEXT NOT NULL DEFAULT '',
+			expires_at_ms INTEGER NOT NULL,
+			created_at_ms INTEGER NOT NULL,
+			PRIMARY KEY(site_id,node_id)
+		);
+		INSERT OR REPLACE INTO site_node_drains_new(site_id,node_id,public_host,expires_at_ms,created_at_ms)
+			SELECT d.site_id,d.node_id,LOWER(TRIM(COALESCE(s.public_host,''))),d.expires_at_ms,d.created_at_ms
+			FROM site_node_drains d LEFT JOIN sites s ON s.id=d.site_id;
+		DROP TABLE site_node_drains;
+		ALTER TABLE site_node_drains_new RENAME TO site_node_drains;
+		CREATE INDEX IF NOT EXISTS idx_site_node_drains_node_expiry ON site_node_drains(node_id,expires_at_ms);
+	`); err != nil {
+		return fmt.Errorf("migrate site node drain ledger: %w", err)
 	}
 	return nil
 }

--- a/edge_agent.go
+++ b/edge_agent.go
@@ -26,6 +26,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	goruntime "runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -235,7 +236,10 @@ func (s *edgeEventStore) persistLocked() error {
 	if err = tmp.Close(); err != nil {
 		return err
 	}
-	return os.Rename(tmpName, s.path)
+	if err := os.Rename(tmpName, s.path); err != nil {
+		return err
+	}
+	return syncDirectory(filepath.Dir(s.path))
 }
 
 func newEdgeEventUID() (string, error) {
@@ -792,6 +796,7 @@ func (runtime *edgeAgentRuntime) telemetrySnapshot() (media []NodeMediaCount, re
 type edgeSiteStatsPending struct {
 	stats   []NodeSiteStat
 	current map[int64]ProxyRuntimeStat
+	final   map[int64]bool
 }
 
 func (runtime *edgeAgentRuntime) prepareSiteStats() edgeSiteStatsPending {
@@ -831,8 +836,18 @@ func (runtime *edgeAgentRuntime) prepareSiteStats() edgeSiteStatsPending {
 		}
 	}
 	pending.current = make(map[int64]ProxyRuntimeStat, len(counters))
+	pending.final = make(map[int64]bool)
 	pending.stats = make([]NodeSiteStat, 0, len(counters))
-	for centralID, counter := range counters {
+	centralIDs := make([]int64, 0, len(counters))
+	for centralID := range counters {
+		centralIDs = append(centralIDs, centralID)
+	}
+	sort.Slice(centralIDs, func(i, j int) bool { return centralIDs[i] < centralIDs[j] })
+	for _, centralID := range centralIDs {
+		counter := counters[centralID]
+		if len(pending.stats) >= maxNodeSiteStatsPerReport {
+			break
+		}
 		if centralID <= 0 || counter == nil {
 			continue
 		}
@@ -861,6 +876,16 @@ func (runtime *edgeAgentRuntime) prepareSiteStats() edgeSiteStatsPending {
 		observed.RequestCount = value.Requests
 		observed.BytesIn, observed.BytesOut = inDelta, outDelta
 		observed.CumulativeBytesIn, observed.CumulativeBytesOut = value.CumulativeBytesIn, value.CumulativeBytesOut
+		// A removed route is final only after all requests admitted by the old
+		// bundle have finished. The Controller uses this marker to retire the
+		// corresponding drain generation and ACK the counter before GC.
+		if bundle != nil && bundle.localSites != nil {
+			_, stillRouted := bundle.localSites[centralID]
+			observed.Final = !stillRouted && counter.pendingRequest.Load() == 0
+		}
+		if observed.Final {
+			pending.final[centralID] = true
+		}
 		if cacheErr == nil {
 			observed.CacheSizeBytes = cacheSizes[centralID]
 			observed.CacheSizeValid = true
@@ -909,6 +934,13 @@ func (runtime *edgeAgentRuntime) commitSiteStatsWithACK(pending edgeSiteStatsPen
 		reported[siteID] = runtime.siteReported[siteID]
 	}
 	runtime.mu.Unlock()
+	finalAcked := make(map[int64]bool)
+	for siteID := range pending.final {
+		if acknowledged[siteID] {
+			finalAcked[siteID] = true
+		}
+	}
+	runtime.gcRetiredTrafficCounters(finalAcked)
 	// Move the ACK watermark into the live instances immediately. Otherwise a
 	// successful report would remain part of the local delta until the next
 	// config refresh and could be charged twice against a quota.
@@ -935,6 +967,36 @@ func (runtime *edgeAgentRuntime) commitSiteStatsWithACK(pending edgeSiteStatsPen
 			inst.trafficAckedCumulativeOut = stat.CumulativeBytesOut
 			inst.trafficMu.Unlock()
 		}
+	}
+}
+
+// gcRetiredTrafficCounters releases process-stable counters only after the
+// Controller ACKed their final snapshot and no request remains admitted.
+func (runtime *edgeAgentRuntime) gcRetiredTrafficCounters(finalAcked map[int64]bool) {
+	if runtime == nil {
+		return
+	}
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	for siteID, counter := range runtime.trafficCounters {
+		if !finalAcked[siteID] {
+			continue
+		}
+		if counter == nil || counter.pendingRequest.Load() != 0 {
+			continue
+		}
+		if runtime.bundle != nil {
+			if _, ok := runtime.bundle.localSites[siteID]; ok {
+				continue
+			}
+		}
+		reported, ok := runtime.siteReported[siteID]
+		if !ok || reported.CumulativeBytesIn != counter.cumulativeIn.Load() || reported.CumulativeBytesOut != counter.cumulativeOut.Load() || reported.Requests != counter.requests.Load() {
+			continue
+		}
+		delete(runtime.trafficCounters, siteID)
+		delete(runtime.trafficHosts, siteID)
+		delete(runtime.siteReported, siteID)
 	}
 }
 
@@ -1331,19 +1393,23 @@ func (runtime *edgeAgentRuntime) getCertificate(*tls.ClientHelloInfo) (*tls.Cert
 	return certificate, nil
 }
 
-func (runtime *edgeAgentRuntime) stopServer() {
+func (runtime *edgeAgentRuntime) stopServer(force ...bool) {
 	runtime.mu.Lock()
 	server := runtime.server
 	runtime.server = nil
 	runtime.mu.Unlock()
 	if server != nil {
+		forceClose := true
+		if len(force) > 0 {
+			forceClose = force[0]
+		}
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		shutdownErr := server.Shutdown(ctx)
 		cancel()
 		// Shutdown closes the listener promptly, but may leave active handlers
 		// alive until the grace period expires. Close is idempotent and ensures a
 		// failed config transaction can never leave a listener bound to a port.
-		if shutdownErr != nil {
+		if shutdownErr != nil && forceClose {
 			_ = server.Close()
 		}
 	}
@@ -1468,7 +1534,9 @@ func (runtime *edgeAgentRuntime) apply(config AgentRuntimeConfig) (retErr error)
 	needsListener := len(config.Routes) > 0
 	listenerChanged := oldState.port != config.HTTPSPort || (oldState.server == nil) != !needsListener
 	if listenerChanged {
-		runtime.stopServer()
+		// Closing the listener stops new connections, while a non-forcing
+		// shutdown leaves already admitted playback/WebSocket handlers alive.
+		runtime.stopServer(false)
 	}
 	runtime.mu.Lock()
 	runtime.nodeGUID = config.NodeGUID
@@ -1517,6 +1585,21 @@ func (runtime *edgeAgentRuntime) apply(config AgentRuntimeConfig) (retErr error)
 	runtime.listenerError = ""
 	runtime.mu.Unlock()
 	if oldState.bundle != nil {
+		if len(config.ForceStopSiteIDs) > 0 {
+			forced := make(map[int64]struct{}, len(config.ForceStopSiteIDs))
+			for _, centralID := range config.ForceStopSiteIDs {
+				for localID, identity := range oldState.bundle.localSites {
+					if identity.centralID == centralID {
+						forced[localID] = struct{}{}
+					}
+				}
+			}
+			if len(forced) > 0 {
+				forceCtx, forceCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				oldState.bundle.manager.ForceStopSites(forceCtx, forced)
+				forceCancel()
+			}
+		}
 		// Hot config changes are not a security revocation. Existing playback and
 		// WebSocket streams finish naturally; close() cancels them on shutdown.
 		runtime.beginBundleDrain(oldState.bundle)
@@ -1630,7 +1713,10 @@ func edgeSaveState(path string, state edgeAgentState) error {
 	if err := temporary.Close(); err != nil {
 		return err
 	}
-	return os.Rename(name, path)
+	if err := os.Rename(name, path); err != nil {
+		return err
+	}
+	return syncDirectory(filepath.Dir(path))
 }
 
 type edgeAPIError struct {

--- a/node_repository.go
+++ b/node_repository.go
@@ -187,6 +187,9 @@ type NodeSiteStat struct {
 	// zero-byte cache. Older Agents omit the field and therefore never erase a
 	// previously known Controller value by reporting an unknown size.
 	CacheSizeValid bool `json:"cache_size_valid,omitempty"`
+	// Final marks the last snapshot for a route removed from an Agent bundle.
+	// The Controller retires only that node's drain generation after accepting it.
+	Final bool `json:"final,omitempty"`
 }
 
 type NodeMediaCount struct {
@@ -254,6 +257,7 @@ const maxNodeRequestEventResponseBodyBytes = 64 << 10
 const maxAgentReportBodyBytes = 2 << 20
 const maxNodeRequestEventsPerReport = 128
 const maxNodeTelemetryItemsPerReport = 128
+const maxNodeSiteStatsPerReport = 512
 
 func newNodeToken() (string, error) {
 	value := make([]byte, 32)
@@ -1043,8 +1047,9 @@ func validateNodeRequestEvent(event NodeRequestEvent) error {
 }
 
 type authorizedNodeSite struct {
-	ID         int64
-	PublicHost string
+	ID          int64
+	PublicHost  string
+	HostAliases map[string]struct{}
 }
 
 // authorizedNodeSitesTx is the single source of truth for report-side site
@@ -1056,11 +1061,10 @@ func authorizedNodeSitesTx(tx *sql.Tx, nodeID, nowMS int64) (map[int64]authorize
 		SELECT s.id, LOWER(TRIM(s.public_host))
 		FROM site_node_schedules n
 		JOIN sites s ON s.id=n.site_id
-		LEFT JOIN site_node_drains d ON d.site_id=n.site_id
 		WHERE n.enabled=1
 		  AND s.enabled=1
-		  AND (n.desired_node_id=? OR n.applied_node_id=? OR (d.node_id=? AND d.expires_at_ms>?))
-	`, nodeID, nodeID, nodeID, nowMS)
+		  AND (n.desired_node_id=? OR n.applied_node_id=?)
+	`, nodeID, nodeID)
 	if err != nil {
 		return nil, err
 	}
@@ -1071,9 +1075,76 @@ func authorizedNodeSitesTx(tx *sql.Tx, nodeID, nowMS int64) (map[int64]authorize
 		if err := rows.Scan(&site.ID, &site.PublicHost); err != nil {
 			return nil, err
 		}
+		site.HostAliases = map[string]struct{}{site.PublicHost: {}}
 		result[site.ID] = site
 	}
-	return result, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	// Public-host renames do not create DNS drain rows. Keep old hosts as
+	// bounded aliases so events buffered by an Agent remain valid for the same
+	// site without widening authorization to another site.
+	aliasRows, err := tx.Query(`SELECT site_id, LOWER(TRIM(public_host))
+		FROM site_node_host_aliases
+		WHERE node_id=? AND expires_at_ms>?`, nodeID, nowMS)
+	if err != nil {
+		return nil, err
+	}
+	for aliasRows.Next() {
+		var siteID int64
+		var host string
+		if err := aliasRows.Scan(&siteID, &host); err != nil {
+			return nil, err
+		}
+		if host == "" {
+			continue
+		}
+		if site, ok := result[siteID]; ok {
+			if site.HostAliases == nil {
+				site.HostAliases = make(map[string]struct{})
+			}
+			site.HostAliases[host] = struct{}{}
+			result[siteID] = site
+		}
+	}
+	if err := aliasRows.Err(); err != nil {
+		aliasRows.Close()
+		return nil, err
+	}
+	if err := aliasRows.Close(); err != nil {
+		return nil, err
+	}
+	// A site may have multiple in-flight drain generations. Keep each former
+	// host as an alias so late events from an admitted old bundle remain valid.
+	drainRows, err := tx.Query(`SELECT d.site_id, LOWER(TRIM(d.public_host))
+		FROM site_node_drains d JOIN sites s ON s.id=d.site_id
+		WHERE d.node_id=? AND d.expires_at_ms>? AND s.enabled=1`, nodeID, nowMS)
+	if err != nil {
+		return nil, err
+	}
+	defer drainRows.Close()
+	for drainRows.Next() {
+		var siteID int64
+		var host string
+		if err := drainRows.Scan(&siteID, &host); err != nil {
+			return nil, err
+		}
+		if site, ok := result[siteID]; ok {
+			if site.HostAliases == nil {
+				site.HostAliases = make(map[string]struct{})
+			}
+			if host != "" {
+				site.HostAliases[host] = struct{}{}
+			}
+			result[siteID] = site
+		} else {
+			var currentHost string
+			if err := tx.QueryRow("SELECT LOWER(TRIM(public_host)) FROM sites WHERE id=? AND enabled=1", siteID).Scan(&currentHost); err == nil {
+				result[siteID] = authorizedNodeSite{ID: siteID, PublicHost: currentHost, HostAliases: map[string]struct{}{host: {}}}
+			}
+		}
+	}
+	return result, drainRows.Err()
 }
 
 func authorizedNodeSiteHost(sites map[int64]authorizedNodeSite, siteID int64, host string) bool {
@@ -1082,7 +1153,18 @@ func authorizedNodeSiteHost(sites map[int64]authorizedNodeSite, siteID int64, ho
 		return false
 	}
 	normalized := requestPublicHost(strings.TrimSpace(host))
-	return normalized != "" && strings.EqualFold(normalized, site.PublicHost)
+	if normalized == "" {
+		return false
+	}
+	if strings.EqualFold(normalized, site.PublicHost) {
+		return true
+	}
+	for alias := range site.HostAliases {
+		if strings.EqualFold(normalized, alias) {
+			return true
+		}
+	}
+	return false
 }
 
 // authorizedNodeSiteForStat accepts legacy Host-only reports but requires the
@@ -1276,6 +1358,9 @@ func recordNodeSiteTrafficTx(tx *sql.Tx, nodeID int64, counterEpoch string, stat
 			cacheSize = stat.CacheSizeBytes
 		}
 		_, err = tx.Exec(`INSERT INTO node_site_counters(node_id,site_id,boot_id,last_bytes_in,last_bytes_out,last_request_count,cache_size_bytes,updated_at_ms) VALUES(?,?,?,?,?,?,?,?)`, nodeID, siteID, counterEpoch, currentIn, currentOut, stat.RequestCount, cacheSize, nowMS)
+		if err == nil && stat.Final {
+			_, err = tx.Exec("DELETE FROM site_node_drains WHERE site_id=? AND node_id=?", siteID, nodeID)
+		}
 		return err
 	}
 	if err != nil {
@@ -1320,7 +1405,15 @@ func recordNodeSiteTrafficTx(tx *sql.Tx, nodeID int64, counterEpoch string, stat
 		cacheSize = stat.CacheSizeBytes
 	}
 	_, err = tx.Exec(`UPDATE node_site_counters SET boot_id=?,last_bytes_in=?,last_bytes_out=?,last_request_count=?,cache_size_bytes=?,updated_at_ms=? WHERE node_id=? AND site_id=?`, counterEpoch, currentIn, currentOut, stat.RequestCount, cacheSize, nowMS, nodeID, siteID)
-	return err
+	if err != nil {
+		return err
+	}
+	if stat.Final {
+		if _, err := tx.Exec("DELETE FROM site_node_drains WHERE site_id=? AND node_id=?", siteID, nodeID); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type nodeReportCommitResult struct {
@@ -1524,6 +1617,11 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 	} else if appliedHash != "" && appliedHash == desiredHash {
 		if _, err := tx.Exec(`UPDATE site_node_schedules SET config_pending_since_ms=0,updated_at_ms=?
 			WHERE enabled=1 AND desired_node_id=? AND config_hash=? AND config_pending_since_ms>0`, now.UnixMilli(), id, appliedHash); err != nil {
+			return nodeReportCommitResult{}, err
+		}
+	}
+	if clearAppliedConfig {
+		if _, err := tx.Exec("DELETE FROM agent_route_revocations WHERE node_id=?", id); err != nil {
 			return nodeReportCommitResult{}, err
 		}
 	}

--- a/node_repository_test.go
+++ b/node_repository_test.go
@@ -373,6 +373,45 @@ func TestBrokenProbeSecretCanBeRotatedWithStableJWT(t *testing.T) {
 	}
 }
 
+func TestAuthorizedNodeSiteAcceptsBufferedHostAfterRename(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now()
+	node, _, err := app.db.CreateControlNode(NodeCreateInput{Name: "alias-node", Address: "203.0.113.90"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "alias-site", PublicHost: "old.alias.example", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:8096"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.SaveSiteNodeSchedule(site.ID, true, "fixed", node.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec("UPDATE site_node_schedules SET desired_node_id=?, applied_node_id=? WHERE site_id=?", node.ID, node.ID, site.ID); err != nil {
+		t.Fatal(err)
+	}
+	updated := *site
+	updated.PublicHost = "new.alias.example"
+	if err := app.db.UpdateSiteRecord(updated); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := app.db.db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	allowed, err := authorizedNodeSitesTx(tx, node.ID, time.Now().UnixMilli())
+	_ = tx.Rollback()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !authorizedNodeSiteHost(allowed, site.ID, "new.alias.example") || !authorizedNodeSiteHost(allowed, site.ID, "old.alias.example") {
+		t.Fatalf("authorized hosts after rename = %#v", allowed[site.ID])
+	}
+	if authorizedNodeSiteHost(allowed, site.ID, "other.alias.example") {
+		t.Fatal("unrelated host was authorized")
+	}
+}
+
 func TestRefreshNodeEnrollmentPreservesRuntimeStateAndTrafficBaseline(t *testing.T) {
 	app := newTestApp(t)
 	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)

--- a/panel_acme.go
+++ b/panel_acme.go
@@ -1597,7 +1597,10 @@ func writePrivateFileAtomic(filename string, data []byte) error {
 			return err
 		}
 	}
-	return os.Rename(tmpName, filename) // #nosec G703 G304 -- both paths are generated within the private TLS directory.
+	if err := os.Rename(tmpName, filename); err != nil { // #nosec G703 G304 -- both paths are generated within the private TLS directory.
+		return err
+	}
+	return syncDirectory(filepath.Dir(filename))
 }
 
 func fulfillCloudflareDNSAuthorization(ctx context.Context, acmeClient *acme.Client, cf *cloudflareClient, authorizationURL, routeDomain string) error {

--- a/proxy_lifecycle.go
+++ b/proxy_lifecycle.go
@@ -55,6 +55,38 @@ func (pm *ProxyManager) StopSite(id int64) error {
 	return nil
 }
 
+// ForceStopSites closes only the explicitly revoked controller sites. It is
+// used for administrative disable/delete and credential revocation; ordinary
+// config migration uses DrainShutdown so admitted playback can finish.
+func (pm *ProxyManager) ForceStopSites(ctx context.Context, siteIDs map[int64]struct{}) {
+	if pm == nil || len(siteIDs) == 0 {
+		return
+	}
+	pm.lifecycleMu.Lock()
+	defer pm.lifecycleMu.Unlock()
+	pm.mu.RLock()
+	targets := make(map[int64]*ProxyInstance)
+	for localID, inst := range pm.proxies {
+		if inst != nil {
+			if _, ok := siteIDs[inst.Site.ID]; ok {
+				targets[localID] = inst
+			}
+		}
+	}
+	pm.mu.RUnlock()
+	for localID, inst := range targets {
+		if err := inst.shutdown(ctx); err != nil {
+			log.Printf("[%s] forced stop failed: %v", inst.Site.Name, err)
+			continue
+		}
+		pm.mu.Lock()
+		if pm.proxies[localID] == inst {
+			delete(pm.proxies, localID)
+		}
+		pm.mu.Unlock()
+	}
+}
+
 func (pm *ProxyManager) IsRunning(id int64) bool {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()

--- a/request_logs.go
+++ b/request_logs.go
@@ -436,6 +436,16 @@ func pruneRequestLogsTx(tx *sql.Tx, now time.Time, retention time.Duration) erro
 	if _, err := tx.Exec("DELETE FROM request_logs WHERE recorded_at_ms<?", cutoffMS); err != nil {
 		return err
 	}
+	if retention < 24*time.Hour {
+		retention = 24 * time.Hour
+	}
+	// The event ledger is only a replay/deduplication window. Keep pending
+	// (processed_at_ms=0) rows forever, but retire acknowledged identities after
+	// the request-log retention plus one extra day so an offline Agent can replay
+	// safely without allowing the table to grow without bound.
+	if _, err := tx.Exec(`DELETE FROM node_request_events WHERE processed_at_ms>0 AND received_at_ms<?`, now.Add(-retention-24*time.Hour).UnixMilli()); err != nil {
+		return err
+	}
 	_, err := tx.Exec(`
 		DELETE FROM request_logs
 		WHERE id IN (

--- a/site_node_scheduler.go
+++ b/site_node_scheduler.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -26,11 +27,11 @@ import (
 
 const (
 	agentConfigSchemaVersion = 1
-	// siteNodeDrainWindow gives an already-admitted stream several report
-	// intervals to finish and publish its final cumulative counters after DNS
-	// points at the replacement node. New requests are prevented by the new
-	// Agent configuration; this is telemetry authorization only.
-	siteNodeDrainWindow = 2 * time.Minute
+	// siteNodeDrainWindow is an emergency upper bound only. Normal drains are
+	// retired by a final SiteStats snapshot (NodeSiteStat.Final) and its ACK;
+	// the long TTL prevents a long-lived playback from losing billable traffic
+	// while still bounding stale authorization after an Agent disappears.
+	siteNodeDrainWindow = 24 * time.Hour
 )
 
 type SiteNodeSchedule struct {
@@ -100,6 +101,7 @@ type AgentRuntimeConfig struct {
 	AgentSHA256          string           `json:"agent_sha256,omitempty"`
 	AgentDownloadURL     string           `json:"agent_download_url,omitempty"`
 	CacheClearGeneration int64            `json:"cache_clear_generation,omitempty"`
+	ForceStopSiteIDs     []int64          `json:"force_stop_site_ids,omitempty"`
 	Routes               []AgentSiteRoute `json:"routes"`
 }
 
@@ -542,6 +544,7 @@ type agentRuntimeConfigHash struct {
 	AgentSHA256          string               `json:"agent_sha256,omitempty"`
 	AgentDownloadURL     string               `json:"agent_download_url,omitempty"`
 	CacheClearGeneration int64                `json:"cache_clear_generation,omitempty"`
+	ForceStopSiteIDs     []int64              `json:"force_stop_site_ids,omitempty"`
 	Routes               []agentSiteRouteHash `json:"routes"`
 }
 
@@ -552,8 +555,11 @@ func agentConfigHashPayload(config AgentRuntimeConfig, legacy bool) agentRuntime
 		config.AgentSHA256 = ""
 	}
 	config.AgentDownloadURL = ""
+	config.ForceStopSiteIDs = append([]int64(nil), config.ForceStopSiteIDs...)
+	sort.Slice(config.ForceStopSiteIDs, func(i, j int) bool { return config.ForceStopSiteIDs[i] < config.ForceStopSiteIDs[j] })
 	if legacy {
 		config.CacheClearGeneration = 0
+		config.ForceStopSiteIDs = nil
 		// ProbeSecret was added after the legacy Agent contract. Older Agents
 		// ignore the field, so omit it from the compatibility hash while current
 		// Agents use the runtime hash above and authenticate their health probes.
@@ -600,6 +606,7 @@ func agentConfigHashPayload(config AgentRuntimeConfig, legacy bool) agentRuntime
 		AgentSHA256:          config.AgentSHA256,
 		AgentDownloadURL:     config.AgentDownloadURL,
 		CacheClearGeneration: config.CacheClearGeneration,
+		ForceStopSiteIDs:     config.ForceStopSiteIDs,
 		Routes:               routes,
 	}
 }
@@ -871,6 +878,23 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 	config := AgentRuntimeConfig{SchemaVersion: agentConfigSchemaVersion, ConfigRevision: node.ConfigRevision, NodeGUID: node.GUID, EntryMode: "direct",
 		HTTPPort: 0, HTTPSPort: node.Port, DynamicKey: encodeRuntimeKey(dynamicKey), ProbeSecret: probeSecretText,
 		CacheClearGeneration: node.CacheClearGeneration, Routes: routes}
+	forceRows, forceErr := tx.Query("SELECT site_id FROM agent_route_revocations WHERE node_id=? ORDER BY site_id", node.ID)
+	if forceErr != nil {
+		return AgentRuntimeConfig{}, forceErr
+	}
+	for forceRows.Next() {
+		var siteID int64
+		if err := forceRows.Scan(&siteID); err != nil {
+			_ = forceRows.Close()
+			return AgentRuntimeConfig{}, err
+		}
+		if siteID > 0 {
+			config.ForceStopSiteIDs = append(config.ForceStopSiteIDs, siteID)
+		}
+	}
+	if err := forceRows.Close(); err != nil {
+		return AgentRuntimeConfig{}, err
+	}
 	if len(routes) > 0 {
 		if a.panelCertificates == nil {
 			return AgentRuntimeConfig{}, errors.New("edge TLS certificate is unavailable")
@@ -1306,9 +1330,9 @@ func (a *App) reconcileOneSiteSchedule(ctx context.Context, schedule SiteNodeSch
 	defer tx.Rollback()
 	if schedule.AppliedNodeID != node.ID {
 		if schedule.AppliedNodeID > 0 {
-			if _, err = tx.Exec(`INSERT INTO site_node_drains(site_id,node_id,expires_at_ms,created_at_ms) VALUES(?,?,?,?)
-				ON CONFLICT(site_id) DO UPDATE SET node_id=excluded.node_id,expires_at_ms=excluded.expires_at_ms,created_at_ms=excluded.created_at_ms`,
-				schedule.SiteID, schedule.AppliedNodeID, now.Add(siteNodeDrainWindow).UnixMilli(), now.UnixMilli()); err != nil {
+			if _, err = tx.Exec(`INSERT INTO site_node_drains(site_id,node_id,public_host,expires_at_ms,created_at_ms) VALUES(?,?,?,?,?)
+				ON CONFLICT(site_id,node_id) DO UPDATE SET public_host=excluded.public_host,expires_at_ms=excluded.expires_at_ms,created_at_ms=excluded.created_at_ms`,
+				schedule.SiteID, schedule.AppliedNodeID, strings.ToLower(strings.TrimSpace(schedule.PublicHost)), now.Add(siteNodeDrainWindow).UnixMilli(), now.UnixMilli()); err != nil {
 				return err
 			}
 		}
@@ -1331,6 +1355,9 @@ func (a *App) reconcileSiteNodeScheduling(ctx context.Context) {
 	now := time.Now()
 	if _, err := a.db.db.Exec("DELETE FROM site_node_drains WHERE expires_at_ms<=?", now.UnixMilli()); err != nil {
 		log.Printf("[node-scheduler] expire node drains: %v", err)
+	}
+	if _, err := a.db.db.Exec("DELETE FROM site_node_host_aliases WHERE expires_at_ms<=?", now.UnixMilli()); err != nil {
+		log.Printf("[node-scheduler] expire site host aliases: %v", err)
 	}
 	if err := a.db.retryNodeTLSCleanup(""); err != nil {
 		log.Printf("[node-scheduler] managed Edge TLS cleanup retry failed: %v", err)
@@ -1416,6 +1443,13 @@ func (a *App) removeSiteNodeSchedule(ctx context.Context, siteID int64) error {
 		return err
 	}
 	defer tx.Rollback()
+	for _, nodeID := range []int64{value.FixedNodeID, value.DesiredNodeID, value.AppliedNodeID} {
+		if nodeID > 0 {
+			if _, err := tx.Exec("INSERT OR IGNORE INTO agent_route_revocations(node_id,site_id,created_at_ms) VALUES(?,?,?)", nodeID, siteID, time.Now().UnixMilli()); err != nil {
+				return err
+			}
+		}
+	}
 	if err := markAgentConfigsDirtyForNodeIDsTx(tx, value.FixedNodeID, value.DesiredNodeID, value.AppliedNodeID); err != nil {
 		return err
 	}
@@ -1483,6 +1517,13 @@ func (a *App) prepareNodeDeletion(ctx context.Context, nodeID int64) error {
 	}
 	defer tx.Rollback()
 	for _, value := range affected {
+		for _, nodeID := range []int64{value.FixedNodeID, value.DesiredNodeID, value.AppliedNodeID} {
+			if nodeID > 0 {
+				if _, err := tx.Exec("INSERT OR IGNORE INTO agent_route_revocations(node_id,site_id,created_at_ms) VALUES(?,?,?)", nodeID, value.SiteID, time.Now().UnixMilli()); err != nil {
+					return err
+				}
+			}
+		}
 		if err := markAgentConfigsDirtyForNodeIDsTx(tx, value.FixedNodeID, value.DesiredNodeID, value.AppliedNodeID); err != nil {
 			return err
 		}

--- a/site_repository.go
+++ b/site_repository.go
@@ -558,8 +558,8 @@ func (d *DB) updateSiteRecord(site Site, restoreRevision bool) error {
 		return err
 	}
 	defer tx.Rollback()
-	var currentTargetURL, currentHeaders string
-	queryErr := tx.QueryRow("SELECT target_url, upstream_headers FROM sites WHERE id=?", site.ID).Scan(&currentTargetURL, &currentHeaders)
+	var currentTargetURL, currentHeaders, currentPublicHost string
+	queryErr := tx.QueryRow("SELECT target_url, upstream_headers, public_host FROM sites WHERE id=?", site.ID).Scan(&currentTargetURL, &currentHeaders, &currentPublicHost)
 	if queryErr != nil && !errors.Is(queryErr, sql.ErrNoRows) {
 		return queryErr
 	}
@@ -578,6 +578,51 @@ func (d *DB) updateSiteRecord(site Site, restoreRevision bool) error {
 			// encrypted v2 values for the new authority; unchanged ciphertext is
 			// always cleared here, even if a caller bypasses the handler checks.
 			site.StoredUpstreamHeaders = "[]"
+		}
+	}
+	// Keep the former public host as a short-lived alias for nodes that may
+	// still have buffered events from the previous Agent route. This is
+	// site-specific authorization state; the old host is never accepted for a
+	// different site and the alias expires automatically.
+	oldHost := strings.ToLower(strings.TrimSpace(currentPublicHost))
+	newHost := strings.ToLower(strings.TrimSpace(site.PublicHost))
+	if oldHost != "" && oldHost != newHost {
+		aliasRows, aliasErr := tx.Query(`SELECT desired_node_id, applied_node_id
+			FROM site_node_schedules WHERE site_id=?`, site.ID)
+		if aliasErr != nil {
+			return aliasErr
+		}
+		var nodeIDs []int64
+		for aliasRows.Next() {
+			var desiredID, appliedID sql.NullInt64
+			if scanErr := aliasRows.Scan(&desiredID, &appliedID); scanErr != nil {
+				aliasRows.Close()
+				return scanErr
+			}
+			for _, value := range []sql.NullInt64{desiredID, appliedID} {
+				if !value.Valid || value.Int64 <= 0 {
+					continue
+				}
+				nodeIDs = append(nodeIDs, value.Int64)
+			}
+		}
+		if rowsErr := aliasRows.Err(); rowsErr != nil {
+			aliasRows.Close()
+			return rowsErr
+		}
+		aliasRows.Close()
+		nowAlias := time.Now()
+		seenNodes := make(map[int64]struct{})
+		for _, nodeID := range nodeIDs {
+			if _, seen := seenNodes[nodeID]; seen {
+				continue
+			}
+			seenNodes[nodeID] = struct{}{}
+			if _, execErr := tx.Exec(`INSERT INTO site_node_host_aliases(site_id,node_id,public_host,expires_at_ms,created_at_ms)
+				VALUES(?,?,?,?,?) ON CONFLICT(site_id,node_id,public_host) DO UPDATE SET expires_at_ms=excluded.expires_at_ms,created_at_ms=excluded.created_at_ms`,
+				site.ID, nodeID, oldHost, nowAlias.Add(siteNodeDrainWindow).UnixMilli(), nowAlias.UnixMilli()); execErr != nil {
+				return execErr
+			}
 		}
 	}
 	dynamicEnabled := sqliteBool(site.DynamicDiscoveryEnabled)
@@ -696,6 +741,10 @@ func (d *DB) SetSiteEnabled(id int64, enabled bool) error {
 		return err
 	}
 	defer tx.Rollback()
+	var fixedNodeID, desiredNodeID, appliedNodeID sql.NullInt64
+	if err := tx.QueryRow("SELECT fixed_node_id,desired_node_id,applied_node_id FROM site_node_schedules WHERE site_id=?", id).Scan(&fixedNodeID, &desiredNodeID, &appliedNodeID); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
 	result, err := tx.Exec("UPDATE sites SET enabled=?, updated_at=CURRENT_TIMESTAMP WHERE id=?", value, id)
 	if err != nil {
 		return err
@@ -714,6 +763,20 @@ func (d *DB) SetSiteEnabled(id int64, enabled bool) error {
 			updated_at_ms=?
 		WHERE site_id=?`, value, nowMS, nowMS, id); err != nil {
 		return err
+	}
+	if enabled {
+		if _, err := tx.Exec("DELETE FROM agent_route_revocations WHERE site_id=?", id); err != nil {
+			return err
+		}
+	} else {
+		for _, value := range []sql.NullInt64{fixedNodeID, desiredNodeID, appliedNodeID} {
+			if !value.Valid || value.Int64 <= 0 {
+				continue
+			}
+			if _, err := tx.Exec("INSERT OR IGNORE INTO agent_route_revocations(node_id,site_id,created_at_ms) VALUES(?,?,?)", value.Int64, id, time.Now().UnixMilli()); err != nil {
+				return err
+			}
+		}
 	}
 	if err := markAgentConfigsDirtyForSiteTx(tx, id); err != nil {
 		return err


### PR DESCRIPTION
## Summary
- preserve admitted streams during Agent listener/config replacement while adding explicit force-stop revocations for disabled or deleted routes
- add final SiteStats ACK retirement, bounded telemetry counter cleanup, per-site/node drain records, and request-event retention
- preserve buffered telemetry across public-host renames and fsync critical atomic state updates

## Validation
- `go test ./... -count=1`
- `go vet ./...`
- `govulncheck ./...`
- `gosec -quiet -severity medium -confidence medium ./...`
- frontend Node syntax checks and `node --test tests/*.test.js`