### PR TITLE
fix: preserve drain generations and alias migration state

### DIFF
--- a/database_migrations.go
+++ b/database_migrations.go
@@ -20,7 +20,7 @@ const (
 	// databaseSchemaVersion is independent from the application and backup
 	// format versions. It is persisted in SQLite so restores can reject a
 	// database whose columns/state are newer than this binary understands.
-	databaseSchemaVersion = 45
+	databaseSchemaVersion = 46
 )
 
 func (d *DB) migrate() error {
@@ -862,6 +862,20 @@ func (d *DB) migrateOnce() error {
 	if err := ensureSiteNodeHostAliasesSchema(ctx, conn); err != nil {
 		return err
 	}
+	// Schema 45 briefly treated legacy host aliases as acknowledged during
+	// migration. That could expire an offline Agent's old-host authorization
+	// before it delivered its final buffered events. Schema 46 repairs only the
+	// values written by that migration; genuinely acknowledged aliases retain
+	// their lifecycle, while repaired rows remain pending until a real config
+	// acknowledgement is recorded.
+	if previousSchemaVersion == 45 {
+		if _, err := conn.ExecContext(ctx, `UPDATE site_node_host_aliases
+			SET acked_at_ms=0,finalization_expires_at_ms=0
+			WHERE acked_at_ms=created_at_ms
+			  AND finalization_expires_at_ms=expires_at_ms`); err != nil {
+			return err
+		}
+	}
 	var eventUIDColumnCount int
 	if err := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM pragma_table_info('node_request_events') WHERE name=?", "event_uid").Scan(&eventUIDColumnCount); err != nil {
 		return err
@@ -1267,7 +1281,6 @@ func ensureSiteNodeDrainsSchema(ctx context.Context, conn *sql.Conn) error {
 // pending until an Agent confirms the configuration that contains the new
 // host; only then does their finalization window begin.
 func ensureSiteNodeHostAliasesSchema(ctx context.Context, conn *sql.Conn) error {
-	addedLifecycle := false
 	for _, migration := range []struct {
 		column string
 		sql    string
@@ -1283,17 +1296,6 @@ func ensureSiteNodeHostAliasesSchema(ctx context.Context, conn *sql.Conn) error 
 			continue
 		}
 		if _, err := conn.ExecContext(ctx, migration.sql); err != nil {
-			return err
-		}
-		addedLifecycle = true
-	}
-	if addedLifecycle {
-		// Aliases created by pre-45 releases already had a creation-time TTL.
-		// Preserve that historical deadline during the one-time migration rather
-		// than turning old rows into immortal, unacknowledged aliases.
-		if _, err := conn.ExecContext(ctx, `UPDATE site_node_host_aliases
-			SET acked_at_ms=created_at_ms,finalization_expires_at_ms=expires_at_ms
-			WHERE acked_at_ms=0 AND finalization_expires_at_ms=0`); err != nil {
 			return err
 		}
 	}

--- a/review_regression_test.go
+++ b/review_regression_test.go
@@ -871,6 +871,121 @@ func TestReviewDrainLifecycleResetsOnABABTransition(t *testing.T) {
 	}
 }
 
+func TestReviewDrainPreservesMultipleHostGenerations(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now().UTC()
+	node, _, err := app.db.CreateControlNode(NodeCreateInput{Name: "drain-generations", Address: "203.0.113.246", Port: 9090}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "drain-generations-site", PublicHost: "h3.example.test", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:18080"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.SaveSiteNodeSchedule(site.ID, true, "fixed", node.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec(`UPDATE site_node_schedules SET desired_node_id=?,applied_node_id=? WHERE site_id=?`, node.ID, node.ID, site.ID); err != nil {
+		t.Fatal(err)
+	}
+	upsert := func(host string, at time.Time) {
+		t.Helper()
+		tx, txErr := app.db.db.Begin()
+		if txErr != nil {
+			t.Fatal(txErr)
+		}
+		if err := upsertSiteNodeDrainTx(tx, site.ID, node.ID, host, at); err != nil {
+			tx.Rollback()
+			t.Fatal(err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	upsert("h1.example.test", now)
+	upsert("h2.example.test", now.Add(time.Minute))
+	upsert("h3.example.test", now.Add(2*time.Minute))
+
+	var drainHost string
+	if err := app.db.db.QueryRow("SELECT public_host FROM site_node_drains WHERE site_id=? AND node_id=?", site.ID, node.ID).Scan(&drainHost); err != nil {
+		t.Fatal(err)
+	}
+	if drainHost != "h3.example.test" {
+		t.Fatalf("latest drain host=%q, want h3.example.test", drainHost)
+	}
+	rows, err := app.db.db.Query("SELECT public_host,acked_at_ms,finalization_expires_at_ms FROM site_node_host_aliases WHERE site_id=? AND node_id=? ORDER BY public_host", site.ID, node.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	seen := make(map[string][2]int64)
+	for rows.Next() {
+		var host string
+		var acked, finalized int64
+		if err := rows.Scan(&host, &acked, &finalized); err != nil {
+			t.Fatal(err)
+		}
+		seen[host] = [2]int64{acked, finalized}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	for _, host := range []string{"h1.example.test", "h2.example.test"} {
+		lifecycle, ok := seen[host]
+		if !ok {
+			t.Fatalf("missing preserved drain generation %q", host)
+		}
+		if lifecycle != [2]int64{} {
+			t.Fatalf("generation %q unexpectedly acknowledged: %#v", host, lifecycle)
+		}
+	}
+	tx, err := app.db.db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	allowed, err := authorizedNodeSitesTx(tx, node.ID, now.Add(3*time.Minute).UnixMilli())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, host := range []string{"h1.example.test", "h2.example.test", "h3.example.test"} {
+		if !authorizedNodeSiteHost(allowed, site.ID, host) {
+			t.Fatalf("host generation %q was not authorized", host)
+		}
+	}
+}
+
+func TestReviewSchema46RepairsLegacyAliasLifecycle(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now().UTC()
+	node, _, err := app.db.CreateControlNode(NodeCreateInput{Name: "alias-migration", Address: "203.0.113.247", Port: 9090}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "alias-migration-site", PublicHost: "new-alias.example.test", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:18080"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	created := now.Add(-time.Hour).UnixMilli()
+	expires := now.Add(-time.Minute).UnixMilli()
+	if _, err := app.db.db.Exec(`INSERT INTO site_node_host_aliases(site_id,node_id,public_host,expires_at_ms,created_at_ms,acked_at_ms,finalization_expires_at_ms) VALUES(?,?,?,?,?,?,?)`, site.ID, node.ID, "old-alias.example.test", expires, created, created, expires); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec("PRAGMA user_version = 45"); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.db.migrate(); err != nil {
+		t.Fatal(err)
+	}
+	var acked, finalized int64
+	if err := app.db.db.QueryRow(`SELECT acked_at_ms,finalization_expires_at_ms FROM site_node_host_aliases WHERE site_id=? AND node_id=?`, site.ID, node.ID).Scan(&acked, &finalized); err != nil {
+		t.Fatal(err)
+	}
+	if acked != 0 || finalized != 0 {
+		t.Fatalf("schema 46 did not repair legacy alias lifecycle: ack=%d final=%d", acked, finalized)
+	}
+}
+
 func TestReviewHostAliasLifecycleStartsOnConfigAck(t *testing.T) {
 	app := newTestApp(t)
 	now := time.Now().UTC()

--- a/site_node_scheduler.go
+++ b/site_node_scheduler.go
@@ -1457,9 +1457,31 @@ func upsertSiteNodeDrainTx(tx *sql.Tx, siteID, nodeID int64, publicHost string, 
 	if tx == nil || siteID <= 0 || nodeID <= 0 {
 		return nil
 	}
+	normalizedHost := strings.ToLower(strings.TrimSpace(publicHost))
+	// The drain table keeps the latest generation for a (site,node) pair for
+	// compatibility with existing databases. Before replacing that row, retain
+	// its host and acknowledgement lifecycle as a site-scoped alias. This
+	// preserves every older generation in the alias ledger during rapid
+	// A→B→A→B transitions, so late events from any admitted bundle remain
+	// authorized until the corresponding acknowledgement/finalization window.
+	var previousHost string
+	var previousExpires, previousCreated, previousAcked, previousFinalization int64
+	lookupErr := tx.QueryRow(`SELECT public_host,expires_at_ms,created_at_ms,acked_at_ms,finalization_expires_at_ms
+		FROM site_node_drains WHERE site_id=? AND node_id=?`, siteID, nodeID).
+		Scan(&previousHost, &previousExpires, &previousCreated, &previousAcked, &previousFinalization)
+	if lookupErr != nil && !errors.Is(lookupErr, sql.ErrNoRows) {
+		return lookupErr
+	}
+	if lookupErr == nil && strings.TrimSpace(previousHost) != "" && !strings.EqualFold(strings.TrimSpace(previousHost), normalizedHost) {
+		if _, err := tx.Exec(`INSERT INTO site_node_host_aliases(site_id,node_id,public_host,expires_at_ms,created_at_ms,acked_at_ms,finalization_expires_at_ms)
+			VALUES(?,?,?,?,?,?,?) ON CONFLICT(site_id,node_id,public_host) DO NOTHING`,
+			siteID, nodeID, strings.ToLower(strings.TrimSpace(previousHost)), previousExpires, previousCreated, previousAcked, previousFinalization); err != nil {
+			return err
+		}
+	}
 	_, err := tx.Exec(`INSERT INTO site_node_drains(site_id,node_id,public_host,expires_at_ms,created_at_ms,acked_at_ms,finalization_expires_at_ms) VALUES(?,?,?,?,?,?,?)
 		ON CONFLICT(site_id,node_id) DO UPDATE SET public_host=excluded.public_host,expires_at_ms=excluded.expires_at_ms,created_at_ms=excluded.created_at_ms,acked_at_ms=0,finalization_expires_at_ms=0`,
-		siteID, nodeID, strings.ToLower(strings.TrimSpace(publicHost)), now.Add(siteNodeDrainWindow).UnixMilli(), now.UnixMilli(), 0, 0)
+		siteID, nodeID, normalizedHost, now.Add(siteNodeDrainWindow).UnixMilli(), now.UnixMilli(), 0, 0)
 	return err
 }
 


### PR DESCRIPTION
## Changes

- preserve replaced drain generations as host aliases across rapid site/node transitions
- keep legacy host aliases pending until a real Agent configuration acknowledgement
- repair schema 45 alias lifecycle values during schema 46 migration
- add regression coverage for multi-generation authorization and migration repair

## Validation

- go test ./...
- go test -race -count=1 ./...
- go vet ./...
- node --test tests/*.test.js