### PR TITLE
fix: complete agent lifecycle acknowledgements

### DIFF
--- a/database_migrations.go
+++ b/database_migrations.go
@@ -20,7 +20,7 @@ const (
 	// databaseSchemaVersion is independent from the application and backup
 	// format versions. It is persisted in SQLite so restores can reject a
 	// database whose columns/state are newer than this binary understands.
-	databaseSchemaVersion = 44
+	databaseSchemaVersion = 45
 )
 
 func (d *DB) migrate() error {
@@ -457,15 +457,18 @@ func (d *DB) migrateOnce() error {
 		PRIMARY KEY(site_id,node_id)
 	);
 	CREATE INDEX IF NOT EXISTS idx_site_node_drains_node_expiry ON site_node_drains(node_id,expires_at_ms);
-	-- Former public hosts remain accepted for a short period while an Agent
-	-- drains a previously applied route. This is separate from DNS/node drains
-	-- because a site rename can happen without a node move.
+	-- Former public hosts remain accepted until the Agent acknowledges the
+	-- replacement configuration, followed by a bounded finalization window.
+	-- This is separate from DNS/node drains because a site rename can happen
+	-- without a node move.
 	CREATE TABLE IF NOT EXISTS site_node_host_aliases (
 		site_id INTEGER NOT NULL REFERENCES sites(id) ON DELETE CASCADE,
 		node_id INTEGER NOT NULL REFERENCES control_nodes(id) ON DELETE CASCADE,
 		public_host TEXT NOT NULL,
 		expires_at_ms INTEGER NOT NULL,
 		created_at_ms INTEGER NOT NULL,
+		acked_at_ms INTEGER NOT NULL DEFAULT 0,
+		finalization_expires_at_ms INTEGER NOT NULL DEFAULT 0,
 		PRIMARY KEY(site_id,node_id,public_host)
 	);
 	CREATE INDEX IF NOT EXISTS idx_site_node_host_aliases_node_expiry ON site_node_host_aliases(node_id,expires_at_ms);
@@ -854,6 +857,9 @@ func (d *DB) migrateOnce() error {
 		return err
 	}
 	if err := ensureAgentRouteRevocationsSchema(ctx, conn); err != nil {
+		return err
+	}
+	if err := ensureSiteNodeHostAliasesSchema(ctx, conn); err != nil {
 		return err
 	}
 	var eventUIDColumnCount int
@@ -1252,6 +1258,44 @@ func ensureSiteNodeDrainsSchema(ctx context.Context, conn *sql.Conn) error {
 		CREATE INDEX IF NOT EXISTS idx_site_node_drains_node_expiry ON site_node_drains(node_id,expires_at_ms);
 	`); err != nil {
 		return fmt.Errorf("migrate site node drain ledger: %w", err)
+	}
+	return nil
+}
+
+// ensureSiteNodeHostAliasesSchema upgrades host-rename aliases to the same
+// acknowledgement-safe lifecycle used by node drains. Existing aliases stay
+// pending until an Agent confirms the configuration that contains the new
+// host; only then does their finalization window begin.
+func ensureSiteNodeHostAliasesSchema(ctx context.Context, conn *sql.Conn) error {
+	addedLifecycle := false
+	for _, migration := range []struct {
+		column string
+		sql    string
+	}{
+		{"acked_at_ms", "ALTER TABLE site_node_host_aliases ADD COLUMN acked_at_ms INTEGER NOT NULL DEFAULT 0"},
+		{"finalization_expires_at_ms", "ALTER TABLE site_node_host_aliases ADD COLUMN finalization_expires_at_ms INTEGER NOT NULL DEFAULT 0"},
+	} {
+		var found int
+		if err := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM pragma_table_info('site_node_host_aliases') WHERE name=?", migration.column).Scan(&found); err != nil {
+			return err
+		}
+		if found != 0 {
+			continue
+		}
+		if _, err := conn.ExecContext(ctx, migration.sql); err != nil {
+			return err
+		}
+		addedLifecycle = true
+	}
+	if addedLifecycle {
+		// Aliases created by pre-45 releases already had a creation-time TTL.
+		// Preserve that historical deadline during the one-time migration rather
+		// than turning old rows into immortal, unacknowledged aliases.
+		if _, err := conn.ExecContext(ctx, `UPDATE site_node_host_aliases
+			SET acked_at_ms=created_at_ms,finalization_expires_at_ms=expires_at_ms
+			WHERE acked_at_ms=0 AND finalization_expires_at_ms=0`); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/node_repository.go
+++ b/node_repository.go
@@ -597,10 +597,9 @@ func nullableNodeID(id int64) interface{} {
 	return id
 }
 
-// markAgentConfigsDirtyTx invalidates runtime snapshots for enrolled Agents.
-// Site and scheduler edits can change the route set of whichever node is
-// currently selected, so keeping a single durable dirty bit per node is safer
-// than relying on the next 60-second poll to discover the change.
+// markAgentConfigsDirtyTx invalidates runtime snapshots for every enrolled
+// Agent. Enrollment and scheduling eligibility are separate concerns: a
+// disabled Agent may still need a route-removal or force-stop command.
 func markAgentConfigsDirtyTx(tx *sql.Tx) error {
 	if tx == nil {
 		return errors.New("nil database transaction")
@@ -611,7 +610,7 @@ func markAgentConfigsDirtyTx(tx *sql.Tx) error {
 		desired_config_revision=0,
 		config_dirty=1,
 		updated_at_ms=?
-		WHERE enabled=1 AND agent_token_hash<>''`, time.Now().UnixMilli())
+		WHERE agent_token_hash<>''`, time.Now().UnixMilli())
 	return err
 }
 
@@ -644,7 +643,7 @@ func markAgentConfigsDirtyForNodeIDsTx(tx *sql.Tx, nodeIDs ...int64) error {
 		desired_config_revision=0,
 		config_dirty=1,
 		updated_at_ms=?
-		WHERE enabled=1 AND agent_token_hash<>'' AND id IN (`+strings.Join(placeholders, ",")+")", args...)
+		WHERE agent_token_hash<>'' AND id IN (`+strings.Join(placeholders, ",")+")", args...)
 	return err
 }
 
@@ -1125,12 +1124,14 @@ func authorizedNodeSitesTx(tx *sql.Tx, nodeID, nowMS int64) (map[int64]authorize
 	if err := revocationRows.Close(); err != nil {
 		return nil, err
 	}
-	// Public-host renames do not create DNS drain rows. Keep old hosts as
-	// bounded aliases so events buffered by an Agent remain valid for the same
-	// site without widening authorization to another site.
+	// Public-host renames do not create DNS drain rows. Keep old hosts pending
+	// until the replacement config is acknowledged, then retain them only for
+	// the bounded finalization window so offline Agents do not lose buffered
+	// events without widening authorization to another site.
 	aliasRows, err := tx.Query(`SELECT site_id, LOWER(TRIM(public_host))
 		FROM site_node_host_aliases
-		WHERE node_id=? AND expires_at_ms>?`, nodeID, nowMS)
+		WHERE node_id=?
+		  AND (acked_at_ms<=0 OR finalization_expires_at_ms<=0 OR finalization_expires_at_ms>?)`, nodeID, nowMS)
 	if err != nil {
 		return nil, err
 	}
@@ -1685,6 +1686,10 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 				WHERE node_id=? AND acked_at_ms<=0`, ackMS, finalizeMS, id); err != nil {
 				return nodeReportCommitResult{}, err
 			}
+		}
+		if _, err := tx.Exec(`UPDATE site_node_host_aliases SET acked_at_ms=?,finalization_expires_at_ms=?
+			WHERE node_id=? AND acked_at_ms<=0`, ackMS, finalizeMS, id); err != nil {
+			return nodeReportCommitResult{}, err
 		}
 	}
 

--- a/review_regression_test.go
+++ b/review_regression_test.go
@@ -775,6 +775,165 @@ func TestReviewDisablingSiteDirtiesCurrentAndDrainNodes(t *testing.T) {
 	}
 }
 
+func TestReviewDisabledNodeForceStopInvalidation(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now().UTC()
+	node, enrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "disabled-force-stop", Address: "203.0.113.242", Port: 9090}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := app.db.EnrollControlNode(enrollment, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec(`UPDATE control_nodes SET enabled=0,config_revision=7,config_dirty=0 WHERE id=?`, node.ID); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := app.db.db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := markAgentConfigsDirtyForNodeIDsTx(tx, node.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	var revision, dirty int64
+	if err := app.db.db.QueryRow(`SELECT config_revision,config_dirty FROM control_nodes WHERE id=?`, node.ID).Scan(&revision, &dirty); err != nil {
+		t.Fatal(err)
+	}
+	if revision != 8 || dirty != 1 {
+		t.Fatalf("disabled enrolled Agent was not invalidated: revision=%d dirty=%d", revision, dirty)
+	}
+}
+
+func TestReviewLegacyDisabledNodeForceStopFallback(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now().UTC()
+	node, enrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "legacy-disabled-force-stop", Address: "203.0.113.243", Port: 9090}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, token, err := app.db.EnrollControlNode(enrollment, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "legacy-disabled-site", PublicHost: "legacy-disabled.example.test", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:18080"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	created := now.Add(-legacyForceStopGrace - time.Second).UnixMilli()
+	if _, err := app.db.db.Exec(`UPDATE control_nodes SET enabled=0,agent_version=? WHERE id=?`, "v1.9.64", node.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec(`INSERT INTO agent_route_revocations(node_id,site_id,public_host,created_at_ms) VALUES(?,?,?,?)`, node.ID, site.ID, site.PublicHost, created); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.revokeLegacyAgentsWithPendingForceStops(now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.nodeByAgentToken(token, now); !errors.Is(err, errInvalidAgentToken) {
+		t.Fatalf("disabled legacy Agent credential remained valid after fallback: %v", err)
+	}
+}
+
+func TestReviewDrainLifecycleResetsOnABABTransition(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now().UTC()
+	node, _, err := app.db.CreateControlNode(NodeCreateInput{Name: "drain-reused", Address: "203.0.113.244", Port: 9090}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "drain-reused-site", PublicHost: "drain-reused.example.test", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:18080"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ack := now.Add(-23 * time.Hour)
+	if _, err := app.db.db.Exec(`INSERT INTO site_node_drains(site_id,node_id,public_host,expires_at_ms,created_at_ms,acked_at_ms,finalization_expires_at_ms) VALUES(?,?,?,?,?,?,?)`, site.ID, node.ID, site.PublicHost, ack.Add(siteNodeDrainWindow).UnixMilli(), now.Add(-24*time.Hour).UnixMilli(), ack.UnixMilli(), ack.Add(siteNodeDrainWindow).UnixMilli()); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := app.db.db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertSiteNodeDrainTx(tx, site.ID, node.ID, site.PublicHost, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	var gotAck, gotFinal int64
+	if err := app.db.db.QueryRow(`SELECT acked_at_ms,finalization_expires_at_ms FROM site_node_drains WHERE site_id=? AND node_id=?`, site.ID, node.ID).Scan(&gotAck, &gotFinal); err != nil {
+		t.Fatal(err)
+	}
+	if gotAck != 0 || gotFinal != 0 {
+		t.Fatalf("reused drain inherited prior lifecycle: ack=%d final=%d", gotAck, gotFinal)
+	}
+}
+
+func TestReviewHostAliasLifecycleStartsOnConfigAck(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now().UTC()
+	node, enrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "host-alias-lifecycle", Address: "203.0.113.245", Port: 9090}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, token, err := app.db.EnrollControlNode(enrollment, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "host-alias-site", PublicHost: "new-host.example.test", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:18080"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.SaveSiteNodeSchedule(site.ID, true, "fixed", node.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec(`UPDATE site_node_schedules SET desired_node_id=?,applied_node_id=?,config_hash=? WHERE site_id=?`, node.ID, node.ID, "alias-config", site.ID); err != nil {
+		t.Fatal(err)
+	}
+	oldHost := "old-host.example.test"
+	if _, err := app.db.db.Exec(`INSERT INTO site_node_host_aliases(site_id,node_id,public_host,expires_at_ms,created_at_ms,acked_at_ms,finalization_expires_at_ms) VALUES(?,?,?,?,?,?,?)`, site.ID, node.ID, oldHost, now.Add(-time.Hour).UnixMilli(), now.Add(-48*time.Hour).UnixMilli(), 0, 0); err != nil {
+		t.Fatal(err)
+	}
+	lookup := func(at time.Time) bool {
+		t.Helper()
+		tx, txErr := app.db.db.Begin()
+		if txErr != nil {
+			t.Fatal(txErr)
+		}
+		defer tx.Rollback()
+		allowed, lookupErr := authorizedNodeSitesTx(tx, node.ID, at.UnixMilli())
+		if lookupErr != nil {
+			t.Fatal(lookupErr)
+		}
+		return authorizedNodeSiteHost(allowed, site.ID, oldHost)
+	}
+	if !lookup(now.Add(48 * time.Hour)) {
+		t.Fatal("unacknowledged host alias expired from creation-time TTL")
+	}
+	if _, err := app.db.db.Exec(`UPDATE control_nodes SET config_revision=3,desired_config_revision=3,desired_config_hash=?,applied_config_hash='' WHERE id=?`, "alias-config", node.ID); err != nil {
+		t.Fatal(err)
+	}
+	report := NodeReport{BootID: "alias-boot", ReportSessionID: "alias-session", CounterEpoch: "alias-epoch", AppliedConfigHash: "alias-config", AppliedConfigRevision: 3, AgentVersion: "v1.9.69", Sequence: 1, InterfaceName: "eth0"}
+	if _, err := app.db.RecordNodeReportResult(token, report, now); err != nil {
+		t.Fatal(err)
+	}
+	var acked, finalized int64
+	if err := app.db.db.QueryRow(`SELECT acked_at_ms,finalization_expires_at_ms FROM site_node_host_aliases WHERE site_id=? AND node_id=?`, site.ID, node.ID).Scan(&acked, &finalized); err != nil {
+		t.Fatal(err)
+	}
+	if acked != now.UnixMilli() || finalized != now.Add(siteNodeDrainWindow).UnixMilli() {
+		t.Fatalf("host alias lifecycle did not start on ACK: ack=%d final=%d", acked, finalized)
+	}
+	if !lookup(now.Add(23 * time.Hour)) {
+		t.Fatal("acked host alias disappeared before finalization")
+	}
+	if lookup(now.Add(25 * time.Hour)) {
+		t.Fatal("acked host alias remained after finalization")
+	}
+}
+
 func TestReviewScheduledSiteRemovalInvalidatesOwningAgent(t *testing.T) {
 	app := newTestApp(t)
 	now := time.Now().UTC()

--- a/site_node_scheduler.go
+++ b/site_node_scheduler.go
@@ -1431,9 +1431,7 @@ func (a *App) reconcileOneSiteSchedule(ctx context.Context, schedule SiteNodeSch
 	defer tx.Rollback()
 	if schedule.AppliedNodeID != node.ID {
 		if schedule.AppliedNodeID > 0 {
-			if _, err = tx.Exec(`INSERT INTO site_node_drains(site_id,node_id,public_host,expires_at_ms,created_at_ms) VALUES(?,?,?,?,?)
-				ON CONFLICT(site_id,node_id) DO UPDATE SET public_host=excluded.public_host,expires_at_ms=excluded.expires_at_ms,created_at_ms=excluded.created_at_ms`,
-				schedule.SiteID, schedule.AppliedNodeID, strings.ToLower(strings.TrimSpace(schedule.PublicHost)), now.Add(siteNodeDrainWindow).UnixMilli(), now.UnixMilli()); err != nil {
+			if err = upsertSiteNodeDrainTx(tx, schedule.SiteID, schedule.AppliedNodeID, schedule.PublicHost, now); err != nil {
 				return err
 			}
 		}
@@ -1452,6 +1450,19 @@ func (a *App) reconcileOneSiteSchedule(ctx context.Context, schedule SiteNodeSch
 	return nil
 }
 
+// upsertSiteNodeDrainTx starts a fresh lifecycle whenever a site returns to a
+// node that has drained an earlier generation. ACK/finalization timestamps are
+// generation state and must never be inherited through the (site,node) key.
+func upsertSiteNodeDrainTx(tx *sql.Tx, siteID, nodeID int64, publicHost string, now time.Time) error {
+	if tx == nil || siteID <= 0 || nodeID <= 0 {
+		return nil
+	}
+	_, err := tx.Exec(`INSERT INTO site_node_drains(site_id,node_id,public_host,expires_at_ms,created_at_ms,acked_at_ms,finalization_expires_at_ms) VALUES(?,?,?,?,?,?,?)
+		ON CONFLICT(site_id,node_id) DO UPDATE SET public_host=excluded.public_host,expires_at_ms=excluded.expires_at_ms,created_at_ms=excluded.created_at_ms,acked_at_ms=0,finalization_expires_at_ms=0`,
+		siteID, nodeID, strings.ToLower(strings.TrimSpace(publicHost)), now.Add(siteNodeDrainWindow).UnixMilli(), now.UnixMilli(), 0, 0)
+	return err
+}
+
 func (a *App) reconcileSiteNodeScheduling(ctx context.Context) {
 	now := time.Now()
 	if _, err := a.db.db.Exec("DELETE FROM site_node_drains WHERE acked_at_ms>0 AND finalization_expires_at_ms>0 AND finalization_expires_at_ms<=?", now.UnixMilli()); err != nil {
@@ -1467,7 +1478,7 @@ func (a *App) reconcileSiteNodeScheduling(ctx context.Context) {
 	if err := a.revokeLegacyAgentsWithPendingForceStops(now); err != nil {
 		log.Printf("[node-scheduler] legacy Agent force-stop fallback failed: %v", err)
 	}
-	if _, err := a.db.db.Exec("DELETE FROM site_node_host_aliases WHERE expires_at_ms<=?", now.UnixMilli()); err != nil {
+	if _, err := a.db.db.Exec("DELETE FROM site_node_host_aliases WHERE acked_at_ms>0 AND finalization_expires_at_ms>0 AND finalization_expires_at_ms<=?", now.UnixMilli()); err != nil {
 		log.Printf("[node-scheduler] expire site host aliases: %v", err)
 	}
 	if err := a.db.retryNodeTLSCleanup(""); err != nil {
@@ -1527,7 +1538,7 @@ func (a *App) revokeLegacyAgentsWithPendingForceStops(now time.Time) error {
 	rows, err := a.db.db.Query(`SELECT DISTINCT n.id,n.agent_version
 		FROM control_nodes n
 		JOIN agent_route_revocations r ON r.node_id=n.id
-		WHERE n.enabled=1 AND n.agent_token_hash<>''
+		WHERE n.agent_token_hash<>''
 		  AND r.acked_at_ms<=0
 		  AND r.created_at_ms>0
 		  AND r.created_at_ms+?<=?`, legacyForceStopGrace.Milliseconds(), now.UnixMilli())

--- a/site_repository.go
+++ b/site_repository.go
@@ -618,9 +618,9 @@ func (d *DB) updateSiteRecord(site Site, restoreRevision bool) error {
 				continue
 			}
 			seenNodes[nodeID] = struct{}{}
-			if _, execErr := tx.Exec(`INSERT INTO site_node_host_aliases(site_id,node_id,public_host,expires_at_ms,created_at_ms)
-				VALUES(?,?,?,?,?) ON CONFLICT(site_id,node_id,public_host) DO UPDATE SET expires_at_ms=excluded.expires_at_ms,created_at_ms=excluded.created_at_ms`,
-				site.ID, nodeID, oldHost, nowAlias.Add(siteNodeDrainWindow).UnixMilli(), nowAlias.UnixMilli()); execErr != nil {
+			if _, execErr := tx.Exec(`INSERT INTO site_node_host_aliases(site_id,node_id,public_host,expires_at_ms,created_at_ms,acked_at_ms,finalization_expires_at_ms)
+				VALUES(?,?,?,?,?,?,?) ON CONFLICT(site_id,node_id,public_host) DO UPDATE SET expires_at_ms=excluded.expires_at_ms,created_at_ms=excluded.created_at_ms,acked_at_ms=0,finalization_expires_at_ms=0`,
+				site.ID, nodeID, oldHost, nowAlias.Add(siteNodeDrainWindow).UnixMilli(), nowAlias.UnixMilli(), 0, 0); execErr != nil {
 				return execErr
 			}
 		}


### PR DESCRIPTION
## 修复内容

- 让已注册但已禁用的 Agent 仍能收到配置失效和 force-stop 指令。
- 修复站点节点 A→B→A→B 迁移时复用旧 drain 记录导致 ACK 生命周期继承的问题。
- 将旧主机别名改为等待 Agent ACK 后再进入有限 finalization 窗口，避免离线 Agent 丢失缓存遥测和事件。
- 为旧数据库增加 host alias 生命周期字段并提升 schema 版本。

## 验证

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `node --test tests/*.test.js`
- `git diff --check`
