### PR TITLE
Fix site rollback and dashboard state

### DIFF
--- a/app_sites.go
+++ b/app_sites.go
@@ -567,6 +567,11 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 			a.jsonErr(w, 404, "site not found")
 			return
 		}
+		oldSiteSnapshot, err := a.db.snapshotSiteUpdate(*oldSite)
+		if err != nil {
+			a.jsonErr(w, http.StatusInternalServerError, fmt.Sprintf("snapshot site before update: %v", err))
+			return
+		}
 		var req struct {
 			Name                       string                 `json:"name"`
 			IconName                   *string                `json:"icon_name"`
@@ -980,7 +985,7 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 			// never points at a configuration that never ran, then bring the
 			// pre-stopped instance back from a fresh read. Any failure in the
 			// rollback itself is reported explicitly.
-			if rollbackErr := a.db.restoreSiteRecord(*oldSite); rollbackErr != nil {
+			if rollbackErr := a.db.restoreSiteSnapshot(oldSiteSnapshot); rollbackErr != nil {
 				a.jsonErr(w, 500, fmt.Sprintf("reload updated site: %v; rollback update: %v", err, rollbackErr))
 				return
 			}
@@ -1000,7 +1005,7 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 		}
 		if site.Enabled {
 			if err := a.pm.StartSite(*site); err != nil {
-				if rollbackErr := a.db.restoreSiteRecord(*oldSite); rollbackErr != nil {
+				if rollbackErr := a.db.restoreSiteSnapshot(oldSiteSnapshot); rollbackErr != nil {
 					a.jsonErr(w, 500, fmt.Sprintf("start updated site: %v; rollback update: %v", err, rollbackErr))
 					return
 				}
@@ -1019,7 +1024,7 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		} else if err := a.pm.RegisterSiteHost(*site); err != nil {
-			if rollbackErr := a.db.restoreSiteRecord(*oldSite); rollbackErr != nil {
+			if rollbackErr := a.db.restoreSiteSnapshot(oldSiteSnapshot); rollbackErr != nil {
 				a.jsonErr(w, 500, fmt.Sprintf("register updated public host: %v; rollback update: %v", err, rollbackErr))
 				return
 			}

--- a/review_regression_test.go
+++ b/review_regression_test.go
@@ -1049,6 +1049,61 @@ func TestReviewHostAliasLifecycleStartsOnConfigAck(t *testing.T) {
 	}
 }
 
+func TestReviewFailedSiteHostUpdateRestoresAliasSnapshot(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now().UTC()
+	node, _, err := app.db.CreateControlNode(NodeCreateInput{Name: "rollback-alias-node", Address: "203.0.113.246", Port: 9090}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "rollback-alias-site", PublicHost: "stable.example.test", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:18080"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.SaveSiteNodeSchedule(site.ID, true, "fixed", node.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	created, expires, acked, finalized := now.Add(-time.Hour).UnixMilli(), now.Add(time.Hour).UnixMilli(), now.Add(-time.Minute).UnixMilli(), now.Add(30*time.Minute).UnixMilli()
+	if _, err := app.db.db.Exec(`INSERT INTO site_node_host_aliases(site_id,node_id,public_host,expires_at_ms,created_at_ms,acked_at_ms,finalization_expires_at_ms) VALUES(?,?,?,?,?,?,?)`, site.ID, node.ID, "legacy.example.test", expires, created, acked, finalized); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := app.db.snapshotSiteUpdate(*site)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate := *site
+	candidate.PublicHost = "candidate.example.test"
+	if err := app.db.UpdateSiteRecord(candidate); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.db.restoreSiteSnapshot(snapshot); err != nil {
+		t.Fatal(err)
+	}
+	restored, err := app.db.GetSite(site.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restored.PublicHost != "stable.example.test" {
+		t.Fatalf("restored public host=%q, want stable.example.test", restored.PublicHost)
+	}
+	var count int
+	if err := app.db.db.QueryRow("SELECT COUNT(*) FROM site_node_host_aliases WHERE site_id=? AND public_host=?", site.ID, "candidate.example.test").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("failed candidate host left %d alias rows", count)
+	}
+	var gotNode int64
+	var gotHost string
+	var gotExpires, gotCreated, gotAcked, gotFinalized int64
+	if err := app.db.db.QueryRow(`SELECT node_id,public_host,expires_at_ms,created_at_ms,acked_at_ms,finalization_expires_at_ms FROM site_node_host_aliases WHERE site_id=?`, site.ID).Scan(&gotNode, &gotHost, &gotExpires, &gotCreated, &gotAcked, &gotFinalized); err != nil {
+		t.Fatal(err)
+	}
+	if gotNode != node.ID || gotHost != "legacy.example.test" || gotExpires != expires || gotCreated != created || gotAcked != acked || gotFinalized != finalized {
+		t.Fatalf("alias lifecycle changed during rollback: node=%d host=%q expires=%d created=%d acked=%d finalized=%d", gotNode, gotHost, gotExpires, gotCreated, gotAcked, gotFinalized)
+	}
+}
+
 func TestReviewScheduledSiteRemovalInvalidatesOwningAgent(t *testing.T) {
 	app := newTestApp(t)
 	now := time.Now().UTC()

--- a/site_repository.go
+++ b/site_repository.go
@@ -456,14 +456,62 @@ func (d *DB) UpdateSiteIcon(id int64, name, imageURL string) (*Site, error) {
 	return d.GetSite(id)
 }
 
+type siteHostAliasSnapshot struct {
+	NodeID                  int64
+	PublicHost              string
+	ExpiresAtMS             int64
+	CreatedAtMS             int64
+	AckedAtMS               int64
+	FinalizationExpiresAtMS int64
+}
+
+type siteUpdateSnapshot struct {
+	Site        Site
+	HostAliases []siteHostAliasSnapshot
+}
+
+func (d *DB) snapshotSiteUpdate(site Site) (siteUpdateSnapshot, error) {
+	snapshot := siteUpdateSnapshot{Site: site, HostAliases: []siteHostAliasSnapshot{}}
+	rows, err := d.db.Query(`SELECT node_id,public_host,expires_at_ms,created_at_ms,acked_at_ms,finalization_expires_at_ms
+		FROM site_node_host_aliases WHERE site_id=? ORDER BY node_id,public_host`, site.ID)
+	if err != nil {
+		return siteUpdateSnapshot{}, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var alias siteHostAliasSnapshot
+		if err := rows.Scan(&alias.NodeID, &alias.PublicHost, &alias.ExpiresAtMS, &alias.CreatedAtMS, &alias.AckedAtMS, &alias.FinalizationExpiresAtMS); err != nil {
+			return siteUpdateSnapshot{}, err
+		}
+		snapshot.HostAliases = append(snapshot.HostAliases, alias)
+	}
+	if err := rows.Err(); err != nil {
+		return siteUpdateSnapshot{}, err
+	}
+	return snapshot, nil
+}
+
 func (d *DB) restoreSiteRecord(site Site) error {
-	if site.DynamicPolicyRevision < 1 {
+	snapshot, err := d.snapshotSiteUpdate(site)
+	if err != nil {
+		return err
+	}
+	return d.restoreSiteSnapshot(snapshot)
+}
+
+func (d *DB) restoreSiteSnapshot(snapshot siteUpdateSnapshot) error {
+	if snapshot.Site.DynamicPolicyRevision < 1 {
 		return fmt.Errorf("cannot restore a dynamic policy revision below 1")
 	}
-	return d.updateSiteRecord(site, true)
+	aliases := append([]siteHostAliasSnapshot(nil), snapshot.HostAliases...)
+	return d.updateSiteRecordWithAliases(snapshot.Site, true, &aliases)
 }
 
 func (d *DB) updateSiteRecord(site Site, restoreRevision bool) error {
+	return d.updateSiteRecordWithAliases(site, restoreRevision, nil)
+}
+
+func (d *DB) updateSiteRecordWithAliases(site Site, restoreRevision bool, aliasSnapshot *[]siteHostAliasSnapshot) error {
 	var err error
 	site.IconName, site.IconURL, err = normalizeSiteIconSelection(site.IconName, site.IconURL)
 	if err != nil {
@@ -580,13 +628,26 @@ func (d *DB) updateSiteRecord(site Site, restoreRevision bool) error {
 			site.StoredUpstreamHeaders = "[]"
 		}
 	}
+	// Restore the exact alias lifecycle captured before a failed update. A
+	// rollback must not create an alias for the failed candidate host.
+	if aliasSnapshot != nil {
+		if _, err := tx.Exec("DELETE FROM site_node_host_aliases WHERE site_id=?", site.ID); err != nil {
+			return err
+		}
+		for _, alias := range *aliasSnapshot {
+			if _, err := tx.Exec(`INSERT INTO site_node_host_aliases(site_id,node_id,public_host,expires_at_ms,created_at_ms,acked_at_ms,finalization_expires_at_ms)
+				VALUES(?,?,?,?,?,?,?)`, site.ID, alias.NodeID, alias.PublicHost, alias.ExpiresAtMS, alias.CreatedAtMS, alias.AckedAtMS, alias.FinalizationExpiresAtMS); err != nil {
+				return err
+			}
+		}
+	}
 	// Keep the former public host as a short-lived alias for nodes that may
 	// still have buffered events from the previous Agent route. This is
 	// site-specific authorization state; the old host is never accepted for a
 	// different site and the alias expires automatically.
 	oldHost := strings.ToLower(strings.TrimSpace(currentPublicHost))
 	newHost := strings.ToLower(strings.TrimSpace(site.PublicHost))
-	if oldHost != "" && oldHost != newHost {
+	if aliasSnapshot == nil && oldHost != "" && oldHost != newHost {
 		aliasRows, aliasErr := tx.Query(`SELECT desired_node_id, applied_node_id
 			FROM site_node_schedules WHERE site_id=?`, site.ID)
 		if aliasErr != nil {

--- a/system_settings.go
+++ b/system_settings.go
@@ -207,10 +207,12 @@ func (a *App) handleSystemSettings(w http.ResponseWriter, r *http.Request) {
 
 type dashboardInsights struct {
 	LogHealthy      bool   `json:"log_healthy"`
+	LogStatus       string `json:"log_status"`
 	LatestLogMS     int64  `json:"latest_log_ms"`
 	LogCountToday   int64  `json:"log_count_today"`
 	DroppedLogs     uint64 `json:"dropped_logs"`
 	ScheduleEnabled bool   `json:"schedule_enabled"`
+	ScheduleStatus  string `json:"schedule_status"`
 	ScheduleLabel   string `json:"schedule_label"`
 	LastSentKey     string `json:"last_sent_key"`
 }
@@ -219,13 +221,23 @@ func (a *App) dashboardInsightsSnapshot() dashboardInsights {
 	location := timezoneLocation(a.db.currentSystemSettings().ScheduleTimezone)
 	now := time.Now().In(location)
 	start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, location)
-	insights := dashboardInsights{LogHealthy: a.db.currentSystemSettings().LogEnabled}
+	settings := a.db.currentSystemSettings()
+	insights := dashboardInsights{LogHealthy: settings.LogEnabled, LogStatus: "disabled", ScheduleStatus: "disabled"}
 	_ = a.db.db.QueryRow(`SELECT COALESCE(MAX(recorded_at_ms),0), COUNT(*) FROM request_logs WHERE recorded_at_ms>=? AND recorded_at_ms<?`, start.UnixMilli(), start.AddDate(0, 0, 1).UnixMilli()).Scan(&insights.LatestLogMS, &insights.LogCountToday)
 	insights.DroppedLogs = a.db.DroppedRequestLogs()
+	if insights.LogHealthy {
+		insights.LogStatus = "healthy"
+		if insights.DroppedLogs > 0 {
+			insights.LogStatus = "degraded"
+		}
+	}
 	if stored, err := a.db.telegramReportSettings(); err == nil {
 		insights.ScheduleEnabled = stored.Enabled
+		if stored.Enabled {
+			insights.ScheduleStatus = "healthy"
+		}
 		insights.LastSentKey = stored.LastSentKey
-		insights.ScheduleLabel = stored.ScheduleTime + " " + timezoneLabel(a.db.currentSystemSettings().ScheduleTimezone)
+		insights.ScheduleLabel = stored.ScheduleTime + " " + timezoneLabel(settings.ScheduleTimezone)
 		if stored.Frequency == "weekly" {
 			insights.ScheduleLabel = "每周 " + insights.ScheduleLabel
 		} else {

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -4952,7 +4952,11 @@ html {
 .dashboard-insight-card, .dashboard-trend-card { padding: 24px; border: 1px solid var(--panel-border); border-radius: var(--ui-radius); background: var(--panel); box-shadow: var(--page-shadow); }
 .dashboard-insight-head { display: flex; justify-content: space-between; align-items: center; }
 .dashboard-insight-head h2 { font-size: 22px; }
-.dashboard-health-dot { width: 12px; height: 12px; border-radius: 50%; background: var(--green); }
+.dashboard-health-dot { width: 12px; height: 12px; flex: 0 0 12px; border-radius: 50%; background: var(--white-38); box-shadow: 0 0 0 4px color-mix(in srgb, var(--white-38) 14%, transparent); transition: background-color .2s ease, box-shadow .2s ease; }
+.dashboard-health-dot.is-healthy { background: var(--green); box-shadow: 0 0 0 4px color-mix(in srgb, var(--green) 16%, transparent); }
+.dashboard-health-dot.is-degraded { background: var(--orange); box-shadow: 0 0 0 4px color-mix(in srgb, var(--orange) 16%, transparent); }
+.dashboard-health-dot.is-error { background: var(--red); box-shadow: 0 0 0 4px color-mix(in srgb, var(--red) 16%, transparent); }
+.dashboard-health-dot.is-disabled { background: var(--white-38); box-shadow: 0 0 0 4px color-mix(in srgb, var(--white-38) 14%, transparent); }
 .dashboard-insight-card p { margin-top: 18px; color: var(--white-60); font-size: 16px; }
 .dashboard-trend-card { margin-top: 18px; }
 .dashboard-trend-wrap { width: 100%; }

--- a/web/static/js/pages/dashboard.js
+++ b/web/static/js/pages/dashboard.js
@@ -20,6 +20,7 @@ let dashboardRealtimeTrendSiteSamples = new Map();
 let dashboardLatestRatesBySite = new Map();
 let dashboardBillingMode = null;
 let dashboardLastSnapshotMS = 0;
+let dashboardLastObservedSiteCount = -1;
 
 function dashboardCreateAbortController() {
   if (typeof AbortController === 'function') return new AbortController();
@@ -95,8 +96,8 @@ function renderDashboard() {
       <section class="dashboard-trend-card" data-dashboard-chart="traffic"><div class="glass-card-header"><div><div class="glass-card-title">流量</div><span class="dashboard-trend-unit" id="dashboard-traffic-unit">计费流量总数</span></div><strong class="dashboard-trend-summary" id="dashboard-traffic-summary">—</strong></div><div class="dashboard-trend-wrap"><canvas id="dashboardTrafficTrend" aria-label="流量趋势图"></canvas><div class="dashboard-chart-tooltip" hidden></div></div><div class="dashboard-trend-legend"><span><i class="traffic"></i>计费流量</span></div></section>
     </div>
     <div class="dashboard-insights-grid fade-up stagger-5">
-      <section class="dashboard-insight-card" id="dashboard-log-health"><div class="dashboard-insight-head"><h2>日志写入</h2><span class="dashboard-health-dot"></span></div><p>正在读取…</p></section>
-      <section class="dashboard-insight-card" id="dashboard-schedule-health"><div class="dashboard-insight-head"><h2>定时任务</h2><span class="dashboard-health-dot"></span></div><p>正在读取…</p></section>
+      <section class="dashboard-insight-card" id="dashboard-log-health"><div class="dashboard-insight-head"><h2>日志写入</h2><span class="dashboard-health-dot is-disabled" aria-hidden="true"></span></div><p>正在读取…</p></section>
+      <section class="dashboard-insight-card" id="dashboard-schedule-health"><div class="dashboard-insight-head"><h2>定时任务</h2><span class="dashboard-health-dot is-disabled" aria-hidden="true"></span></div><p>正在读取…</p></section>
     </div>
     <div class="glass-card dashboard-site-status fade-up stagger-5">
       <div class="glass-card-header">
@@ -126,11 +127,30 @@ function renderDashboard() {
 
 function applyDashboardInsights(insights) {
   if (!insights || Router.current !== 'dashboard') return;
+  const setHealthState = (id, state) => {
+    const dot = document.querySelector(`#${id} .dashboard-health-dot`);
+    if (!dot) return;
+    dot.classList.remove('is-healthy', 'is-degraded', 'is-disabled', 'is-error');
+    dot.classList.add(`is-${state || 'disabled'}`);
+  };
   const log = document.querySelector('#dashboard-log-health p');
   const schedule = document.querySelector('#dashboard-schedule-health p');
   const latestLog = insights.latest_log_ms ? meridianFormatDateTime(insights.latest_log_ms) : '暂无记录';
+  const logStatus = insights.log_status || (insights.log_healthy ? (insights.dropped_logs ? 'degraded' : 'healthy') : 'disabled');
+  const scheduleStatus = insights.schedule_status || (insights.schedule_enabled ? 'healthy' : 'disabled');
+  setHealthState('dashboard-log-health', logStatus);
+  setHealthState('dashboard-schedule-health', scheduleStatus);
   if (log) log.textContent = insights.log_healthy ? `今日写入 ${formatNumber(insights.log_count_today || 0)} 条 · 最近写入 ${latestLog}` : '已关闭';
+  if (log && logStatus === 'degraded') log.textContent += ' · 有日志丢弃';
   if (schedule) schedule.textContent = insights.schedule_enabled ? `Telegram 日报 · ${insights.schedule_label || '已启用'}` : 'Telegram 日报 · 未启用';
+}
+
+function reconcileDashboardTrendSiteSelection() {
+  if (dashboardTrendState.siteId === 'all') return false;
+  const exists = dashboardSites.some(site => String(site.id) === String(dashboardTrendState.siteId));
+  if (exists) return false;
+  dashboardTrendState.siteId = 'all';
+  return true;
 }
 
 async function loadDashboardBootstrap() {
@@ -146,12 +166,14 @@ async function loadDashboardBootstrap() {
       return speed ? { ...site, _liveSpeed: speed } : site;
     }) : [];
     dashboardSitesInitialized = true;
+    const selectionReset = reconcileDashboardTrendSiteSelection();
     const cacheEl = document.getElementById('s-cache');
     if (cacheEl) cacheEl.textContent = formatBytes(dashboardSites.reduce((total, site) => total + Number(site.cache_size_bytes || 0), 0));
     if (data.snapshot) updateDashboardLive(data.snapshot);
     applyDashboardInsights(data.insights);
     renderDashboardTrendSites();
     renderDashboardTableRows();
+    if (selectionReset && dashboardTrendState.range) void loadDashboardTrends();
     return data;
   }).catch(error => {
     if (error && error.name === 'AbortError') return null;
@@ -204,7 +226,7 @@ function dashboardTrendValueLabel(value, metric) {
   return formatNumber(Math.round(value));
 }
 
-function dashboardTrendPointerState(rect, geometry, event, pointCount) {
+function dashboardTrendPointerState(rect, geometry, event, pointsOrCount, chartStartMS = 0, chartEndMS = 0) {
   const width = Math.max(1, Number(rect?.width) || 1);
   const height = Math.max(1, Number(rect?.height) || 1);
   const scaleX = Math.max(1, Number(geometry?.width) || width) / width;
@@ -217,7 +239,22 @@ function dashboardTrendPointerState(rect, geometry, event, pointCount) {
   const plotH = Math.max(1, Number(geometry?.plotH) || 1);
   const x = Math.max(left, Math.min(left + plotW, Number.isFinite(rawX) ? rawX : left));
   const y = Math.max(top, Math.min(top + plotH, Number.isFinite(rawY) ? rawY : top));
-  const index = Math.max(0, Math.min(Math.max(0, pointCount - 1), Math.round(((x - left) / plotW) * Math.max(0, pointCount - 1))));
+  const points = Array.isArray(pointsOrCount) ? pointsOrCount : null;
+  const pointCount = points ? points.length : Math.max(0, Number(pointsOrCount) || 0);
+  let index = Math.max(0, Math.min(Math.max(0, pointCount - 1), Math.round(((x - left) / plotW) * Math.max(0, pointCount - 1))));
+  if (points && points.length > 1) {
+    const start = Number(chartStartMS || points[0]?.timestamp_ms || 0);
+    const end = Number(chartEndMS || points[points.length - 1]?.timestamp_ms || start);
+    if (end > start) {
+      const target = start + ((x - left) / plotW) * (end - start);
+      let bestDistance = Infinity;
+      points.forEach((point, candidate) => {
+        const timestamp = Number(point?.timestamp_ms || 0);
+        const distance = Math.abs(timestamp - target);
+        if (distance < bestDistance) { bestDistance = distance; index = candidate; }
+      });
+    }
+  }
   return { x, y, index };
 }
 
@@ -355,6 +392,21 @@ function dashboardRealtimeTrendPoints() {
   return dashboardRealtimeTrendSamples.get(key) || [];
 }
 
+function dashboardRealtimeWindowStartMS() {
+  const configured = Number(dashboardTrendData?.start_ms || 0);
+  return configured > 0 ? configured : Date.now() - 30 * 60 * 1000;
+}
+
+function pruneDashboardRealtimeSamples(samples) {
+  if (!Array.isArray(samples) || !samples.length) return samples;
+  const startMS = dashboardRealtimeWindowStartMS();
+  let first = 0;
+  while (first < samples.length && Number(samples[first]?.timestamp_ms || 0) < startMS) first += 1;
+  if (first > 0) samples.splice(0, first);
+  if (samples.length > 2000) samples.splice(0, samples.length - 2000);
+  return samples;
+}
+
 function dashboardTrendRealtimeOffset() {
   const historical = dashboardTrendData?.points || [];
   const realtime = dashboardRealtimeTrendPoints();
@@ -442,6 +494,11 @@ function drawDashboardTrendChart(metric) {
   const left = Math.min(Math.max(50, Math.ceil(yLabelWidth) + 16), Math.floor(width * .36));
   const right = 12, top = 14, bottom = 30;
   const plotW = Math.max(1, width - left - right), plotH = Math.max(1, height - top - bottom);
+  const chartStartMS = Number(dashboardTrendData?.start_ms || points[0]?.timestamp_ms || 0);
+  const chartEndMS = Math.max(chartStartMS, Number(dashboardTrendData?.end_ms || points[points.length - 1]?.timestamp_ms || chartStartMS));
+  const xForTimestamp = timestamp => chartEndMS > chartStartMS
+    ? left + plotW * Math.max(0, Math.min(1, (Number(timestamp || chartStartMS) - chartStartMS) / (chartEndMS - chartStartMS)))
+    : left + plotW / 2;
   chart.geometry = { width, height, left, right, top, bottom, plotW, plotH };
   ctx.textBaseline = 'middle';
   ctx.fillStyle = 'var(--white-60)';
@@ -456,7 +513,7 @@ function drawDashboardTrendChart(metric) {
   }
   if (ctx.setLineDash) ctx.setLineDash([]);
   const canvasSeries = series.map(item => ({ ...item, points: item.values.map((value, index) => ({
-    x: left + plotW * index / Math.max(1, points.length - 1),
+    x: xForTimestamp(points[index]?.timestamp_ms),
     y: top + plotH * (1 - (value / (scale.max || 1))),
   })) }));
   canvasSeries.forEach(item => {
@@ -629,7 +686,14 @@ function setupDashboardTrendControls() {
         return;
       }
       const geometry = chart.geometry || { width: rect.width, height: rect.height, left: 0, top: 0, plotW: rect.width, plotH: rect.height };
-      const pointer = dashboardTrendPointerState(rect, geometry, event, points.length);
+      const pointer = dashboardTrendPointerState(
+        rect,
+        geometry,
+        event,
+        points,
+        Number(dashboardTrendData?.start_ms || points[0]?.timestamp_ms || 0),
+        Number(dashboardTrendData?.end_ms || points[points.length - 1]?.timestamp_ms || 0),
+      );
       chart.hoverIndex = pointer.index;
       chart.hoverX = pointer.x;
       chart.hoverY = pointer.y;
@@ -698,11 +762,9 @@ async function loadDashboardTrends() {
       if (endInput) endInput.value = customDefault.end;
     }
     dashboardTrendData = data;
-    if (Array.isArray(data.site_series)) {
-      data.site_series.forEach(series => {
-        if (!dashboardSites.some(site => Number(site.id) === Number(series.site_id))) dashboardSites.push({ id: series.site_id, name: series.site_name });
-      });
-    }
+    for (const samples of dashboardRealtimeTrendSamples.values()) pruneDashboardRealtimeSamples(samples);
+    for (const samples of dashboardRealtimeTrendSiteSamples.values()) pruneDashboardRealtimeSamples(samples);
+    reconcileDashboardTrendSiteSelection();
     dashboardTrendSummary(data);
     renderDashboardTrendCharts();
   } catch (error) {
@@ -826,8 +888,15 @@ function updateDashboardLive(stats) {
 	const panelDomainEl = document.getElementById('s-panel-domain');
 	const currentPanelURL = dashboardCurrentPanelURL(stats.panel_access_url);
 	if (panelDomainEl && currentPanelURL) panelDomainEl.textContent = currentPanelURL;
-  animateValue('s-total', stats.total_sites || 0);
-  animateValue('s-running', stats.running_sites || 0);
+	animateValue('s-total', stats.total_sites || 0);
+	animateValue('s-running', stats.running_sites || 0);
+	const totalSites = Number(stats?.total_sites);
+	if (Number.isFinite(totalSites)) {
+		if (dashboardLastObservedSiteCount >= 0 && dashboardLastObservedSiteCount !== totalSites && dashboardSitesInitialized && dashboardSites.length !== totalSites) {
+			void refreshDashboardSecondary();
+		}
+		dashboardLastObservedSiteCount = totalSites;
+	}
 
   const trafficEl = document.getElementById('s-traffic');
   if (trafficEl) trafficEl.textContent = formatBytes(stats.monthly_traffic != null ? stats.monthly_traffic : (stats.total_traffic || 0));
@@ -980,7 +1049,7 @@ function updateDashboardSiteSpeeds(liveSites, snapshotMS, billingModeOverride) {
     }
   }
   const sampledAt = Number(snapshotMS || Date.now());
-  const appendRealtimeTrendSample = (key, sample, sampleTimestamp = sampledAt, contributions = null) => {
+	const appendRealtimeTrendSample = (key, sample, sampleTimestamp = sampledAt, contributions = null) => {
     const samples = dashboardRealtimeTrendSamples.get(key) || [];
     const bytesIn = Math.max(0, Number(sample?.bytesIn || 0));
     const bytesOut = Math.max(0, Number(sample?.bytesOut || 0));
@@ -995,10 +1064,8 @@ function updateDashboardSiteSpeeds(liveSites, snapshotMS, billingModeOverride) {
     if (billingKnown) point.traffic_bytes = billingMode === 'outbound' ? bytesOut : 2 * (bytesIn + bytesOut);
     if (contributions && Object.keys(contributions).length) point.site_contributions = contributions;
     samples.push(point);
-    // Keep the active dashboard session responsive without imposing a time
-    // window; the X axis adapts to however many samples are available.
-    if (samples.length > 1800) samples.splice(0, samples.length - 1800);
-    dashboardRealtimeTrendSamples.set(key, samples);
+		pruneDashboardRealtimeSamples(samples);
+		dashboardRealtimeTrendSamples.set(key, samples);
   };
   if (changedSiteIDs.size > 0) {
     const contributions = {};
@@ -1036,7 +1103,7 @@ function updateDashboardSiteSpeeds(liveSites, snapshotMS, billingModeOverride) {
     // aggregate series still uses the controller snapshot timestamp.
     appendRealtimeTrendSample(String(siteID), { ...rate, ...delta }, siteSampledAt);
     siteSamples.push(siteSample);
-    if (siteSamples.length > 1800) siteSamples.splice(0, siteSamples.length - 1800);
+		pruneDashboardRealtimeSamples(siteSamples);
     dashboardRealtimeTrendSiteSamples.set(String(siteID), siteSamples);
   }
   dashboardSites = dashboardSites.map(site => {
@@ -1090,6 +1157,7 @@ function stopDashSSE() {
   dashboardRealtimeTrendSamples = new Map();
   dashboardRealtimeTrendSiteSamples = new Map();
   dashboardLastSnapshotMS = 0;
+  dashboardLastObservedSiteCount = -1;
   dashboardTrendData = null;
   dashboardSitesInitialized = false;
   dashboardTrendCharts = new Map();


### PR DESCRIPTION
## Changes
- snapshot and restore site Host Alias lifecycle on failed updates
- keep dashboard site selection authoritative and refresh on site count changes
- bound realtime trend samples to the 30-minute backend window and map the X axis by timestamps
- expose healthy, degraded, and disabled dashboard health states

## Validation
- go test ./...
- go test -race -count=1 ./...
- go vet ./...
- node --test tests/*.test.js
