### PR TITLE
fix: harden Agent lifecycle finalization

### DIFF
--- a/node_repository.go
+++ b/node_repository.go
@@ -1402,9 +1402,6 @@ func recordNodeSiteTrafficTx(tx *sql.Tx, nodeID int64, counterEpoch string, stat
 			cacheSize = stat.CacheSizeBytes
 		}
 		_, err = tx.Exec(`INSERT INTO node_site_counters(node_id,site_id,boot_id,last_bytes_in,last_bytes_out,last_request_count,cache_size_bytes,updated_at_ms) VALUES(?,?,?,?,?,?,?,?)`, nodeID, siteID, counterEpoch, currentIn, currentOut, stat.RequestCount, cacheSize, nowMS)
-		if err == nil && stat.Final {
-			_, err = tx.Exec("DELETE FROM site_node_drains WHERE site_id=? AND node_id=?", siteID, nodeID)
-		}
 		return err
 	}
 	if err != nil {
@@ -1426,7 +1423,12 @@ func recordNodeSiteTrafficTx(tx *sql.Tx, nodeID int64, counterEpoch string, stat
 		if currentOut >= previousOut && stat.BytesOut == 0 {
 			deltaOut = currentOut - previousOut
 		}
-		if stat.RequestCount >= previousRequests {
+		// Explicit per-site epochs are emitted by current Agents and reset the
+		// cumulative request counter to zero for the new route generation. Only
+		// legacy reports without CounterEpoch may use the old monotonic
+		// subtraction compatibility path; subtracting an older generation here
+		// would silently drop the first requests of the new generation.
+		if stat.CounterEpoch == 0 && stat.RequestCount >= previousRequests {
 			deltaRequests = stat.RequestCount - previousRequests
 		}
 	} else if currentIn >= previousIn && currentOut >= previousOut && stat.RequestCount >= previousRequests {
@@ -1452,11 +1454,9 @@ func recordNodeSiteTrafficTx(tx *sql.Tx, nodeID int64, counterEpoch string, stat
 	if err != nil {
 		return err
 	}
-	if stat.Final {
-		if _, err := tx.Exec("DELETE FROM site_node_drains WHERE site_id=? AND node_id=?", siteID, nodeID); err != nil {
-			return err
-		}
-	}
+	// Final is an Agent-side counter watermark, not proof that every paginated
+	// telemetry/event queue is empty. Keep the drain authorization tombstone
+	// until its bounded expiry so later pages remain accepted.
 	return nil
 }
 
@@ -1664,11 +1664,10 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 			return nodeReportCommitResult{}, err
 		}
 	}
-	if clearAppliedConfig {
-		if _, err := tx.Exec("DELETE FROM agent_route_revocations WHERE node_id=?", id); err != nil {
-			return nodeReportCommitResult{}, err
-		}
-	}
+	// A matching applied config only acknowledges the runtime transition. It
+	// does not acknowledge every paginated telemetry/event queue. Revocation
+	// tombstones remain available for the bounded drain window and are cleaned
+	// by expiry, preventing late pages from being discarded prematurely.
 
 	for _, stat := range report.SiteStats {
 		host := strings.ToLower(strings.TrimSpace(stat.Host))

--- a/node_repository_test.go
+++ b/node_repository_test.go
@@ -713,6 +713,90 @@ func TestControlNodeManualTrafficOffsetAndSiteStats(t *testing.T) {
 	}
 }
 
+func TestNodeSiteTrafficExplicitEpochKeepsFirstRequestBatch(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now().UTC()
+	node, enrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "epoch-node", Address: "203.0.113.220"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, token, err := app.db.EnrollControlNode(enrollment, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "epoch-site", PublicHost: "epoch.example.test", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:18080"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.SaveSiteNodeSchedule(site.ID, true, "fixed", node.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec("UPDATE site_node_schedules SET desired_node_id=?,applied_node_id=? WHERE site_id=?", node.ID, node.ID, site.ID); err != nil {
+		t.Fatal(err)
+	}
+	first := NodeReport{BootID: "boot", ReportSessionID: "session-a", CounterEpoch: "kernel-a", SiteCounterEpoch: "1", Sequence: 1, InterfaceName: "eth0", SiteStats: []NodeSiteStat{{SiteID: site.ID, Host: site.PublicHost, RequestCount: 3, CounterEpoch: 1, LastRequestAtMS: now.UnixMilli(), LastStatus: 200}}}
+	if _, err := app.db.RecordNodeReport(token, first, now); err != nil {
+		t.Fatal(err)
+	}
+	second := NodeReport{BootID: "boot", ReportSessionID: "session-b", CounterEpoch: "kernel-a", SiteCounterEpoch: "2", Sequence: 1, InterfaceName: "eth0", SiteStats: []NodeSiteStat{{SiteID: site.ID, Host: site.PublicHost, RequestCount: 10, CounterEpoch: 1, LastRequestAtMS: now.Add(time.Second).UnixMilli(), LastStatus: 200}}}
+	if _, err := app.db.RecordNodeReport(token, second, now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	var requests int64
+	if err := app.db.db.QueryRow("SELECT COALESCE(SUM(requests),0) FROM node_site_traffic_logs WHERE node_id=? AND site_id=?", node.ID, site.ID).Scan(&requests); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 13 {
+		t.Fatalf("explicit epoch request total=%d, want 13 (3 + 10)", requests)
+	}
+}
+
+func TestDisabledSiteRevocationSurvivesAppliedConfigAndFinalStat(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now().UTC()
+	node, enrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "final-node", Address: "203.0.113.221"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, token, err := app.db.EnrollControlNode(enrollment, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "final-site", PublicHost: "final.example.test", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:18080"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.SaveSiteNodeSchedule(site.ID, true, "fixed", node.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec("UPDATE site_node_schedules SET desired_node_id=?,applied_node_id=?,config_hash='applied' WHERE site_id=?", node.ID, node.ID, site.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.db.SetSiteEnabled(site.ID, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec("UPDATE control_nodes SET desired_config_hash='applied',desired_config_revision=4,config_revision=4,applied_config_revision=0 WHERE id=?", node.ID); err != nil {
+		t.Fatal(err)
+	}
+	report := NodeReport{BootID: "final", ReportSessionID: "final", CounterEpoch: "final", AppliedConfigHash: "applied", AppliedConfigRevision: 4, Sequence: 1, InterfaceName: "eth0", SiteStats: []NodeSiteStat{{SiteID: site.ID, Host: site.PublicHost, RequestCount: 1, CounterEpoch: 1, Final: true, LastRequestAtMS: now.UnixMilli(), LastStatus: 200}}}
+	if _, err := app.db.RecordNodeReportResult(token, report, now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	var revocations, drains int
+	if err := app.db.db.QueryRow("SELECT COUNT(*) FROM agent_route_revocations WHERE node_id=? AND site_id=?", node.ID, site.ID).Scan(&revocations); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.db.db.QueryRow("SELECT COUNT(*) FROM site_node_drains WHERE node_id=? AND site_id=?", node.ID, site.ID).Scan(&drains); err != nil {
+		t.Fatal(err)
+	}
+	if revocations != 1 {
+		t.Fatalf("revocation tombstone was removed after config ACK: %d", revocations)
+	}
+	if drains != 0 {
+		t.Fatalf("unexpected drain row for disabled site: %d", drains)
+	}
+}
+
 func TestNodeHTTPSProbePortFollowsNodePort(t *testing.T) {
 	if got := nodeHTTPSProbePort(ControlNode{Port: 9090}); got != 9090 {
 		t.Fatalf("probe port = %d, want 9090", got)
@@ -1399,6 +1483,23 @@ func TestAgentConfigHashSeparatesReleaseMetadata(t *testing.T) {
 	}
 	if agentSupportsCacheClear("v1.9.49") || !agentSupportsCacheClear("v1.9.50") {
 		t.Fatal("cache clear compatibility gate is incorrect")
+	}
+	if agentSupportsForceStop("v1.9.64") || !agentSupportsForceStop("v1.9.65") {
+		t.Fatal("force-stop compatibility gate is incorrect")
+	}
+	forceStopConfig := config
+	forceStopConfig.ForceStopSiteIDs = []int64{42, 7}
+	withoutForceStop := forceStopConfig
+	withoutForceStop.ForceStopSiteIDs = nil
+	wantPreForceStopHash, err := agentConfigHash(withoutForceStop)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, err := agentConfigHashForVersion(forceStopConfig, "v1.9.64"); err != nil || got != wantPreForceStopHash {
+		t.Fatalf("v1.9.64 hash included unknown force-stop field: got=%q want=%q err=%v", got, wantPreForceStopHash, err)
+	}
+	if got, err := agentConfigHashForVersion(forceStopConfig, "v1.9.65"); err != nil || got != wantPreForceStopHash {
+		t.Fatalf("v1.9.65 force-stop command changed runtime hash: got=%q want=%q err=%v", got, wantPreForceStopHash, err)
 	}
 	cacheGenerationConfig := config
 	cacheGenerationConfig.CacheClearGeneration = 7

--- a/review_regression_test.go
+++ b/review_regression_test.go
@@ -571,10 +571,17 @@ func TestReviewCompletedDNSMoveKeepsTailTrafficAuthorizedOnlyDuringDrain(t *test
 	if _, err := app.db.db.Exec(`INSERT INTO site_node_drains(site_id,node_id,expires_at_ms,created_at_ms) VALUES(?,?,?,?)`, site.ID, oldNode.ID, now.Add(time.Minute).UnixMilli(), now.UnixMilli()); err != nil {
 		t.Fatal(err)
 	}
-	report := NodeReport{BootID: "drain", ReportSessionID: "drain", CounterEpoch: "epoch", SiteCounterEpoch: "drain:1", Sequence: 1, InterfaceName: "eth0", SiteStats: []NodeSiteStat{{SiteID: site.ID, Host: site.PublicHost, RequestCount: 1, LastRequestAtMS: now.UnixMilli(), LastStatus: 200, BytesOut: 100, CumulativeBytesOut: 100}}}
+	report := NodeReport{BootID: "drain", ReportSessionID: "drain", CounterEpoch: "epoch", SiteCounterEpoch: "drain:1", Sequence: 1, InterfaceName: "eth0", SiteStats: []NodeSiteStat{{SiteID: site.ID, Host: site.PublicHost, RequestCount: 1, LastRequestAtMS: now.UnixMilli(), LastStatus: 200, BytesOut: 100, CumulativeBytesOut: 100, Final: true}}}
 	result, err := app.db.RecordNodeReportResult(oldToken, report, now)
 	if err != nil || len(result.AcceptedSiteIDs) != 1 || result.AcceptedSiteIDs[0] != site.ID {
 		t.Fatalf("draining tail report=%#v err=%v, want accepted", result, err)
+	}
+	var activeDrains int
+	if err := app.db.db.QueryRow("SELECT COUNT(*) FROM site_node_drains WHERE site_id=? AND node_id=?", site.ID, oldNode.ID).Scan(&activeDrains); err != nil {
+		t.Fatal(err)
+	}
+	if activeDrains != 1 {
+		t.Fatalf("Final SiteStat retired drain before tail queues were flushed: %d", activeDrains)
 	}
 	if _, err := app.db.db.Exec(`UPDATE site_node_drains SET expires_at_ms=? WHERE site_id=?`, now.Add(-time.Second).UnixMilli(), site.ID); err != nil {
 		t.Fatal(err)
@@ -583,6 +590,102 @@ func TestReviewCompletedDNSMoveKeepsTailTrafficAuthorizedOnlyDuringDrain(t *test
 	result, err = app.db.RecordNodeReportResult(oldToken, report, now.Add(time.Second))
 	if err != nil || len(result.DiscardedSiteIDs) != 1 || result.DiscardedSiteIDs[0] != site.ID {
 		t.Fatalf("expired drain report=%#v err=%v, want discarded", result, err)
+	}
+}
+
+func TestReviewDeletingDrainOnlyNodeLeavesCurrentAssignmentUntouched(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now().UTC()
+	oldNode, oldEnrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "delete-drain-only-old", Address: "203.0.113.180", Port: 9090}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newNode, newEnrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "delete-drain-only-new", Address: "203.0.113.181", Port: 9090}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := app.db.EnrollControlNode(oldEnrollment, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := app.db.EnrollControlNode(newEnrollment, now); err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "delete-drain-only-site", PublicHost: "delete-drain-only.example.test", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:18080"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.SaveSiteNodeSchedule(site.ID, true, "fixed", newNode.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec(`UPDATE site_node_schedules SET desired_node_id=?,applied_node_id=?,dns_status='active' WHERE site_id=?`, newNode.ID, newNode.ID, site.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec(`INSERT INTO site_node_drains(site_id,node_id,expires_at_ms,created_at_ms) VALUES(?,?,?,?)`, site.ID, oldNode.ID, now.Add(time.Hour).UnixMilli(), now.UnixMilli()); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.prepareNodeDeletion(context.Background(), oldNode.ID); err != nil {
+		t.Fatalf("prepare drain-only deletion: %v", err)
+	}
+	schedule, err := app.db.siteNodeSchedule(site.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !schedule.Enabled || schedule.DesiredNodeID != newNode.ID || schedule.AppliedNodeID != newNode.ID || schedule.DNSStatus != "active" {
+		t.Fatalf("drain-only deletion changed current schedule: %#v", schedule)
+	}
+	var revocations int
+	if err := app.db.db.QueryRow("SELECT COUNT(*) FROM agent_route_revocations WHERE site_id=? AND node_id=?", site.ID, newNode.ID).Scan(&revocations); err != nil {
+		t.Fatal(err)
+	}
+	if revocations != 0 {
+		t.Fatalf("drain-only deletion created a revocation for current node: %d", revocations)
+	}
+}
+
+func TestReviewDisablingSiteDirtiesCurrentAndDrainNodes(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now().UTC()
+	oldNode, oldEnrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "disable-drain-old", Address: "203.0.113.182", Port: 9090}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newNode, newEnrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "disable-drain-new", Address: "203.0.113.183", Port: 9090}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := app.db.EnrollControlNode(oldEnrollment, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := app.db.EnrollControlNode(newEnrollment, now); err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "disable-drain-site", PublicHost: "disable-drain.example.test", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:18080"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.SaveSiteNodeSchedule(site.ID, true, "fixed", newNode.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec(`UPDATE site_node_schedules SET desired_node_id=?,applied_node_id=? WHERE site_id=?`, newNode.ID, newNode.ID, site.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec(`INSERT INTO site_node_drains(site_id,node_id,expires_at_ms,created_at_ms) VALUES(?,?,?,?)`, site.ID, oldNode.ID, now.Add(time.Hour).UnixMilli(), now.UnixMilli()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec("UPDATE control_nodes SET config_dirty=0 WHERE id IN (?,?)", oldNode.ID, newNode.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.db.SetSiteEnabled(site.ID, false); err != nil {
+		t.Fatal(err)
+	}
+	for _, nodeID := range []int64{oldNode.ID, newNode.ID} {
+		var dirty int
+		if err := app.db.db.QueryRow("SELECT config_dirty FROM control_nodes WHERE id=?", nodeID).Scan(&dirty); err != nil {
+			t.Fatal(err)
+		}
+		if dirty != 1 {
+			t.Fatalf("node %d was not dirtied when disabling site", nodeID)
+		}
 	}
 }
 

--- a/site_node_scheduler.go
+++ b/site_node_scheduler.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -555,8 +554,13 @@ func agentConfigHashPayload(config AgentRuntimeConfig, legacy bool) agentRuntime
 		config.AgentSHA256 = ""
 	}
 	config.AgentDownloadURL = ""
-	config.ForceStopSiteIDs = append([]int64(nil), config.ForceStopSiteIDs...)
-	sort.Slice(config.ForceStopSiteIDs, func(i, j int) bool { return config.ForceStopSiteIDs[i] < config.ForceStopSiteIDs[j] })
+	// ForceStopSiteIDs is a one-shot command carried by a config revision, not
+	// route runtime state. Excluding it from the hash means adding the command
+	// still triggers one apply through ConfigRevision, while expiry of a
+	// revocation tombstone does not cause a second full hot-apply when routes are
+	// otherwise unchanged. It also keeps the hash identical for older Agents
+	// that ignore this newer JSON field.
+	config.ForceStopSiteIDs = nil
 	if legacy {
 		config.CacheClearGeneration = 0
 		config.ForceStopSiteIDs = nil
@@ -708,6 +712,32 @@ func agentSupportsCacheClear(version string) bool {
 		return minor > 9
 	}
 	return patch >= 50
+}
+
+// agentSupportsForceStop reports whether an Agent understands the
+// force_stop_site_ids command added in v1.9.65. Older Agents ignore unknown
+// JSON fields, so the Controller must omit this command from their hash until
+// they have upgraded; otherwise they reject an otherwise valid configuration
+// because their locally computed hash has no such field.
+func agentSupportsForceStop(version string) bool {
+	version = strings.TrimSpace(strings.TrimPrefix(version, "v"))
+	parts := strings.Split(version, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	major, errMajor := strconv.Atoi(parts[0])
+	minor, errMinor := strconv.Atoi(parts[1])
+	patch, errPatch := strconv.Atoi(parts[2])
+	if errMajor != nil || errMinor != nil || errPatch != nil {
+		return false
+	}
+	if major != 1 {
+		return major > 1
+	}
+	if minor != 9 {
+		return minor > 9
+	}
+	return patch >= 65
 }
 
 func agentConfigHashForVersion(config AgentRuntimeConfig, version string) (string, error) {
@@ -1356,6 +1386,13 @@ func (a *App) reconcileSiteNodeScheduling(ctx context.Context) {
 	if _, err := a.db.db.Exec("DELETE FROM site_node_drains WHERE expires_at_ms<=?", now.UnixMilli()); err != nil {
 		log.Printf("[node-scheduler] expire node drains: %v", err)
 	}
+	// Revocation tombstones are deliberately retained after an Agent reports
+	// its config as applied so paginated tail telemetry remains authorized. The
+	// same bounded window used for drains is the cleanup boundary; expiry also
+	// removes ForceStop commands from the next config snapshot naturally.
+	if _, err := a.db.db.Exec("DELETE FROM agent_route_revocations WHERE created_at_ms>0 AND created_at_ms+?<=?", siteNodeDrainWindow.Milliseconds(), now.UnixMilli()); err != nil {
+		log.Printf("[node-scheduler] expire Agent route revocations: %v", err)
+	}
 	if _, err := a.db.db.Exec("DELETE FROM site_node_host_aliases WHERE expires_at_ms<=?", now.UnixMilli()); err != nil {
 		log.Printf("[node-scheduler] expire site host aliases: %v", err)
 	}
@@ -1518,32 +1555,15 @@ func (a *App) prepareNodeDeletion(ctx context.Context, nodeID int64) error {
 	if err != nil {
 		return err
 	}
-	drainSites := make(map[int64]struct{})
-	drainRows, drainErr := a.db.db.Query("SELECT site_id FROM site_node_drains WHERE node_id=?", nodeID)
-	if drainErr != nil {
-		return drainErr
-	}
-	for drainRows.Next() {
-		var siteID int64
-		if scanErr := drainRows.Scan(&siteID); scanErr != nil {
-			drainRows.Close()
-			return scanErr
-		}
-		drainSites[siteID] = struct{}{}
-	}
-	if drainErr := drainRows.Err(); drainErr != nil {
-		drainRows.Close()
-		return drainErr
-	}
-	if drainErr := drainRows.Close(); drainErr != nil {
-		return drainErr
-	}
 	affected := make([]SiteNodeSchedule, 0)
 	for _, value := range values {
 		if value.FixedNodeID != nodeID && value.DesiredNodeID != nodeID && value.AppliedNodeID != nodeID {
-			if _, draining := drainSites[value.SiteID]; !draining {
-				continue
-			}
+			// A drain-only row represents a retired generation that no longer
+			// owns the site's current schedule. Deleting that old node must not
+			// disable the site, clear the active assignment, or delete current
+			// DNS on the replacement node. The node row deletion/foreign-key
+			// cleanup is sufficient for the stale drain record itself.
+			continue
 		}
 		affected = append(affected, value)
 	}

--- a/site_repository.go
+++ b/site_repository.go
@@ -800,9 +800,17 @@ func (d *DB) SetSiteEnabled(id int64, enabled bool) error {
 				return err
 			}
 		}
+		// The revocation set includes current and drain-only generations. Mark
+		// that exact set dirty so every Agent receives the ForceStop command
+		// promptly; the site schedule helper only knows desired/applied nodes.
+		if err := markAgentConfigsDirtyForNodeIDsTx(tx, nodeIDs...); err != nil {
+			return err
+		}
 	}
-	if err := markAgentConfigsDirtyForSiteTx(tx, id); err != nil {
-		return err
+	if enabled {
+		if err := markAgentConfigsDirtyForSiteTx(tx, id); err != nil {
+			return err
+		}
 	}
 	return tx.Commit()
 }

--- a/watch_history_test.go
+++ b/watch_history_test.go
@@ -851,6 +851,18 @@ func TestPersistWatchHistoryInboxBatchCommitsAndUsesMetadata(t *testing.T) {
 
 func TestPersistWatchHistoryInboxBatchCommitsPartialBatchAtLimit(t *testing.T) {
 	database := openWatchHistoryTestDB(t)
+	// Stop the asynchronous maintenance writer for this boundary test. The
+	// partial commit is intentionally observed before the inbox consumer can
+	// drain a row, and racing that consumer makes the count assertion depend on
+	// scheduler timing (especially under -race).
+	database.dynamicObservationGate.Lock()
+	database.dynamicObservationClosed.Store(true)
+	database.dynamicObservationGate.Unlock()
+	stopResult := make(chan error, 1)
+	database.dynamicObservationQueue <- dynamicObservationCommand{kind: dynamicObservationCommandStop, result: stopResult}
+	<-stopResult
+	<-database.dynamicObservationDone
+	database.dynamicObservationQueue = nil
 	payload := `{"SiteID":1,"SessionHash":"legacy","ObservedAtMS":1}`
 	tx, err := database.db.Begin()
 	if err != nil {


### PR DESCRIPTION
## Summary
- keep Agent report authorization through bounded telemetry and event drains
- prevent deleting drain-only nodes from disabling current site assignments
- remove ForceStop commands from runtime hashes while retaining revision-triggered apply
- dirty all current and drain generations when disabling a site
- preserve request counts across explicit per-site counter epochs

## Validation
- go test ./...
- go test -race ./...
- go vet ./...
- govulncheck ./...
- gosec
- Node.js tests