### PR TITLE
fix: harden agent report lifecycle and route authorization

### DIFF
--- a/database_migrations.go
+++ b/database_migrations.go
@@ -20,7 +20,7 @@ const (
 	// databaseSchemaVersion is independent from the application and backup
 	// format versions. It is persisted in SQLite so restores can reject a
 	// database whose columns/state are newer than this binary understands.
-	databaseSchemaVersion = 42
+	databaseSchemaVersion = 43
 )
 
 func (d *DB) migrate() error {
@@ -476,7 +476,10 @@ func (d *DB) migrateOnce() error {
 	);
 	CREATE TABLE IF NOT EXISTS agent_route_revocations (
 		node_id INTEGER NOT NULL REFERENCES control_nodes(id) ON DELETE CASCADE,
-		site_id INTEGER NOT NULL REFERENCES sites(id) ON DELETE CASCADE,
+		-- Deliberately no sites foreign key: a revocation is a durable
+		-- force-stop tombstone and must survive the site row being deleted.
+		site_id INTEGER NOT NULL,
+		public_host TEXT NOT NULL DEFAULT '',
 		created_at_ms INTEGER NOT NULL,
 		PRIMARY KEY(node_id,site_id)
 	) WITHOUT ROWID;
@@ -844,6 +847,9 @@ func (d *DB) migrateOnce() error {
 		return err
 	}
 	if err := ensureSiteNodeDrainsSchema(ctx, conn); err != nil {
+		return err
+	}
+	if err := ensureAgentRouteRevocationsSchema(ctx, conn); err != nil {
 		return err
 	}
 	var eventUIDColumnCount int
@@ -1224,6 +1230,83 @@ func ensureSiteNodeDrainsSchema(ctx context.Context, conn *sql.Conn) error {
 		CREATE INDEX IF NOT EXISTS idx_site_node_drains_node_expiry ON site_node_drains(node_id,expires_at_ms);
 	`); err != nil {
 		return fmt.Errorf("migrate site node drain ledger: %w", err)
+	}
+	return nil
+}
+
+// ensureAgentRouteRevocationsSchema keeps force-stop tombstones independent
+// from the sites table. Deleting a site must not cascade away the marker before
+// the next Agent config fetch can stop an old generation.
+func ensureAgentRouteRevocationsSchema(ctx context.Context, conn *sql.Conn) error {
+	rows, err := conn.QueryContext(ctx, "PRAGMA table_info('agent_route_revocations')")
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	columns := make(map[string]bool)
+	for rows.Next() {
+		var cid, notNull, pk int
+		var name, columnType string
+		var defaultValue any
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &pk); err != nil {
+			return err
+		}
+		columns[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if !columns["node_id"] || !columns["site_id"] {
+		return errors.New("agent_route_revocations table has an invalid schema")
+	}
+	if !columns["public_host"] {
+		if _, err := conn.ExecContext(ctx, "ALTER TABLE agent_route_revocations ADD COLUMN public_host TEXT NOT NULL DEFAULT ''"); err != nil {
+			return err
+		}
+	}
+	// Existing releases declared a sites foreign key. Rebuild the table when
+	// that legacy definition is present; SQLite has no ALTER TABLE DROP FK.
+	fkRows, err := conn.QueryContext(ctx, "PRAGMA foreign_key_list('agent_route_revocations')")
+	if err != nil {
+		return err
+	}
+	hasSitesFK := false
+	for fkRows.Next() {
+		var id, seq int
+		var table, from, to, onUpdate, onDelete, match string
+		if err := fkRows.Scan(&id, &seq, &table, &from, &to, &onUpdate, &onDelete, &match); err != nil {
+			fkRows.Close()
+			return err
+		}
+		if strings.EqualFold(table, "sites") {
+			hasSitesFK = true
+		}
+	}
+	if err := fkRows.Err(); err != nil {
+		fkRows.Close()
+		return err
+	}
+	if err := fkRows.Close(); err != nil {
+		return err
+	}
+	if !hasSitesFK {
+		return nil
+	}
+	if _, err := conn.ExecContext(ctx, `
+		CREATE TABLE agent_route_revocations_new (
+			node_id INTEGER NOT NULL REFERENCES control_nodes(id) ON DELETE CASCADE,
+			site_id INTEGER NOT NULL,
+			public_host TEXT NOT NULL DEFAULT '',
+			created_at_ms INTEGER NOT NULL,
+			PRIMARY KEY(node_id,site_id)
+		) WITHOUT ROWID;
+		INSERT OR REPLACE INTO agent_route_revocations_new(node_id,site_id,public_host,created_at_ms)
+			SELECT r.node_id,r.site_id,LOWER(TRIM(COALESCE(r.public_host,s.public_host,''))),r.created_at_ms
+			FROM agent_route_revocations r LEFT JOIN sites s ON s.id=r.site_id;
+		DROP TABLE agent_route_revocations;
+		ALTER TABLE agent_route_revocations_new RENAME TO agent_route_revocations;
+	`); err != nil {
+		return fmt.Errorf("migrate agent route revocations: %w", err)
 	}
 	return nil
 }

--- a/edge_agent.go
+++ b/edge_agent.go
@@ -471,6 +471,10 @@ type edgeProxyBundle struct {
 	manager    *ProxyManager
 	handler    http.Handler
 	localSites map[int64]edgeSiteIdentity
+	// centralSites is keyed by the stable Controller SiteID. localSites is
+	// intentionally keyed by the ephemeral in-memory SQLite ID and must never
+	// be used for lifecycle checks against Controller IDs.
+	centralSites map[int64]struct{}
 }
 
 func (b *edgeProxyBundle) close() {
@@ -514,6 +518,10 @@ type edgeAgentRuntime struct {
 	appliedHash          string
 	appliedRevision      int64
 	siteCounterEpoch     uint64
+	siteCounterEpochs    map[int64]uint64
+	siteStatsCursor      int64
+	mediaCursor          int64
+	retentionCursor      int64
 	cacheClearGeneration int64
 	listenerError        string
 	applyError           string
@@ -538,8 +546,8 @@ type edgeAgentRuntime struct {
 }
 
 // beginBundleDrain rejects new work on an old generation but gives streams
-// admitted before a hot apply an unbounded lifetime. Runtime shutdown/revoke
-// cancels this context and therefore remains an immediate security boundary.
+// admitted before a hot apply time to finish. Runtime shutdown/revoke cancels
+// this context and therefore remains an immediate security boundary.
 func (runtime *edgeAgentRuntime) beginBundleDrain(bundle *edgeProxyBundle) {
 	if runtime == nil || bundle == nil {
 		return
@@ -552,14 +560,65 @@ func (runtime *edgeAgentRuntime) beginBundleDrain(bundle *edgeProxyBundle) {
 		runtime.drainingBundles = make(map[*edgeProxyBundle]struct{})
 	}
 	runtime.drainingBundles[bundle] = struct{}{}
-	ctx := runtime.drainContext
+	parent := runtime.drainContext
 	runtime.mu.Unlock()
+	// Normal drains finish when admitted handlers and final counters are
+	// acknowledged. Keep an emergency bound so a wedged handler cannot pin a
+	// complete old generation forever or outlive the Controller drain window.
+	ctx, cancel := context.WithTimeout(parent, siteNodeDrainWindow)
 	go func() {
+		defer cancel()
 		bundle.drain(ctx)
 		runtime.mu.Lock()
 		delete(runtime.drainingBundles, bundle)
 		runtime.mu.Unlock()
 	}()
+}
+
+// forceStopCentralSites applies an explicit revocation to the current bundle
+// and every generation that is still draining. A route can be absent from the
+// current config while an older generation continues to own live streams.
+func (runtime *edgeAgentRuntime) forceStopCentralSites(ctx context.Context, siteIDs []int64, extraBundles ...*edgeProxyBundle) {
+	if runtime == nil || len(siteIDs) == 0 {
+		return
+	}
+	wanted := make(map[int64]struct{}, len(siteIDs))
+	for _, siteID := range siteIDs {
+		if siteID > 0 {
+			wanted[siteID] = struct{}{}
+		}
+	}
+	if len(wanted) == 0 {
+		return
+	}
+	runtime.mu.RLock()
+	bundles := make(map[*edgeProxyBundle]struct{}, len(runtime.drainingBundles)+1)
+	if runtime.bundle != nil {
+		bundles[runtime.bundle] = struct{}{}
+	}
+	for bundle := range runtime.drainingBundles {
+		bundles[bundle] = struct{}{}
+	}
+	for _, bundle := range extraBundles {
+		if bundle != nil {
+			bundles[bundle] = struct{}{}
+		}
+	}
+	runtime.mu.RUnlock()
+	for bundle := range bundles {
+		if bundle == nil || bundle.manager == nil {
+			continue
+		}
+		localIDs := make(map[int64]struct{})
+		for localID, identity := range bundle.localSites {
+			if _, ok := wanted[identity.centralID]; ok {
+				localIDs[localID] = struct{}{}
+			}
+		}
+		if len(localIDs) > 0 {
+			bundle.manager.ForceStopSites(ctx, localIDs)
+		}
+	}
 }
 
 type edgeAgentRuntimeState struct {
@@ -595,7 +654,15 @@ func (runtime *edgeAgentRuntime) trafficCounterFor(siteID int64, hosts ...string
 	if counter := runtime.trafficCounters[siteID]; counter != nil {
 		return counter
 	}
-	counter := &edgeSiteTrafficCounter{}
+	if runtime.siteCounterEpochs == nil {
+		runtime.siteCounterEpochs = make(map[int64]uint64)
+	}
+	epoch := runtime.siteCounterEpochs[siteID] + 1
+	if epoch == 0 {
+		epoch = 1
+	}
+	runtime.siteCounterEpochs[siteID] = epoch
+	counter := &edgeSiteTrafficCounter{epoch: epoch}
 	runtime.trafficCounters[siteID] = counter
 	return counter
 }
@@ -693,9 +760,11 @@ func (runtime *edgeAgentRuntime) recordTelemetry(event edgeTelemetryEvent) {
 }
 
 type edgeTelemetryPending struct {
-	media        []NodeMediaCount
-	retention    []NodeRetentionStatus
-	observations []NodeDynamicObservation
+	media          []NodeMediaCount
+	retention      []NodeRetentionStatus
+	observations   []NodeDynamicObservation
+	mediaOrder     []int64
+	retentionOrder []int64
 }
 
 func (runtime *edgeAgentRuntime) prepareTelemetry() edgeTelemetryPending {
@@ -705,11 +774,29 @@ func (runtime *edgeAgentRuntime) prepareTelemetry() edgeTelemetryPending {
 	runtime.telemetryMu.Lock()
 	defer runtime.telemetryMu.Unlock()
 	pending := edgeTelemetryPending{}
-	for _, value := range runtime.mediaCounts {
-		pending.media = append(pending.media, value)
+	mediaIDs := make([]int64, 0, len(runtime.mediaCounts))
+	for siteID := range runtime.mediaCounts {
+		mediaIDs = append(mediaIDs, siteID)
 	}
-	for _, value := range runtime.retention {
-		pending.retention = append(pending.retention, value)
+	sort.Slice(mediaIDs, func(i, j int) bool { return mediaIDs[i] < mediaIDs[j] })
+	mediaStart := telemetryCursorStart(mediaIDs, runtime.mediaCursor)
+	for offset := 0; offset < len(mediaIDs) && len(pending.media) < maxNodeTelemetryItemsPerReport; offset++ {
+		index := (mediaStart + offset) % len(mediaIDs)
+		siteID := mediaIDs[index]
+		pending.mediaOrder = append(pending.mediaOrder, siteID)
+		pending.media = append(pending.media, runtime.mediaCounts[siteID])
+	}
+	retentionIDs := make([]int64, 0, len(runtime.retention))
+	for siteID := range runtime.retention {
+		retentionIDs = append(retentionIDs, siteID)
+	}
+	sort.Slice(retentionIDs, func(i, j int) bool { return retentionIDs[i] < retentionIDs[j] })
+	retentionStart := telemetryCursorStart(retentionIDs, runtime.retentionCursor)
+	for offset := 0; offset < len(retentionIDs) && len(pending.retention) < maxNodeTelemetryItemsPerReport; offset++ {
+		index := (retentionStart + offset) % len(retentionIDs)
+		siteID := retentionIDs[index]
+		pending.retentionOrder = append(pending.retentionOrder, siteID)
+		pending.retention = append(pending.retention, runtime.retention[siteID])
 	}
 	end := len(runtime.observations)
 	if end > maxNodeTelemetryItemsPerReport {
@@ -717,6 +804,18 @@ func (runtime *edgeAgentRuntime) prepareTelemetry() edgeTelemetryPending {
 	}
 	pending.observations = append([]NodeDynamicObservation(nil), runtime.observations[:end]...)
 	return pending
+}
+
+func telemetryCursorStart(ids []int64, cursor int64) int {
+	if len(ids) == 0 || cursor <= 0 {
+		return 0
+	}
+	for index, siteID := range ids {
+		if siteID >= cursor {
+			return index
+		}
+	}
+	return 0
 }
 
 func acknowledgedSiteIDs(accepted, discarded []int64) map[int64]bool {
@@ -742,6 +841,21 @@ func (runtime *edgeAgentRuntime) commitTelemetryWithACK(pending edgeTelemetryPen
 	}
 	runtime.telemetryMu.Lock()
 	defer runtime.telemetryMu.Unlock()
+	advanceCursor := func(order []int64, acknowledged map[int64]bool) int64 {
+		var next int64
+		for _, siteID := range order {
+			if acknowledged[siteID] {
+				next = siteID + 1
+			}
+		}
+		return next
+	}
+	if next := advanceCursor(pending.mediaOrder, mediaACK); next > 0 {
+		runtime.mediaCursor = next
+	}
+	if next := advanceCursor(pending.retentionOrder, retentionACK); next > 0 {
+		runtime.retentionCursor = next
+	}
 	for _, sent := range pending.media {
 		if mediaACK[sent.SiteID] {
 			if current, ok := runtime.mediaCounts[sent.SiteID]; ok && current == sent {
@@ -794,9 +908,11 @@ func (runtime *edgeAgentRuntime) telemetrySnapshot() (media []NodeMediaCount, re
 }
 
 type edgeSiteStatsPending struct {
-	stats   []NodeSiteStat
-	current map[int64]ProxyRuntimeStat
-	final   map[int64]bool
+	stats      []NodeSiteStat
+	current    map[int64]ProxyRuntimeStat
+	final      map[int64]bool
+	order      []int64
+	nextCursor int64
 }
 
 func (runtime *edgeAgentRuntime) prepareSiteStats() edgeSiteStatsPending {
@@ -806,6 +922,7 @@ func (runtime *edgeAgentRuntime) prepareSiteStats() edgeSiteStatsPending {
 	}
 	runtime.mu.RLock()
 	bundle := runtime.bundle
+	statsCursor := runtime.siteStatsCursor
 	previous := make(map[int64]ProxyRuntimeStat, len(runtime.siteReported))
 	for siteID, value := range runtime.siteReported {
 		previous[siteID] = value
@@ -843,7 +960,9 @@ func (runtime *edgeAgentRuntime) prepareSiteStats() edgeSiteStatsPending {
 		centralIDs = append(centralIDs, centralID)
 	}
 	sort.Slice(centralIDs, func(i, j int) bool { return centralIDs[i] < centralIDs[j] })
-	for _, centralID := range centralIDs {
+	start := telemetryCursorStart(centralIDs, statsCursor)
+	for offset := 0; offset < len(centralIDs); offset++ {
+		centralID := centralIDs[(start+offset)%len(centralIDs)]
 		counter := counters[centralID]
 		if len(pending.stats) >= maxNodeSiteStatsPerReport {
 			break
@@ -879,10 +998,11 @@ func (runtime *edgeAgentRuntime) prepareSiteStats() edgeSiteStatsPending {
 		// A removed route is final only after all requests admitted by the old
 		// bundle have finished. The Controller uses this marker to retire the
 		// corresponding drain generation and ACK the counter before GC.
-		if bundle != nil && bundle.localSites != nil {
-			_, stillRouted := bundle.localSites[centralID]
-			observed.Final = !stillRouted && counter.pendingRequest.Load() == 0
+		if bundle != nil && bundle.centralSites != nil {
+			_, stillRouted := bundle.centralSites[centralID]
+			observed.Final = !stillRouted && counter.activeRequests.Load() == 0
 		}
+		observed.CounterEpoch = counter.epoch
 		if observed.Final {
 			pending.final[centralID] = true
 		}
@@ -891,6 +1011,10 @@ func (runtime *edgeAgentRuntime) prepareSiteStats() edgeSiteStatsPending {
 			observed.CacheSizeValid = true
 		}
 		pending.stats = append(pending.stats, observed)
+		pending.order = append(pending.order, centralID)
+	}
+	if len(pending.order) > 0 {
+		pending.nextCursor = pending.order[len(pending.order)-1] + 1
 	}
 	return pending
 }
@@ -904,6 +1028,11 @@ func (runtime *edgeAgentRuntime) commitSiteStatsWithACK(pending edgeSiteStatsPen
 		runtime.siteReported = make(map[int64]ProxyRuntimeStat)
 	}
 	deltas := make(map[int64]ProxyRuntimeStat, len(pending.current))
+	for index, siteID := range pending.order {
+		if acknowledged[siteID] {
+			runtime.siteStatsCursor = pending.order[index] + 1
+		}
+	}
 	for siteID, sent := range pending.current {
 		if !acknowledged[siteID] {
 			continue
@@ -982,11 +1111,11 @@ func (runtime *edgeAgentRuntime) gcRetiredTrafficCounters(finalAcked map[int64]b
 		if !finalAcked[siteID] {
 			continue
 		}
-		if counter == nil || counter.pendingRequest.Load() != 0 {
+		if counter == nil || counter.activeRequests.Load() != 0 {
 			continue
 		}
 		if runtime.bundle != nil {
-			if _, ok := runtime.bundle.localSites[siteID]; ok {
+			if _, ok := runtime.bundle.centralSites[siteID]; ok {
 				continue
 			}
 		}
@@ -1232,7 +1361,7 @@ func buildEdgeProxy(config AgentRuntimeConfig, runtime *edgeAgentRuntime) (*edge
 		return nil, err
 	}
 	database.edgeEphemeral = true
-	bundle := &edgeProxyBundle{database: database, localSites: make(map[int64]edgeSiteIdentity)}
+	bundle := &edgeProxyBundle{database: database, localSites: make(map[int64]edgeSiteIdentity), centralSites: make(map[int64]struct{})}
 	database.edgeTelemetrySink = func(event edgeTelemetryEvent) {
 		mapped, ok := edgeTelemetryEventSiteID(event, bundle.localSites)
 		if !ok {
@@ -1309,6 +1438,9 @@ func buildEdgeProxy(config AgentRuntimeConfig, runtime *edgeAgentRuntime) (*edge
 		siteIDs[site.PublicHost] = route.SiteID
 		localSites[created.ID] = edgeSiteIdentity{centralID: route.SiteID, host: site.PublicHost}
 		bundle.localSites[created.ID] = localSites[created.ID]
+		if route.SiteID > 0 {
+			bundle.centralSites[route.SiteID] = struct{}{}
+		}
 		runtimeSites[site.PublicHost] = *created
 	}
 	database.edgeRequestLogSink = func(event requestLogEvent) {
@@ -1584,22 +1716,12 @@ func (runtime *edgeAgentRuntime) apply(config AgentRuntimeConfig) (retErr error)
 	}
 	runtime.listenerError = ""
 	runtime.mu.Unlock()
+	if len(config.ForceStopSiteIDs) > 0 {
+		forceCtx, forceCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		runtime.forceStopCentralSites(forceCtx, config.ForceStopSiteIDs, oldState.bundle)
+		forceCancel()
+	}
 	if oldState.bundle != nil {
-		if len(config.ForceStopSiteIDs) > 0 {
-			forced := make(map[int64]struct{}, len(config.ForceStopSiteIDs))
-			for _, centralID := range config.ForceStopSiteIDs {
-				for localID, identity := range oldState.bundle.localSites {
-					if identity.centralID == centralID {
-						forced[localID] = struct{}{}
-					}
-				}
-			}
-			if len(forced) > 0 {
-				forceCtx, forceCancel := context.WithTimeout(context.Background(), 5*time.Second)
-				oldState.bundle.manager.ForceStopSites(forceCtx, forced)
-				forceCancel()
-			}
-		}
 		// Hot config changes are not a security revocation. Existing playback and
 		// WebSocket streams finish naturally; close() cancels them on shutdown.
 		runtime.beginBundleDrain(oldState.bundle)
@@ -2043,6 +2165,40 @@ func edgeCollect(sessionID string, sequence int64) (NodeReport, error) {
 	return NodeReport{BootID: sessionID, ReportSessionID: sessionID, CounterEpoch: edgeCounterEpoch(interfaceName), Sequence: sequence, InterfaceName: interfaceName, RXBytes: rx, TXBytes: tx, AgentVersion: appVersion}, nil
 }
 
+// edgeReportEventsByBudget takes both the protocol item limit and the encoded
+// JSON budget into account. Without the byte budget a queue containing large
+// metadata responses can exceed the Controller limit forever: the same head
+// events are retried on every heartbeat and no ACK is ever possible.
+func edgeReportEventsByBudget(report NodeReport, events []NodeRequestEvent) []NodeRequestEvent {
+	if len(events) == 0 {
+		return nil
+	}
+	if len(events) > maxNodeRequestEventsPerReport {
+		events = events[:maxNodeRequestEventsPerReport]
+	}
+	selected := make([]NodeRequestEvent, 0, len(events))
+	for _, event := range events {
+		candidate := append(append([]NodeRequestEvent(nil), selected...), event)
+		report.Events = candidate
+		encoded, err := json.Marshal(report)
+		if err != nil {
+			break
+		}
+		if len(encoded) > targetAgentReportBytes {
+			// A single event is bounded well below the report limit. If the
+			// non-event payload itself ever grows beyond the target, retain no
+			// event in this report so the queue can still make progress after
+			// the base payload is reduced by a later protocol change.
+			if len(selected) == 0 {
+				return nil
+			}
+			break
+		}
+		selected = candidate
+	}
+	return selected
+}
+
 func edgeExecutableDigest() (string, string, error) {
 	executable, err := os.Executable()
 	if err != nil {
@@ -2358,7 +2514,7 @@ func runEdgeAgent() error {
 			pendingTelemetry := runtime.prepareTelemetry()
 			report.SiteStats = pendingStats.stats
 			report.MediaCounts, report.Retention, report.Observations = pendingTelemetry.media, pendingTelemetry.retention, pendingTelemetry.observations
-			report.Events = runtime.events.snapshot()
+			report.Events = edgeReportEventsByBudget(report, runtime.events.snapshot())
 			ack, wsErr := wsReporter.report(ctx, report)
 			if wsErr != nil {
 				wsErr = edgeAPIRequest(ctx, client, http.MethodPost, controller+"/api/agent/report", state.Token, report, &ack)

--- a/edge_agent_test.go
+++ b/edge_agent_test.go
@@ -6,8 +6,10 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -93,6 +95,19 @@ func TestEdgeTrafficCounterSurvivesHotApply(t *testing.T) {
 	}
 }
 
+func TestEdgeTrafficCounterEpochAdvancesAfterRetirement(t *testing.T) {
+	runtime := &edgeAgentRuntime{}
+	first := runtime.trafficCounterFor(42, "epoch.example.test")
+	if first.epoch != 1 {
+		t.Fatalf("first counter epoch=%d, want 1", first.epoch)
+	}
+	runtime.trafficCounters = make(map[int64]*edgeSiteTrafficCounter)
+	second := runtime.trafficCounterFor(42, "epoch.example.test")
+	if second.epoch != 2 {
+		t.Fatalf("recreated counter epoch=%d, want 2", second.epoch)
+	}
+}
+
 func TestEdgeSiteStatsRetainRemovedRouteUntilControllerAcknowledgesIt(t *testing.T) {
 	runtime := &edgeAgentRuntime{}
 	counter := runtime.trafficCounterFor(42, "tail.example.test")
@@ -113,6 +128,85 @@ func TestEdgeSiteStatsRetainRemovedRouteUntilControllerAcknowledgesIt(t *testing
 	}
 }
 
+func TestEdgeSiteStatsUseStableControllerSiteIndex(t *testing.T) {
+	runtime := &edgeAgentRuntime{}
+	counter := runtime.trafficCounterFor(42, "stable.example.test")
+	bundle := &edgeProxyBundle{
+		localSites:   map[int64]edgeSiteIdentity{1: {centralID: 42}},
+		centralSites: map[int64]struct{}{42: {}},
+	}
+	runtime.bundle = bundle
+	pending := runtime.prepareSiteStats()
+	if len(pending.stats) != 1 || pending.stats[0].Final {
+		t.Fatalf("current route with local ID 1 and controller ID 42 was marked final: %#v", pending.stats)
+	}
+	counter.cumulativeOut.Store(1)
+	runtime.siteReported = map[int64]ProxyRuntimeStat{42: {SiteID: 42, CumulativeBytesOut: 1}}
+	runtime.commitSiteStatsWithACK(pending, map[int64]bool{42: true})
+	if _, ok := runtime.trafficCounters[42]; !ok {
+		t.Fatal("active route counter was garbage-collected")
+	}
+}
+
+func TestEdgeSiteStatsWaitForActiveRequestsBeforeFinal(t *testing.T) {
+	runtime := &edgeAgentRuntime{}
+	counter := runtime.trafficCounterFor(42, "draining.example.test")
+	counter.activeRequests.Add(1)
+	runtime.bundle = &edgeProxyBundle{centralSites: map[int64]struct{}{}}
+	pending := runtime.prepareSiteStats()
+	if len(pending.stats) != 1 || pending.stats[0].Final {
+		t.Fatal("active request was ignored when deciding final site stats")
+	}
+	counter.activeRequests.Add(-1)
+	pending = runtime.prepareSiteStats()
+	if len(pending.stats) != 1 || !pending.stats[0].Final {
+		t.Fatal("site was not marked final after the active request ended")
+	}
+}
+
+func TestEdgeSiteStatsRoundRobinPaging(t *testing.T) {
+	runtime := &edgeAgentRuntime{}
+	bundle := &edgeProxyBundle{centralSites: make(map[int64]struct{})}
+	for siteID := int64(1); siteID <= 600; siteID++ {
+		runtime.trafficCounterFor(siteID, fmt.Sprintf("site-%d.example.test", siteID))
+		bundle.centralSites[siteID] = struct{}{}
+	}
+	runtime.bundle = bundle
+	first := runtime.prepareSiteStats()
+	if len(first.stats) != maxNodeSiteStatsPerReport || first.stats[0].SiteID != 1 {
+		t.Fatalf("first site stats page=%d first=%d", len(first.stats), first.stats[0].SiteID)
+	}
+	ack := make(map[int64]bool, len(first.current))
+	for siteID := range first.current {
+		ack[siteID] = true
+	}
+	runtime.commitSiteStatsWithACK(first, ack)
+	second := runtime.prepareSiteStats()
+	if len(second.stats) == 0 || second.stats[0].SiteID != 513 {
+		t.Fatalf("second site stats page first=%d, want 513", second.stats[0].SiteID)
+	}
+}
+
+func TestEdgeReportEventsRespectEncodedByteBudget(t *testing.T) {
+	base := NodeReport{BootID: "boot", ReportSessionID: "session", CounterEpoch: "epoch", Sequence: 1, InterfaceName: "eth0"}
+	events := make([]NodeRequestEvent, 40)
+	for index := range events {
+		events[index] = NodeRequestEvent{EventID: int64(index + 1), SiteID: 1, Host: "site.example.test", Method: "GET", Path: "/Items", StatusCode: 200, ResponseBody: strings.Repeat("x", 60<<10), RecordedAtMS: 1}
+	}
+	selected := edgeReportEventsByBudget(base, events)
+	if len(selected) == 0 || len(selected) >= len(events) {
+		t.Fatalf("byte budget did not page large events: selected=%d total=%d", len(selected), len(events))
+	}
+	base.Events = selected
+	encoded, err := json.Marshal(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(encoded) > targetAgentReportBytes {
+		t.Fatalf("encoded event page=%d exceeds target=%d", len(encoded), targetAgentReportBytes)
+	}
+}
+
 func TestEdgeTelemetryNeedsCategoryAcknowledgement(t *testing.T) {
 	runtime := &edgeAgentRuntime{mediaCounts: map[int64]NodeMediaCount{7: {SiteID: 7, MovieCount: 1, ObservedAtMS: 1}}}
 	pending := runtime.prepareTelemetry()
@@ -123,6 +217,31 @@ func TestEdgeTelemetryNeedsCategoryAcknowledgement(t *testing.T) {
 	runtime.commitTelemetryWithACK(pending, map[int64]bool{7: true}, nil, nil)
 	if _, ok := runtime.mediaCounts[7]; ok {
 		t.Fatal("acknowledged telemetry remained pending")
+	}
+}
+
+func TestEdgeTelemetryRoundRobinPaging(t *testing.T) {
+	runtime := &edgeAgentRuntime{mediaCounts: make(map[int64]NodeMediaCount), retention: make(map[int64]NodeRetentionStatus)}
+	for siteID := int64(1); siteID <= 256; siteID++ {
+		runtime.mediaCounts[siteID] = NodeMediaCount{SiteID: siteID, MovieCount: 1, ObservedAtMS: siteID}
+		runtime.retention[siteID] = NodeRetentionStatus{SiteID: siteID, ExpectedStartedAtMS: 1, CompletedAtMS: siteID, Done: true}
+	}
+	first := runtime.prepareTelemetry()
+	if len(first.media) != maxNodeTelemetryItemsPerReport || len(first.retention) != maxNodeTelemetryItemsPerReport {
+		t.Fatalf("first telemetry page sizes media=%d retention=%d", len(first.media), len(first.retention))
+	}
+	mediaACK := make(map[int64]bool, len(first.media))
+	retentionACK := make(map[int64]bool, len(first.retention))
+	for _, value := range first.media {
+		mediaACK[value.SiteID] = true
+	}
+	for _, value := range first.retention {
+		retentionACK[value.SiteID] = true
+	}
+	runtime.commitTelemetryWithACK(first, mediaACK, retentionACK, nil)
+	second := runtime.prepareTelemetry()
+	if len(second.media) == 0 || second.media[0].SiteID != 129 || len(second.retention) == 0 || second.retention[0].SiteID != 129 {
+		t.Fatalf("second telemetry page did not advance cursor: media=%d retention=%d", second.media[0].SiteID, second.retention[0].SiteID)
 	}
 }
 

--- a/node_repository.go
+++ b/node_repository.go
@@ -187,6 +187,10 @@ type NodeSiteStat struct {
 	// zero-byte cache. Older Agents omit the field and therefore never erase a
 	// previously known Controller value by reporting an unknown size.
 	CacheSizeValid bool `json:"cache_size_valid,omitempty"`
+	// CounterEpoch changes when an Agent recreates a retired site counter. It
+	// lets the Controller distinguish an A→B→A route transition from a
+	// monotonic continuation of the old cumulative values.
+	CounterEpoch uint64 `json:"counter_epoch,omitempty"`
 	// Final marks the last snapshot for a route removed from an Agent bundle.
 	// The Controller retires only that node's drain generation after accepting it.
 	Final bool `json:"final,omitempty"`
@@ -255,6 +259,10 @@ const (
 const maxNodeRequestEventBodyBytes = 8 << 10
 const maxNodeRequestEventResponseBodyBytes = 64 << 10
 const maxAgentReportBodyBytes = 2 << 20
+
+// Leave headroom below the Controller's hard 2 MiB limit so an event batch is
+// accepted consistently by both the JSON HTTP fallback and WebSocket path.
+const targetAgentReportBytes = 1536 << 10
 const maxNodeRequestEventsPerReport = 128
 const maxNodeTelemetryItemsPerReport = 128
 const maxNodeSiteStatsPerReport = 512
@@ -1081,6 +1089,42 @@ func authorizedNodeSitesTx(tx *sql.Tx, nodeID, nowMS int64) (map[int64]authorize
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+	// A disabled route remains authorized for the short finalization window
+	// represented by its revocation tombstone. This lets the Agent flush its
+	// last counters and queued events after ForceStop without reopening the
+	// route for scheduling. Deleted sites have no durable application state to
+	// update, so they are intentionally omitted here while the tombstone still
+	// drives the Agent-side force stop.
+	revocationRows, err := tx.Query(`SELECT r.site_id,
+		LOWER(TRIM(COALESCE(NULLIF(r.public_host,''),s.public_host,'')))
+		FROM agent_route_revocations r
+		LEFT JOIN sites s ON s.id=r.site_id
+		WHERE r.node_id=? AND s.id IS NOT NULL
+		  AND (r.created_at_ms<=0 OR r.created_at_ms+? > ?)`, nodeID, siteNodeDrainWindow.Milliseconds(), nowMS)
+	if err != nil {
+		return nil, err
+	}
+	for revocationRows.Next() {
+		var siteID int64
+		var host string
+		if err := revocationRows.Scan(&siteID, &host); err != nil {
+			revocationRows.Close()
+			return nil, err
+		}
+		if siteID <= 0 || host == "" {
+			continue
+		}
+		if _, exists := result[siteID]; !exists {
+			result[siteID] = authorizedNodeSite{ID: siteID, PublicHost: host, HostAliases: map[string]struct{}{host: {}}}
+		}
+	}
+	if err := revocationRows.Err(); err != nil {
+		revocationRows.Close()
+		return nil, err
+	}
+	if err := revocationRows.Close(); err != nil {
+		return nil, err
+	}
 	// Public-host renames do not create DNS drain rows. Keep old hosts as
 	// bounded aliases so events buffered by an Agent remain valid for the same
 	// site without widening authorization to another site.
@@ -1118,7 +1162,7 @@ func authorizedNodeSitesTx(tx *sql.Tx, nodeID, nowMS int64) (map[int64]authorize
 	// host as an alias so late events from an admitted old bundle remain valid.
 	drainRows, err := tx.Query(`SELECT d.site_id, LOWER(TRIM(d.public_host))
 		FROM site_node_drains d JOIN sites s ON s.id=d.site_id
-		WHERE d.node_id=? AND d.expires_at_ms>? AND s.enabled=1`, nodeID, nowMS)
+		WHERE d.node_id=? AND d.expires_at_ms>?`, nodeID, nowMS)
 	if err != nil {
 		return nil, err
 	}
@@ -1139,7 +1183,7 @@ func authorizedNodeSitesTx(tx *sql.Tx, nodeID, nowMS int64) (map[int64]authorize
 			result[siteID] = site
 		} else {
 			var currentHost string
-			if err := tx.QueryRow("SELECT LOWER(TRIM(public_host)) FROM sites WHERE id=? AND enabled=1", siteID).Scan(&currentHost); err == nil {
+			if err := tx.QueryRow("SELECT LOWER(TRIM(public_host)) FROM sites WHERE id=?", siteID).Scan(&currentHost); err == nil {
 				result[siteID] = authorizedNodeSite{ID: siteID, PublicHost: currentHost, HostAliases: map[string]struct{}{host: {}}}
 			}
 		}
@@ -1176,7 +1220,7 @@ func authorizedNodeSiteForStat(sites map[int64]authorizedNodeSite, stat NodeSite
 	}
 	host := requestPublicHost(strings.TrimSpace(stat.Host))
 	for _, site := range sites {
-		if strings.EqualFold(site.PublicHost, host) {
+		if authorizedNodeSiteHost(sites, site.ID, host) {
 			return site, true
 		}
 	}
@@ -1655,7 +1699,11 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 			sessionID, count, stat.LastRequestAtMS, stat.LastStatus, now.UnixMilli(), scheduleID); err != nil {
 			return nodeReportCommitResult{}, err
 		}
-		if err := recordNodeSiteTrafficTx(tx, id, siteCounterEpoch, stat, now.UnixMilli(), allowedSites); err != nil {
+		statCounterEpoch := siteCounterEpoch
+		if stat.CounterEpoch > 0 {
+			statCounterEpoch = fmt.Sprintf("%s:%d", siteCounterEpoch, stat.CounterEpoch)
+		}
+		if err := recordNodeSiteTrafficTx(tx, id, statCounterEpoch, stat, now.UnixMilli(), allowedSites); err != nil {
 			return nodeReportCommitResult{}, err
 		}
 		appendUniqueNodeSiteID(&result.acceptedSiteIDs, scheduleID)

--- a/node_repository_test.go
+++ b/node_repository_test.go
@@ -498,6 +498,135 @@ func TestRecordNodeReportResultRetiresInvalidEvents(t *testing.T) {
 	}
 }
 
+func TestRecordNodeReportRejectsUnauthorizedSiteData(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now().UTC()
+	nodeA, enrollmentA, err := app.db.CreateControlNode(NodeCreateInput{Name: "report-a", Address: "203.0.113.70"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, tokenA, err := app.db.EnrollControlNode(enrollmentA, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nodeB, enrollmentB, err := app.db.CreateControlNode(NodeCreateInput{Name: "report-b", Address: "203.0.113.71"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := app.db.EnrollControlNode(enrollmentB, now); err != nil {
+		t.Fatal(err)
+	}
+	siteA, err := app.db.CreateSiteRecord(Site{Name: "report-site-a", ListenPort: 18083, PublicHost: "report-a.example.com", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:18080"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	siteB, err := app.db.CreateSiteRecord(Site{Name: "report-site-b", ListenPort: 18084, PublicHost: "report-b.example.com", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:18081"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, value := range []struct {
+		siteID, nodeID int64
+	}{
+		{siteA.ID, nodeA.ID},
+		{siteB.ID, nodeB.ID},
+	} {
+		if _, err := app.db.SaveSiteNodeSchedule(value.siteID, true, "fixed", value.nodeID, now); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := app.db.db.Exec("UPDATE site_node_schedules SET desired_node_id=?,applied_node_id=? WHERE site_id=?", value.nodeID, value.nodeID, value.siteID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	result, err := app.db.RecordNodeReportResult(tokenA, NodeReport{
+		BootID: "report", ReportSessionID: "report", CounterEpoch: "report-epoch", Sequence: 1, InterfaceName: "eth0",
+		SiteStats: []NodeSiteStat{
+			{SiteID: siteB.ID, Host: siteB.PublicHost, RequestCount: 2, BytesIn: 11, CumulativeBytesIn: 11, LastRequestAtMS: now.UnixMilli(), LastStatus: 200},
+			{SiteID: siteA.ID, Host: siteB.PublicHost, RequestCount: 3, LastRequestAtMS: now.UnixMilli(), LastStatus: 200},
+		},
+		MediaCounts:  []NodeMediaCount{{SiteID: siteB.ID, MovieCount: 99, SeriesCount: 99, EpisodeCount: 99, ObservedAtMS: now.UnixMilli()}},
+		Retention:    []NodeRetentionStatus{{SiteID: siteB.ID, ExpectedStartedAtMS: now.UnixMilli() - 1000, CompletedAtMS: now.UnixMilli()}},
+		Observations: []NodeDynamicObservation{{SiteID: siteB.ID, CanonicalAuthority: "https://cdn.example.com:443", Source: "hls", Decision: "denied", ReasonCode: "parse_failure", ObservedAtMS: now.UnixMilli()}},
+		Events: []NodeRequestEvent{
+			{EventID: 1, EventUID: strings.Repeat("a", 32), SiteID: siteB.ID, Host: siteB.PublicHost, Method: "GET", Path: "/Items", StatusCode: 200, RecordedAtMS: now.UnixMilli()},
+			{EventID: 2, EventUID: strings.Repeat("b", 32), SiteID: siteA.ID, Host: siteB.PublicHost, Method: "GET", Path: "/Items", StatusCode: 200, RecordedAtMS: now.UnixMilli()},
+		},
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.AcceptedSiteIDs) != 0 || len(result.DiscardedSiteIDs) != 2 || len(result.DiscardedMediaSiteIDs) != 1 || len(result.DiscardedRetentionSiteIDs) != 1 || len(result.DiscardedObservationSiteIDs) != 1 || len(result.DiscardedEventIDs) != 2 {
+		t.Fatalf("unexpected authorization result: %#v", result)
+	}
+	var count int
+	if err := app.db.db.QueryRow("SELECT COUNT(*) FROM node_site_counters WHERE node_id=? AND site_id=?", nodeA.ID, siteB.ID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatal("unauthorized site stats created a counter")
+	}
+	if err := app.db.db.QueryRow("SELECT media_movie_count FROM sites WHERE id=?", siteB.ID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count == 99 {
+		t.Fatalf("unauthorized media count changed site B: %d", count)
+	}
+	if err := app.db.db.QueryRow("SELECT COUNT(*) FROM dynamic_observations WHERE site_id=?", siteB.ID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatal("unauthorized observation was persisted")
+	}
+	if err := app.db.db.QueryRow("SELECT COUNT(*) FROM node_request_events WHERE node_id=?", nodeA.ID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatal("unauthorized request event was persisted")
+	}
+}
+
+func TestRecordNodeReportAcceptsDisabledSiteFinalization(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now().UTC()
+	node, enrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "disabled-tail", Address: "203.0.113.72"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, token, err := app.db.EnrollControlNode(enrollment, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "disabled-tail-site", PublicHost: "disabled-tail.example.test", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:18082"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.SaveSiteNodeSchedule(site.ID, true, "fixed", node.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec("UPDATE site_node_schedules SET desired_node_id=?,applied_node_id=? WHERE site_id=?", node.ID, node.ID, site.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.db.SetSiteEnabled(site.ID, false); err != nil {
+		t.Fatal(err)
+	}
+	result, err := app.db.RecordNodeReportResult(token, NodeReport{
+		BootID: "disabled", ReportSessionID: "disabled", CounterEpoch: "disabled-epoch", Sequence: 1, InterfaceName: "eth0",
+		SiteStats: []NodeSiteStat{{SiteID: site.ID, Host: site.PublicHost, RequestCount: 1, BytesIn: 17, CumulativeBytesIn: 17, LastRequestAtMS: now.UnixMilli(), LastStatus: 200}},
+	}, now.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.AcceptedSiteIDs) != 1 || result.AcceptedSiteIDs[0] != site.ID {
+		t.Fatalf("disabled final stat was not accepted: %#v", result)
+	}
+	var used int64
+	if err := app.db.db.QueryRow("SELECT traffic_used FROM sites WHERE id=?", site.ID).Scan(&used); err != nil {
+		t.Fatal(err)
+	}
+	if used != 17 {
+		t.Fatalf("disabled site final traffic=%d, want 17", used)
+	}
+}
+
 func TestControlNodePortValidation(t *testing.T) {
 	custom, err := normalizeNodeInput(NodeCreateInput{Name: "custom", Port: 9090})
 	if err != nil || custom.Port != 9090 {

--- a/proxy_manager.go
+++ b/proxy_manager.go
@@ -76,6 +76,11 @@ type edgeSiteTrafficCounter struct {
 	cumulativeOut  atomic.Int64
 	requests       atomic.Int64
 	pendingRequest atomic.Int64
+	// activeRequests tracks handlers admitted to this site generation. It is
+	// deliberately separate from pendingRequest, which counts traffic waiting
+	// for persistence and may remain non-zero after a request has completed.
+	activeRequests atomic.Int64
+	epoch          uint64
 }
 
 func (inst *ProxyInstance) trafficBytesIn() *atomic.Int64 {
@@ -202,10 +207,16 @@ func (inst *ProxyInstance) beginRequest() bool {
 		return false
 	}
 	inst.activeRequests.Add(1)
+	if inst.trafficCounter != nil {
+		inst.trafficCounter.activeRequests.Add(1)
+	}
 	return true
 }
 
 func (inst *ProxyInstance) endRequest() {
+	if inst.trafficCounter != nil {
+		inst.trafficCounter.activeRequests.Add(-1)
+	}
 	inst.activeRequests.Done()
 }
 
@@ -221,6 +232,9 @@ func (inst *ProxyInstance) beginHTTPRequest(w http.ResponseWriter) (*http.Respon
 	}
 	inst.activeHTTP[controller] = struct{}{}
 	inst.activeRequests.Add(1)
+	if inst.trafficCounter != nil {
+		inst.trafficCounter.activeRequests.Add(1)
+	}
 	return controller, true
 }
 
@@ -228,6 +242,9 @@ func (inst *ProxyInstance) endHTTPRequest(controller *http.ResponseController) {
 	inst.lifecycleMu.Lock()
 	delete(inst.activeHTTP, controller)
 	inst.lifecycleMu.Unlock()
+	if inst.trafficCounter != nil {
+		inst.trafficCounter.activeRequests.Add(-1)
+	}
 	inst.activeRequests.Done()
 }
 

--- a/site_node_scheduler.go
+++ b/site_node_scheduler.go
@@ -1419,6 +1419,37 @@ func runSiteNodeScheduler(ctx context.Context, app *App) {
 	}
 }
 
+func siteNodeRevocationIDsTx(tx *sql.Tx, siteID int64, nodeIDs ...int64) ([]int64, error) {
+	seen := make(map[int64]struct{})
+	result := make([]int64, 0, len(nodeIDs)+2)
+	for _, nodeID := range nodeIDs {
+		if nodeID > 0 {
+			if _, ok := seen[nodeID]; !ok {
+				seen[nodeID] = struct{}{}
+				result = append(result, nodeID)
+			}
+		}
+	}
+	rows, err := tx.Query("SELECT node_id FROM site_node_drains WHERE site_id=?", siteID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var nodeID int64
+		if err := rows.Scan(&nodeID); err != nil {
+			return nil, err
+		}
+		if nodeID > 0 {
+			if _, ok := seen[nodeID]; !ok {
+				seen[nodeID] = struct{}{}
+				result = append(result, nodeID)
+			}
+		}
+	}
+	return result, rows.Err()
+}
+
 func (a *App) removeSiteNodeSchedule(ctx context.Context, siteID int64) error {
 	var exists int
 	if err := a.db.db.QueryRow("SELECT COUNT(*) FROM site_node_schedules WHERE site_id=?", siteID).Scan(&exists); err != nil {
@@ -1443,14 +1474,18 @@ func (a *App) removeSiteNodeSchedule(ctx context.Context, siteID int64) error {
 		return err
 	}
 	defer tx.Rollback()
-	for _, nodeID := range []int64{value.FixedNodeID, value.DesiredNodeID, value.AppliedNodeID} {
+	revocationIDs, err := siteNodeRevocationIDsTx(tx, siteID, value.FixedNodeID, value.DesiredNodeID, value.AppliedNodeID)
+	if err != nil {
+		return err
+	}
+	for _, nodeID := range revocationIDs {
 		if nodeID > 0 {
-			if _, err := tx.Exec("INSERT OR IGNORE INTO agent_route_revocations(node_id,site_id,created_at_ms) VALUES(?,?,?)", nodeID, siteID, time.Now().UnixMilli()); err != nil {
+			if _, err := tx.Exec("INSERT OR IGNORE INTO agent_route_revocations(node_id,site_id,public_host,created_at_ms) VALUES(?,?,?,?)", nodeID, siteID, strings.ToLower(strings.TrimSpace(value.PublicHost)), time.Now().UnixMilli()); err != nil {
 				return err
 			}
 		}
 	}
-	if err := markAgentConfigsDirtyForNodeIDsTx(tx, value.FixedNodeID, value.DesiredNodeID, value.AppliedNodeID); err != nil {
+	if err := markAgentConfigsDirtyForNodeIDsTx(tx, revocationIDs...); err != nil {
 		return err
 	}
 	if _, err := tx.Exec(`UPDATE site_node_schedules SET enabled=0,dns_status='waiting',last_error='',updated_at_ms=? WHERE site_id=?`, time.Now().UnixMilli(), siteID); err != nil {
@@ -1483,10 +1518,32 @@ func (a *App) prepareNodeDeletion(ctx context.Context, nodeID int64) error {
 	if err != nil {
 		return err
 	}
+	drainSites := make(map[int64]struct{})
+	drainRows, drainErr := a.db.db.Query("SELECT site_id FROM site_node_drains WHERE node_id=?", nodeID)
+	if drainErr != nil {
+		return drainErr
+	}
+	for drainRows.Next() {
+		var siteID int64
+		if scanErr := drainRows.Scan(&siteID); scanErr != nil {
+			drainRows.Close()
+			return scanErr
+		}
+		drainSites[siteID] = struct{}{}
+	}
+	if drainErr := drainRows.Err(); drainErr != nil {
+		drainRows.Close()
+		return drainErr
+	}
+	if drainErr := drainRows.Close(); drainErr != nil {
+		return drainErr
+	}
 	affected := make([]SiteNodeSchedule, 0)
 	for _, value := range values {
 		if value.FixedNodeID != nodeID && value.DesiredNodeID != nodeID && value.AppliedNodeID != nodeID {
-			continue
+			if _, draining := drainSites[value.SiteID]; !draining {
+				continue
+			}
 		}
 		affected = append(affected, value)
 	}
@@ -1517,14 +1574,18 @@ func (a *App) prepareNodeDeletion(ctx context.Context, nodeID int64) error {
 	}
 	defer tx.Rollback()
 	for _, value := range affected {
-		for _, nodeID := range []int64{value.FixedNodeID, value.DesiredNodeID, value.AppliedNodeID} {
+		revocationIDs, revocationErr := siteNodeRevocationIDsTx(tx, value.SiteID, value.FixedNodeID, value.DesiredNodeID, value.AppliedNodeID)
+		if revocationErr != nil {
+			return revocationErr
+		}
+		for _, nodeID := range revocationIDs {
 			if nodeID > 0 {
-				if _, err := tx.Exec("INSERT OR IGNORE INTO agent_route_revocations(node_id,site_id,created_at_ms) VALUES(?,?,?)", nodeID, value.SiteID, time.Now().UnixMilli()); err != nil {
+				if _, err := tx.Exec("INSERT OR IGNORE INTO agent_route_revocations(node_id,site_id,public_host,created_at_ms) VALUES(?,?,?,?)", nodeID, value.SiteID, strings.ToLower(strings.TrimSpace(value.PublicHost)), time.Now().UnixMilli()); err != nil {
 					return err
 				}
 			}
 		}
-		if err := markAgentConfigsDirtyForNodeIDsTx(tx, value.FixedNodeID, value.DesiredNodeID, value.AppliedNodeID); err != nil {
+		if err := markAgentConfigsDirtyForNodeIDsTx(tx, revocationIDs...); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(`UPDATE site_node_schedules SET enabled=0,dns_status='waiting',last_error='',updated_at_ms=? WHERE site_id=?`, time.Now().UnixMilli(), value.SiteID); err != nil {

--- a/site_repository.go
+++ b/site_repository.go
@@ -742,7 +742,11 @@ func (d *DB) SetSiteEnabled(id int64, enabled bool) error {
 	}
 	defer tx.Rollback()
 	var fixedNodeID, desiredNodeID, appliedNodeID sql.NullInt64
+	var publicHost string
 	if err := tx.QueryRow("SELECT fixed_node_id,desired_node_id,applied_node_id FROM site_node_schedules WHERE site_id=?", id).Scan(&fixedNodeID, &desiredNodeID, &appliedNodeID); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	if err := tx.QueryRow("SELECT public_host FROM sites WHERE id=?", id).Scan(&publicHost); err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return err
 	}
 	result, err := tx.Exec("UPDATE sites SET enabled=?, updated_at=CURRENT_TIMESTAMP WHERE id=?", value, id)
@@ -769,11 +773,30 @@ func (d *DB) SetSiteEnabled(id int64, enabled bool) error {
 			return err
 		}
 	} else {
-		for _, value := range []sql.NullInt64{fixedNodeID, desiredNodeID, appliedNodeID} {
-			if !value.Valid || value.Int64 <= 0 {
-				continue
-			}
-			if _, err := tx.Exec("INSERT OR IGNORE INTO agent_route_revocations(node_id,site_id,created_at_ms) VALUES(?,?,?)", value.Int64, id, time.Now().UnixMilli()); err != nil {
+		nodeIDs, err := siteNodeRevocationIDsTx(tx, id,
+			func() int64 {
+				if fixedNodeID.Valid {
+					return fixedNodeID.Int64
+				}
+				return 0
+			}(),
+			func() int64 {
+				if desiredNodeID.Valid {
+					return desiredNodeID.Int64
+				}
+				return 0
+			}(),
+			func() int64 {
+				if appliedNodeID.Valid {
+					return appliedNodeID.Int64
+				}
+				return 0
+			}())
+		if err != nil {
+			return err
+		}
+		for _, nodeID := range nodeIDs {
+			if _, err := tx.Exec("INSERT OR IGNORE INTO agent_route_revocations(node_id,site_id,public_host,created_at_ms) VALUES(?,?,?,?)", nodeID, id, strings.ToLower(strings.TrimSpace(publicHost)), time.Now().UnixMilli()); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Hardens Agent telemetry lifecycle, stable site authorization, revocation handling, bounded report payloads, and traffic counter continuity. Includes regression coverage for node transitions and unauthorized reports.