### PR TITLE
fix: make Agent route revocations acknowledgement-safe

### DIFF
--- a/database_migrations.go
+++ b/database_migrations.go
@@ -20,7 +20,7 @@ const (
 	// databaseSchemaVersion is independent from the application and backup
 	// format versions. It is persisted in SQLite so restores can reject a
 	// database whose columns/state are newer than this binary understands.
-	databaseSchemaVersion = 43
+	databaseSchemaVersion = 44
 )
 
 func (d *DB) migrate() error {
@@ -452,6 +452,8 @@ func (d *DB) migrateOnce() error {
 		public_host TEXT NOT NULL DEFAULT '',
 		expires_at_ms INTEGER NOT NULL,
 		created_at_ms INTEGER NOT NULL,
+		acked_at_ms INTEGER NOT NULL DEFAULT 0,
+		finalization_expires_at_ms INTEGER NOT NULL DEFAULT 0,
 		PRIMARY KEY(site_id,node_id)
 	);
 	CREATE INDEX IF NOT EXISTS idx_site_node_drains_node_expiry ON site_node_drains(node_id,expires_at_ms);
@@ -481,6 +483,8 @@ func (d *DB) migrateOnce() error {
 		site_id INTEGER NOT NULL,
 		public_host TEXT NOT NULL DEFAULT '',
 		created_at_ms INTEGER NOT NULL,
+		acked_at_ms INTEGER NOT NULL DEFAULT 0,
+		finalization_expires_at_ms INTEGER NOT NULL DEFAULT 0,
 		PRIMARY KEY(node_id,site_id)
 	) WITHOUT ROWID;
 	`); err != nil {
@@ -1190,6 +1194,8 @@ func ensureSiteNodeDrainsSchema(ctx context.Context, conn *sql.Conn) error {
 	defer rows.Close()
 	var sitePK, nodePK int
 	hasPublicHost := false
+	hasAckedAt := false
+	hasFinalizationExpiry := false
 	for rows.Next() {
 		var cid int
 		var name, columnType string
@@ -1205,12 +1211,26 @@ func ensureSiteNodeDrainsSchema(ctx context.Context, conn *sql.Conn) error {
 			nodePK = pk
 		case "public_host":
 			hasPublicHost = true
+		case "acked_at_ms":
+			hasAckedAt = true
+		case "finalization_expires_at_ms":
+			hasFinalizationExpiry = true
 		}
 	}
 	if err := rows.Err(); err != nil {
 		return err
 	}
 	if sitePK == 1 && nodePK == 2 && hasPublicHost {
+		if !hasAckedAt {
+			if _, err := conn.ExecContext(ctx, "ALTER TABLE site_node_drains ADD COLUMN acked_at_ms INTEGER NOT NULL DEFAULT 0"); err != nil {
+				return err
+			}
+		}
+		if !hasFinalizationExpiry {
+			if _, err := conn.ExecContext(ctx, "ALTER TABLE site_node_drains ADD COLUMN finalization_expires_at_ms INTEGER NOT NULL DEFAULT 0"); err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 	if _, err := conn.ExecContext(ctx, `
@@ -1220,10 +1240,12 @@ func ensureSiteNodeDrainsSchema(ctx context.Context, conn *sql.Conn) error {
 			public_host TEXT NOT NULL DEFAULT '',
 			expires_at_ms INTEGER NOT NULL,
 			created_at_ms INTEGER NOT NULL,
+			acked_at_ms INTEGER NOT NULL DEFAULT 0,
+			finalization_expires_at_ms INTEGER NOT NULL DEFAULT 0,
 			PRIMARY KEY(site_id,node_id)
 		);
-		INSERT OR REPLACE INTO site_node_drains_new(site_id,node_id,public_host,expires_at_ms,created_at_ms)
-			SELECT d.site_id,d.node_id,LOWER(TRIM(COALESCE(s.public_host,''))),d.expires_at_ms,d.created_at_ms
+		INSERT OR REPLACE INTO site_node_drains_new(site_id,node_id,public_host,expires_at_ms,created_at_ms,acked_at_ms,finalization_expires_at_ms)
+			SELECT d.site_id,d.node_id,LOWER(TRIM(COALESCE(s.public_host,''))),d.expires_at_ms,d.created_at_ms,0,0
 			FROM site_node_drains d LEFT JOIN sites s ON s.id=d.site_id;
 		DROP TABLE site_node_drains;
 		ALTER TABLE site_node_drains_new RENAME TO site_node_drains;
@@ -1264,6 +1286,16 @@ func ensureAgentRouteRevocationsSchema(ctx context.Context, conn *sql.Conn) erro
 			return err
 		}
 	}
+	if !columns["acked_at_ms"] {
+		if _, err := conn.ExecContext(ctx, "ALTER TABLE agent_route_revocations ADD COLUMN acked_at_ms INTEGER NOT NULL DEFAULT 0"); err != nil {
+			return err
+		}
+	}
+	if !columns["finalization_expires_at_ms"] {
+		if _, err := conn.ExecContext(ctx, "ALTER TABLE agent_route_revocations ADD COLUMN finalization_expires_at_ms INTEGER NOT NULL DEFAULT 0"); err != nil {
+			return err
+		}
+	}
 	// Existing releases declared a sites foreign key. Rebuild the table when
 	// that legacy definition is present; SQLite has no ALTER TABLE DROP FK.
 	fkRows, err := conn.QueryContext(ctx, "PRAGMA foreign_key_list('agent_route_revocations')")
@@ -1298,10 +1330,12 @@ func ensureAgentRouteRevocationsSchema(ctx context.Context, conn *sql.Conn) erro
 			site_id INTEGER NOT NULL,
 			public_host TEXT NOT NULL DEFAULT '',
 			created_at_ms INTEGER NOT NULL,
+			acked_at_ms INTEGER NOT NULL DEFAULT 0,
+			finalization_expires_at_ms INTEGER NOT NULL DEFAULT 0,
 			PRIMARY KEY(node_id,site_id)
 		) WITHOUT ROWID;
-		INSERT OR REPLACE INTO agent_route_revocations_new(node_id,site_id,public_host,created_at_ms)
-			SELECT r.node_id,r.site_id,LOWER(TRIM(COALESCE(r.public_host,s.public_host,''))),r.created_at_ms
+		INSERT OR REPLACE INTO agent_route_revocations_new(node_id,site_id,public_host,created_at_ms,acked_at_ms,finalization_expires_at_ms)
+			SELECT r.node_id,r.site_id,LOWER(TRIM(COALESCE(r.public_host,s.public_host,''))),r.created_at_ms,0,0
 			FROM agent_route_revocations r LEFT JOIN sites s ON s.id=r.site_id;
 		DROP TABLE agent_route_revocations;
 		ALTER TABLE agent_route_revocations_new RENAME TO agent_route_revocations;

--- a/node_repository.go
+++ b/node_repository.go
@@ -1100,7 +1100,7 @@ func authorizedNodeSitesTx(tx *sql.Tx, nodeID, nowMS int64) (map[int64]authorize
 		FROM agent_route_revocations r
 		LEFT JOIN sites s ON s.id=r.site_id
 		WHERE r.node_id=? AND s.id IS NOT NULL
-		  AND (r.created_at_ms<=0 OR r.created_at_ms+? > ?)`, nodeID, siteNodeDrainWindow.Milliseconds(), nowMS)
+		  AND (r.acked_at_ms<=0 OR r.finalization_expires_at_ms<=0 OR r.finalization_expires_at_ms > ?)`, nodeID, nowMS)
 	if err != nil {
 		return nil, err
 	}
@@ -1162,7 +1162,7 @@ func authorizedNodeSitesTx(tx *sql.Tx, nodeID, nowMS int64) (map[int64]authorize
 	// host as an alias so late events from an admitted old bundle remain valid.
 	drainRows, err := tx.Query(`SELECT d.site_id, LOWER(TRIM(d.public_host))
 		FROM site_node_drains d JOIN sites s ON s.id=d.site_id
-		WHERE d.node_id=? AND d.expires_at_ms>?`, nodeID, nowMS)
+		WHERE d.node_id=? AND (d.acked_at_ms<=0 OR d.finalization_expires_at_ms<=0 OR d.finalization_expires_at_ms > ?)`, nodeID, nowMS)
 	if err != nil {
 		return nil, err
 	}
@@ -1524,10 +1524,10 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 	var id, lastSequence, lastRX, lastTX int64
 	var previousApplyFailures int64
 	var cacheClearGeneration int64
-	var lastBootID, lastSessionID, desiredConfigHash, previousApplyError string
+	var lastBootID, lastSessionID, desiredConfigHash, previousApplyError, previousAgentVersion string
 	var configDirty, configRevision, desiredConfigRevision, appliedConfigRevision int64
-	err = tx.QueryRow(`SELECT id,last_sequence,last_raw_rx_bytes,last_raw_tx_bytes,last_boot_id,last_report_session_id,cache_clear_generation,desired_config_hash,config_dirty,agent_apply_error,agent_apply_failures,config_revision,desired_config_revision,applied_config_revision FROM control_nodes WHERE agent_token_hash=?`, hashNodeToken(agentToken)).Scan(
-		&id, &lastSequence, &lastRX, &lastTX, &lastBootID, &lastSessionID, &cacheClearGeneration, &desiredConfigHash, &configDirty, &previousApplyError, &previousApplyFailures, &configRevision, &desiredConfigRevision, &appliedConfigRevision)
+	err = tx.QueryRow(`SELECT id,last_sequence,last_raw_rx_bytes,last_raw_tx_bytes,last_boot_id,last_report_session_id,cache_clear_generation,desired_config_hash,config_dirty,agent_apply_error,agent_apply_failures,config_revision,desired_config_revision,applied_config_revision,agent_version FROM control_nodes WHERE agent_token_hash=?`, hashNodeToken(agentToken)).Scan(
+		&id, &lastSequence, &lastRX, &lastTX, &lastBootID, &lastSessionID, &cacheClearGeneration, &desiredConfigHash, &configDirty, &previousApplyError, &previousApplyFailures, &configRevision, &desiredConfigRevision, &appliedConfigRevision, &previousAgentVersion)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nodeReportCommitResult{}, errInvalidAgentToken
 	}
@@ -1664,10 +1664,29 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 			return nodeReportCommitResult{}, err
 		}
 	}
-	// A matching applied config only acknowledges the runtime transition. It
-	// does not acknowledge every paginated telemetry/event queue. Revocation
-	// tombstones remain available for the bounded drain window and are cleaned
-	// by expiry, preventing late pages from being discarded prematurely.
+	// A matching revision is the Agent's acknowledgement that it received the
+	// complete transition payload. Start the finalization window only then;
+	// commands and drain authorization must survive an offline Agent rather than
+	// expiring from their creation timestamp. Legacy Agents that do not support
+	// ForceStopSiteIDs stay pending and are handled by the scheduler fallback.
+	if clearAppliedConfig && report.AppliedConfigRevision > 0 {
+		ackMS := now.UnixMilli()
+		finalizeMS := now.Add(siteNodeDrainWindow).UnixMilli()
+		if _, err := tx.Exec(`UPDATE site_node_drains SET acked_at_ms=?,finalization_expires_at_ms=?
+			WHERE node_id=? AND acked_at_ms<=0`, ackMS, finalizeMS, id); err != nil {
+			return nodeReportCommitResult{}, err
+		}
+		effectiveAgentVersion := strings.TrimSpace(report.AgentVersion)
+		if effectiveAgentVersion == "" {
+			effectiveAgentVersion = strings.TrimSpace(previousAgentVersion)
+		}
+		if agentSupportsForceStop(effectiveAgentVersion) {
+			if _, err := tx.Exec(`UPDATE agent_route_revocations SET acked_at_ms=?,finalization_expires_at_ms=?
+				WHERE node_id=? AND acked_at_ms<=0`, ackMS, finalizeMS, id); err != nil {
+				return nodeReportCommitResult{}, err
+			}
+		}
+	}
 
 	for _, stat := range report.SiteStats {
 		host := strings.ToLower(strings.TrimSpace(stat.Host))

--- a/review_regression_test.go
+++ b/review_regression_test.go
@@ -583,13 +583,99 @@ func TestReviewCompletedDNSMoveKeepsTailTrafficAuthorizedOnlyDuringDrain(t *test
 	if activeDrains != 1 {
 		t.Fatalf("Final SiteStat retired drain before tail queues were flushed: %d", activeDrains)
 	}
-	if _, err := app.db.db.Exec(`UPDATE site_node_drains SET expires_at_ms=? WHERE site_id=?`, now.Add(-time.Second).UnixMilli(), site.ID); err != nil {
+	if _, err := app.db.db.Exec(`UPDATE site_node_drains SET acked_at_ms=?,finalization_expires_at_ms=? WHERE site_id=?`, now.UnixMilli(), now.Add(-time.Second).UnixMilli(), site.ID); err != nil {
 		t.Fatal(err)
 	}
 	report.Sequence = 2
 	result, err = app.db.RecordNodeReportResult(oldToken, report, now.Add(time.Second))
 	if err != nil || len(result.DiscardedSiteIDs) != 1 || result.DiscardedSiteIDs[0] != site.ID {
 		t.Fatalf("expired drain report=%#v err=%v, want discarded", result, err)
+	}
+}
+
+func TestReviewRevocationAndDrainExpiryStartAfterAgentAck(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now().UTC()
+	node, enrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "ack-lifecycle", Address: "203.0.113.240", Port: 9090}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := app.db.EnrollControlNode(enrollment, now); err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "ack-lifecycle-site", PublicHost: "ack-lifecycle.example.test", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:18080"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec(`UPDATE sites SET enabled=0 WHERE id=?`, site.ID); err != nil {
+		t.Fatal(err)
+	}
+	old := now.Add(-48 * time.Hour).UnixMilli()
+	if _, err := app.db.db.Exec(`INSERT INTO agent_route_revocations(node_id,site_id,public_host,created_at_ms) VALUES(?,?,?,?)`, node.ID, site.ID, site.PublicHost, old); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec(`INSERT INTO site_node_drains(site_id,node_id,public_host,expires_at_ms,created_at_ms) VALUES(?,?,?,?,?)`, site.ID, node.ID, site.PublicHost, old, old); err != nil {
+		t.Fatal(err)
+	}
+	lookup := func(at time.Time) map[int64]authorizedNodeSite {
+		t.Helper()
+		tx, txErr := app.db.db.Begin()
+		if txErr != nil {
+			t.Fatal(txErr)
+		}
+		defer tx.Rollback()
+		allowed, lookupErr := authorizedNodeSitesTx(tx, node.ID, at.UnixMilli())
+		if lookupErr != nil {
+			t.Fatal(lookupErr)
+		}
+		return allowed
+	}
+	if _, ok := lookup(now)[site.ID]; !ok {
+		t.Fatal("unacknowledged revocation/drain was lost based on its old creation time")
+	}
+	ack := now.UnixMilli()
+	finalize := now.Add(siteNodeDrainWindow).UnixMilli()
+	if _, err := app.db.db.Exec(`UPDATE agent_route_revocations SET acked_at_ms=?,finalization_expires_at_ms=? WHERE node_id=? AND site_id=?`, ack, finalize, node.ID, site.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec(`UPDATE site_node_drains SET acked_at_ms=?,finalization_expires_at_ms=? WHERE node_id=? AND site_id=?`, ack, finalize, node.ID, site.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := lookup(now.Add(23 * time.Hour))[site.ID]; !ok {
+		t.Fatal("acked revocation/drain disappeared before finalization window")
+	}
+	if _, ok := lookup(now.Add(25 * time.Hour))[site.ID]; ok {
+		t.Fatal("acked revocation/drain remained after finalization window")
+	}
+}
+
+func TestReviewLegacyForceStopFallbackRevokesOldCredential(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now().UTC()
+	node, enrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "legacy-force-stop", Address: "203.0.113.241", Port: 9090}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, token, err := app.db.EnrollControlNode(enrollment, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "legacy-force-stop-site", PublicHost: "legacy-force-stop.example.test", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:18080"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec(`UPDATE control_nodes SET agent_version=? WHERE id=?`, "v1.9.64", node.ID); err != nil {
+		t.Fatal(err)
+	}
+	created := now.Add(-legacyForceStopGrace - time.Second).UnixMilli()
+	if _, err := app.db.db.Exec(`INSERT INTO agent_route_revocations(node_id,site_id,public_host,created_at_ms) VALUES(?,?,?,?)`, node.ID, site.ID, site.PublicHost, created); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.revokeLegacyAgentsWithPendingForceStops(now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.nodeByAgentToken(token, now); !errors.Is(err, errInvalidAgentToken) {
+		t.Fatalf("legacy Agent credential remained valid after fallback: %v", err)
 	}
 }
 

--- a/site_node_scheduler.go
+++ b/site_node_scheduler.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -31,6 +32,11 @@ const (
 	// the long TTL prevents a long-lived playback from losing billable traffic
 	// while still bounding stale authorization after an Agent disappears.
 	siteNodeDrainWindow = 24 * time.Hour
+	// Legacy Agents do not understand ForceStopSiteIDs. Give an updated Agent
+	// a bounded opportunity to self-upgrade; if it keeps reporting an old (or
+	// unknown) version while a revocation is pending, the whole Agent
+	// credential is revoked so the old data-plane listener cannot drain forever.
+	legacyForceStopGrace = 10 * time.Minute
 )
 
 type SiteNodeSchedule struct {
@@ -809,6 +815,37 @@ func readBoundedPrivateFile(path string) (string, error) {
 	return string(data), nil
 }
 
+// readNodeEdgeCertificatePair snapshots one complete Edge certificate
+// generation. The current directory is resolved once before either file is
+// opened, so cert and key are read from the same immutable generation even if
+// renewal atomically switches the current symlink immediately afterwards. The
+// caller holds nodeTLSMutationMu while constructing a config transaction.
+func (a *App) readNodeEdgeCertificatePair(nodeGUID string) (string, string, error) {
+	if a == nil || a.db == nil || a.panelCertificates == nil {
+		return "", "", errors.New("edge TLS certificate is unavailable")
+	}
+	certFile, keyFile, err := a.panelCertificates.nodeEdgeTLSPaths(nodeGUID)
+	if err != nil {
+		return "", "", err
+	}
+	if resolvedDir, resolveErr := filepath.EvalSymlinks(filepath.Dir(certFile)); resolveErr == nil {
+		certFile = filepath.Join(resolvedDir, filepath.Base(certFile))
+		keyFile = filepath.Join(resolvedDir, filepath.Base(keyFile))
+	}
+	certPEM, err := readBoundedPrivateFile(certFile)
+	if err != nil {
+		return "", "", fmt.Errorf("read edge TLS certificate: %w", err)
+	}
+	keyPEM, err := readBoundedPrivateFile(keyFile)
+	if err != nil {
+		return "", "", fmt.Errorf("read edge TLS private key: %w", err)
+	}
+	if _, err := tls.X509KeyPair([]byte(certPEM), []byte(keyPEM)); err != nil {
+		return "", "", fmt.Errorf("edge TLS certificate/key pair is invalid: %w", err)
+	}
+	return certPEM, keyPEM, nil
+}
+
 func (a *App) buildAgentConfig(token string, now time.Time) (AgentRuntimeConfig, error) {
 	return a.buildAgentConfigForPlatform(token, now, "")
 }
@@ -847,6 +884,12 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 	if _, probeErr := decodeNodeProbeSecret(probeSecretText); probeErr != nil {
 		return AgentRuntimeConfig{}, probeErr
 	}
+	// Keep lock ordering consistent with certificate renewal/cleanup: acquire
+	// the TLS mutation lock before opening the SQLite snapshot transaction. This
+	// prevents a renewal from holding the lock while waiting for the sole DB
+	// connection as this function waits on the same lock.
+	a.db.nodeTLSMutationMu.Lock()
+	defer a.db.nodeTLSMutationMu.Unlock()
 	// Hold one SQLite read/write transaction for the route snapshot and the
 	// desired-hash publication below. This prevents a site edit from being
 	// observed half-way through config construction.
@@ -968,23 +1011,9 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 		return AgentRuntimeConfig{}, err
 	}
 	if len(routes) > 0 {
-		if a.panelCertificates == nil {
-			return AgentRuntimeConfig{}, errors.New("edge TLS certificate is unavailable")
-		}
-		edgeCertFile, edgeKeyFile, pathErr := a.panelCertificates.nodeEdgeTLSPaths(node.GUID)
-		if pathErr != nil {
-			return AgentRuntimeConfig{}, pathErr
-		}
-		config.CertificatePEM, err = readBoundedPrivateFile(edgeCertFile)
+		config.CertificatePEM, config.PrivateKeyPEM, err = a.readNodeEdgeCertificatePair(node.GUID)
 		if err != nil {
-			return AgentRuntimeConfig{}, fmt.Errorf("read edge TLS certificate: %w", err)
-		}
-		config.PrivateKeyPEM, err = readBoundedPrivateFile(edgeKeyFile)
-		if err != nil {
-			return AgentRuntimeConfig{}, fmt.Errorf("read edge TLS private key: %w", err)
-		}
-		if _, err := tls.X509KeyPair([]byte(config.CertificatePEM), []byte(config.PrivateKeyPEM)); err != nil {
-			return AgentRuntimeConfig{}, fmt.Errorf("edge TLS certificate/key pair is invalid: %w", err)
+			return AgentRuntimeConfig{}, err
 		}
 	}
 	config.ConfigHash, err = agentConfigHashForVersion(config, clientVersion)
@@ -1425,15 +1454,18 @@ func (a *App) reconcileOneSiteSchedule(ctx context.Context, schedule SiteNodeSch
 
 func (a *App) reconcileSiteNodeScheduling(ctx context.Context) {
 	now := time.Now()
-	if _, err := a.db.db.Exec("DELETE FROM site_node_drains WHERE expires_at_ms<=?", now.UnixMilli()); err != nil {
+	if _, err := a.db.db.Exec("DELETE FROM site_node_drains WHERE acked_at_ms>0 AND finalization_expires_at_ms>0 AND finalization_expires_at_ms<=?", now.UnixMilli()); err != nil {
 		log.Printf("[node-scheduler] expire node drains: %v", err)
 	}
-	// Revocation tombstones are deliberately retained after an Agent reports
-	// its config as applied so paginated tail telemetry remains authorized. The
-	// same bounded window used for drains is the cleanup boundary; expiry also
-	// removes ForceStop commands from the next config snapshot naturally.
-	if _, err := a.db.db.Exec("DELETE FROM agent_route_revocations WHERE created_at_ms>0 AND created_at_ms+?<=?", siteNodeDrainWindow.Milliseconds(), now.UnixMilli()); err != nil {
+	// Revocation tombstones are retained until the Agent has acknowledged the
+	// exact config revision carrying ForceStop. The finalization window starts
+	// at that acknowledgement, so an offline Agent cannot lose the command just
+	// because a wall-clock TTL elapsed while it was disconnected.
+	if _, err := a.db.db.Exec("DELETE FROM agent_route_revocations WHERE acked_at_ms>0 AND finalization_expires_at_ms>0 AND finalization_expires_at_ms<=?", now.UnixMilli()); err != nil {
 		log.Printf("[node-scheduler] expire Agent route revocations: %v", err)
+	}
+	if err := a.revokeLegacyAgentsWithPendingForceStops(now); err != nil {
+		log.Printf("[node-scheduler] legacy Agent force-stop fallback failed: %v", err)
 	}
 	if _, err := a.db.db.Exec("DELETE FROM site_node_host_aliases WHERE expires_at_ms<=?", now.UnixMilli()); err != nil {
 		log.Printf("[node-scheduler] expire site host aliases: %v", err)
@@ -1479,6 +1511,75 @@ func (a *App) reconcileSiteNodeScheduling(ctx context.Context) {
 			}
 		}
 	}
+}
+
+// revokeLegacyAgentsWithPendingForceStops is the compatibility safety net for
+// Agents older than v1.9.65. They ignore the site-level ForceStop command, so
+// retaining the tombstone alone cannot close an already admitted stream. The
+// Agent gets a bounded self-update grace period; if it still reports an old or
+// unknown version, removing its long-lived credential causes the existing
+// revoked-token path to quiesce the entire legacy listener on its next
+// control-plane request.
+func (a *App) revokeLegacyAgentsWithPendingForceStops(now time.Time) error {
+	if a == nil || a.db == nil || a.db.db == nil {
+		return nil
+	}
+	rows, err := a.db.db.Query(`SELECT DISTINCT n.id,n.agent_version
+		FROM control_nodes n
+		JOIN agent_route_revocations r ON r.node_id=n.id
+		WHERE n.enabled=1 AND n.agent_token_hash<>''
+		  AND r.acked_at_ms<=0
+		  AND r.created_at_ms>0
+		  AND r.created_at_ms+?<=?`, legacyForceStopGrace.Milliseconds(), now.UnixMilli())
+	if err != nil {
+		return err
+	}
+	type candidate struct {
+		id      int64
+		version string
+	}
+	candidates := make([]candidate, 0)
+	for rows.Next() {
+		var value candidate
+		if err := rows.Scan(&value.id, &value.version); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		if !agentSupportsForceStop(value.version) {
+			candidates = append(candidates, value)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return err
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	tx, err := a.db.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	for _, value := range candidates {
+		result, err := tx.Exec(`UPDATE control_nodes SET agent_token_hash='',
+			desired_config_hash='',desired_config_revision=0,config_dirty=1,updated_at_ms=?
+			WHERE id=? AND agent_token_hash<>''`, now.UnixMilli(), value.id)
+		if err != nil {
+			return err
+		}
+		changed, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if changed > 0 {
+			log.Printf("[node-scheduler] revoked legacy Agent credential for node %d pending site force-stop (version=%q)", value.id, strings.TrimSpace(value.version))
+		}
+	}
+	return tx.Commit()
 }
 
 func runSiteNodeScheduler(ctx context.Context, app *App) {


### PR DESCRIPTION
## 变更
- 为 site_node_drains 与 agent_route_revocations 增加 ACK/finalization 生命周期字段，离线 Agent 不会丢失 ForceStop 或尾遥测授权。
- 对不支持站点级 ForceStop 的旧 Agent 增加升级宽限和整节点凭据撤销回退。
- Edge TLS cert/key 读取固定到同一 generation，并与 TLS mutation 生命周期保持一致。

## 验证
- go test ./...
- go vet ./...
- go test -race -run 'TestReview(RevocationAndDrainExpiryStartAfterAgentAck|LegacyForceStopFallbackRevokesOldCredential|CompletedDNSMoveKeepsTailTrafficAuthorizedOnlyDuringDrain)$'