### PR TITLE
fix: order telemetry and bound dashboard trends

### DIFF
--- a/agent_live.go
+++ b/agent_live.go
@@ -19,10 +19,11 @@ type nodeLiveTrafficKey struct {
 
 type nodeLiveTrafficState struct {
 	NodeLiveSiteTraffic
-	reportSessionID string
-	counterEpoch    string
-	sequence        int64
-	updatedAt       time.Time
+	reportSessionID   string
+	counterEpoch      string
+	sequence          int64
+	telemetrySequence int64
+	updatedAt         time.Time
 }
 
 func validateNodeLiveReport(report NodeLiveReport, now time.Time) error {
@@ -31,7 +32,7 @@ func validateNodeLiveReport(report NodeLiveReport, now time.Time) error {
 	if report.ReportSessionID == "" || len(report.ReportSessionID) > 128 || len(report.CounterEpoch) > 128 {
 		return errors.New("invalid live report session")
 	}
-	if report.Sequence <= 0 || report.SampledAtMS <= 0 || len(report.SiteStats) > maxNodeLiveSitesPerReport {
+	if report.Sequence <= 0 || report.TelemetrySequence < 0 || report.SampledAtMS <= 0 || len(report.SiteStats) > maxNodeLiveSitesPerReport {
 		return errors.New("invalid live report metadata")
 	}
 	// The timestamp is only a diagnostic hint. The server receive time is used
@@ -46,6 +47,16 @@ func validateNodeLiveReport(report NodeLiveReport, now time.Time) error {
 		}
 	}
 	return nil
+}
+
+func telemetrySequenceIsStale(previous nodeLiveTrafficState, sessionID, counterEpoch string, sequence int64) bool {
+	if sequence <= 0 || previous.telemetrySequence <= 0 {
+		return false
+	}
+	// The shared sequence restarts with a new Agent process. Only compare it
+	// inside the same report session/counter epoch; a new session is a fresh
+	// ordering domain and may legitimately begin at sequence 1.
+	return previous.reportSessionID == sessionID && previous.counterEpoch == counterEpoch && sequence <= previous.telemetrySequence
 }
 
 // recordNodeLiveReport validates site ownership in a read transaction and
@@ -90,6 +101,12 @@ func (d *DB) recordNodeLiveReport(nodeID int64, report NodeLiveReport, now time.
 		}
 		key := nodeLiveTrafficKey{nodeID: nodeID, siteID: site.ID}
 		previous, exists := d.agentLive[key]
+		// Full and lightweight reports share TelemetrySequence. A delayed
+		// lightweight report must never overwrite a newer full report (or the
+		// reverse), even though their channel-local sequences are independent.
+		if exists && telemetrySequenceIsStale(previous, report.ReportSessionID, report.CounterEpoch, report.TelemetrySequence) {
+			continue
+		}
 		if exists && previous.reportSessionID == report.ReportSessionID && report.Sequence <= previous.sequence {
 			continue
 		}
@@ -101,15 +118,79 @@ func (d *DB) recordNodeLiveReport(nodeID int64, report NodeLiveReport, now time.
 				Requests:           stat.Requests,
 				SampledAtMS:        serverSampledAt,
 			},
-			reportSessionID: report.ReportSessionID,
-			counterEpoch:    report.CounterEpoch,
-			sequence:        report.Sequence,
-			updatedAt:       now,
+			reportSessionID:   report.ReportSessionID,
+			counterEpoch:      report.CounterEpoch,
+			sequence:          report.Sequence,
+			telemetrySequence: report.TelemetrySequence,
+			updatedAt:         now,
 		}
 		accepted = appendUniqueInt64(accepted, stat.SiteID)
 	}
 	d.agentLiveMu.Unlock()
 	return accepted, discarded, nil
+}
+
+// recordNodeFullTelemetry publishes accepted full-report site counters into
+// the same in-memory overlay used by /api/agent/live. The shared telemetry
+// watermark prevents a delayed report from either channel from replacing a
+// newer sample.
+func (d *DB) recordNodeFullTelemetry(nodeID int64, report NodeReport, acceptedSiteIDs []int64, now time.Time) {
+	if d == nil || nodeID <= 0 || report.TelemetrySequence <= 0 || len(acceptedSiteIDs) == 0 {
+		return
+	}
+	allowed := make(map[int64]struct{}, len(acceptedSiteIDs))
+	for _, siteID := range acceptedSiteIDs {
+		if siteID > 0 {
+			allowed[siteID] = struct{}{}
+		}
+	}
+	d.agentLiveMu.Lock()
+	defer d.agentLiveMu.Unlock()
+	if d.agentLive == nil {
+		d.agentLive = make(map[nodeLiveTrafficKey]nodeLiveTrafficState)
+	}
+	sessionID := strings.TrimSpace(report.ReportSessionID)
+	if sessionID == "" {
+		sessionID = strings.TrimSpace(report.BootID)
+	}
+	counterEpoch := strings.TrimSpace(report.CounterEpoch)
+	for _, stat := range report.SiteStats {
+		if _, ok := allowed[stat.SiteID]; !ok {
+			continue
+		}
+		host := requestPublicHost(stat.Host)
+		if host == "" {
+			continue
+		}
+		currentIn, currentOut := stat.CumulativeBytesIn, stat.CumulativeBytesOut
+		if currentIn == 0 && stat.BytesIn > 0 {
+			currentIn = stat.BytesIn
+		}
+		if currentOut == 0 && stat.BytesOut > 0 {
+			currentOut = stat.BytesOut
+		}
+		key := nodeLiveTrafficKey{nodeID: nodeID, siteID: stat.SiteID}
+		previous, exists := d.agentLive[key]
+		if exists && telemetrySequenceIsStale(previous, sessionID, counterEpoch, report.TelemetrySequence) {
+			continue
+		}
+		liveSequence := int64(0)
+		if exists {
+			liveSequence = previous.sequence
+		}
+		d.agentLive[key] = nodeLiveTrafficState{
+			NodeLiveSiteTraffic: NodeLiveSiteTraffic{
+				SiteID: stat.SiteID, Host: host,
+				CumulativeBytesIn: currentIn, CumulativeBytesOut: currentOut,
+				Requests: stat.RequestCount, SampledAtMS: now.UnixMilli(),
+			},
+			reportSessionID:   sessionID,
+			counterEpoch:      counterEpoch,
+			sequence:          liveSequence,
+			telemetrySequence: report.TelemetrySequence,
+			updatedAt:         now,
+		}
+	}
 }
 
 func appendUniqueInt64(values []int64, value int64) []int64 {

--- a/agent_live_test.go
+++ b/agent_live_test.go
@@ -64,6 +64,80 @@ func TestNodeLiveReportOverlaysDashboardWithoutPersistingTraffic(t *testing.T) {
 	}
 }
 
+func TestNodeTelemetrySequenceOrdersFullAndLiveChannels(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now().UTC()
+	node, enrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "ordered-live", Address: "203.0.113.73", Port: 19073}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, token, err := app.db.EnrollControlNode(enrollment, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "ordered-site", ListenPort: freePort(t), PublicHost: "ordered.example", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:1", PlaybackMode: "direct", MainVideoStreamMode: "proxy", StreamHosts: "[]", UAMode: passthroughUAMode})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.SaveSiteNodeSchedule(site.ID, true, "fixed", node.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec("UPDATE site_node_schedules SET applied_node_id=?, dns_status='active' WHERE site_id=?", node.ID, site.ID); err != nil {
+		t.Fatal(err)
+	}
+	fullReport := func(sequence, telemetry int64, in, out, requests int64, at time.Time) {
+		t.Helper()
+		if _, err := app.db.RecordNodeReport(token, NodeReport{
+			BootID: "ordered-boot", ReportSessionID: "ordered-session", CounterEpoch: "kernel:eth0",
+			Sequence: sequence, TelemetrySequence: telemetry, InterfaceName: "eth0",
+			SiteStats: []NodeSiteStat{{SiteID: site.ID, Host: site.PublicHost, CumulativeBytesIn: in, CumulativeBytesOut: out, RequestCount: requests}},
+		}, at); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fullReport(1, 100, 100, 200, 3, now)
+	accepted, _, err := app.db.recordNodeLiveReport(node.ID, NodeLiveReport{
+		ReportSessionID: "ordered-session", CounterEpoch: "kernel:eth0", Sequence: 1, TelemetrySequence: 101,
+		SampledAtMS: now.Add(time.Second).UnixMilli(),
+		SiteStats:   []NodeLiveSiteTraffic{{SiteID: site.ID, Host: site.PublicHost, CumulativeBytesIn: 900, CumulativeBytesOut: 1200, Requests: 17}},
+	}, now.Add(time.Second))
+	if err != nil || len(accepted) != 1 {
+		t.Fatalf("live report accepted=%v err=%v", accepted, err)
+	}
+	fullReport(2, 102, 950, 1250, 19, now.Add(2*time.Second))
+	// A delayed live request with an older shared sequence must not overlay
+	// the newer committed full report.
+	accepted, _, err = app.db.recordNodeLiveReport(node.ID, NodeLiveReport{
+		ReportSessionID: "ordered-session", CounterEpoch: "kernel:eth0", Sequence: 2, TelemetrySequence: 101,
+		SampledAtMS: now.Add(3 * time.Second).UnixMilli(),
+		SiteStats:   []NodeLiveSiteTraffic{{SiteID: site.ID, Host: site.PublicHost, CumulativeBytesIn: 910, CumulativeBytesOut: 1210, Requests: 18}},
+	}, now.Add(3*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(accepted) != 0 {
+		t.Fatalf("delayed live report was accepted: %v", accepted)
+	}
+	snapshot, err := app.db.NodeSiteLiveTrafficSnapshot(now.Add(4 * time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, ok := snapshot[site.ID]
+	if !ok || value.CumulativeBytesIn != 950 || value.CumulativeBytesOut != 1250 || value.Requests != 19 {
+		t.Fatalf("newer full report was overwritten: %#v", snapshot)
+	}
+	// A restarted Agent begins a fresh telemetry sequence and must not be
+	// blocked by the previous process's watermark.
+	accepted, _, err = app.db.recordNodeLiveReport(node.ID, NodeLiveReport{
+		ReportSessionID: "restarted-session", CounterEpoch: "kernel:eth0", Sequence: 1, TelemetrySequence: 1,
+		SampledAtMS: now.Add(5 * time.Second).UnixMilli(),
+		SiteStats:   []NodeLiveSiteTraffic{{SiteID: site.ID, Host: site.PublicHost, CumulativeBytesIn: 1000, CumulativeBytesOut: 1300, Requests: 20}},
+	}, now.Add(5*time.Second))
+	if err != nil || len(accepted) != 1 {
+		t.Fatalf("restarted live report accepted=%v err=%v", accepted, err)
+	}
+}
+
 func TestNodeLiveReportRejectsUnauthorizedSite(t *testing.T) {
 	app := newTestApp(t)
 	now := time.Now().UTC()

--- a/dashboard_trends.go
+++ b/dashboard_trends.go
@@ -14,6 +14,8 @@ type dashboardTrendCacheEntry struct {
 	Response  *dashboardTrendsResponse
 }
 
+const maxDashboardTrendCacheEntries = 128
+
 func (pm *ProxyManager) dashboardTrendCached(key string, now time.Time) *dashboardTrendsResponse {
 	pm.trendCacheMu.Lock()
 	defer pm.trendCacheMu.Unlock()
@@ -33,11 +35,22 @@ func (pm *ProxyManager) cacheDashboardTrend(key string, response *dashboardTrend
 	if pm.trendCache == nil {
 		pm.trendCache = make(map[string]dashboardTrendCacheEntry)
 	}
-	if len(pm.trendCache) > 128 {
+	now := time.Now()
+	for cacheKey, entry := range pm.trendCache {
+		if !now.Before(entry.ExpiresAt) {
+			delete(pm.trendCache, cacheKey)
+		}
+	}
+	if len(pm.trendCache) >= maxDashboardTrendCacheEntries {
+		oldestKey := ""
+		var oldestExpiry time.Time
 		for cacheKey, entry := range pm.trendCache {
-			if !time.Now().Before(entry.ExpiresAt) {
-				delete(pm.trendCache, cacheKey)
+			if oldestKey == "" || entry.ExpiresAt.Before(oldestExpiry) {
+				oldestKey, oldestExpiry = cacheKey, entry.ExpiresAt
 			}
+		}
+		if oldestKey != "" {
+			delete(pm.trendCache, oldestKey)
 		}
 	}
 	pm.trendCache[key] = dashboardTrendCacheEntry{ExpiresAt: expiresAt, Response: response}
@@ -54,15 +67,18 @@ type dashboardTrendPoint struct {
 }
 
 type dashboardTrendsResponse struct {
-	SiteID         string                `json:"site_id"`
-	Range          string                `json:"range"`
-	BillingMode    string                `json:"billing_mode"`
-	TimezoneOffset int                   `json:"timezone_offset_minutes"`
-	StartMS        int64                 `json:"start_ms"`
-	EndMS          int64                 `json:"end_ms"`
-	BucketSeconds  int64                 `json:"bucket_seconds"`
-	Points         []dashboardTrendPoint `json:"points"`
-	SiteSeries     []dashboardTrendSite  `json:"site_series"`
+	SiteID         string `json:"site_id"`
+	Range          string `json:"range"`
+	BillingMode    string `json:"billing_mode"`
+	TimezoneOffset int    `json:"timezone_offset_minutes"`
+	StartMS        int64  `json:"start_ms"`
+	EndMS          int64  `json:"end_ms"`
+	// AsOfMS is the history snapshot cutoff. Realtime points newer than this
+	// instant can be merged without double-counting the current bucket.
+	AsOfMS        int64                 `json:"as_of_ms"`
+	BucketSeconds int64                 `json:"bucket_seconds"`
+	Points        []dashboardTrendPoint `json:"points"`
+	SiteSeries    []dashboardTrendSite  `json:"site_series"`
 }
 
 // dashboardTrendSite carries the same time buckets as the aggregate chart,
@@ -335,6 +351,7 @@ func (pm *ProxyManager) dashboardTrendsUncoalesced(siteID *int64, rangeName stri
 		TimezoneOffset: settings.ScheduleTimezone,
 		StartMS:        start.UnixMilli(),
 		EndMS:          end.UnixMilli(),
+		AsOfMS:         now.UnixMilli(),
 		BucketSeconds:  int64(bucket / time.Second),
 		Points:         points,
 		SiteSeries:     siteSeries,

--- a/dashboard_trends_test.go
+++ b/dashboard_trends_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -43,6 +44,9 @@ func TestDashboardTrendsAggregateAllAndSingleSite(t *testing.T) {
 	if all.SiteID != "all" || all.Range != "hour" || all.BucketSeconds != 60 || len(all.Points) != 60 {
 		t.Fatalf("all metadata = %+v", all)
 	}
+	if all.AsOfMS <= 0 {
+		t.Fatalf("dashboard trend is missing its history snapshot cutoff: %+v", all)
+	}
 	traffic, requests := sumDashboardTrend(all.Points)
 	if traffic != 860 || requests != 6 {
 		t.Fatalf("all totals = traffic %d requests %d, want 860/6", traffic, requests)
@@ -70,6 +74,24 @@ func TestDashboardTrendsAggregateAllAndSingleSite(t *testing.T) {
 	}
 	if len(single.SiteSeries) != 1 || single.SiteSeries[0].SiteID != first.ID || single.SiteSeries[0].SiteName != "first" {
 		t.Fatalf("single site series = %+v, want first only", single.SiteSeries)
+	}
+}
+
+func TestDashboardTrendCacheHasHardEntryLimit(t *testing.T) {
+	pm := &ProxyManager{trendCache: make(map[string]dashboardTrendCacheEntry)}
+	expires := time.Now().Add(time.Hour)
+	for i := 0; i < maxDashboardTrendCacheEntries; i++ {
+		pm.cacheDashboardTrend(fmt.Sprintf("trend-%d", i), &dashboardTrendsResponse{}, expires.Add(time.Duration(i)*time.Second))
+	}
+	pm.cacheDashboardTrend("trend-new", &dashboardTrendsResponse{}, expires.Add(2*time.Hour))
+	if len(pm.trendCache) != maxDashboardTrendCacheEntries {
+		t.Fatalf("trend cache size=%d, want=%d", len(pm.trendCache), maxDashboardTrendCacheEntries)
+	}
+	if pm.dashboardTrendCached("trend-0", time.Now()) != nil {
+		t.Fatal("oldest trend cache entry was not evicted at the hard limit")
+	}
+	if pm.dashboardTrendCached("trend-new", time.Now()) == nil {
+		t.Fatal("newest trend cache entry was evicted")
 	}
 }
 

--- a/edge_agent.go
+++ b/edge_agent.go
@@ -517,6 +517,7 @@ type edgeAgentRuntime struct {
 	drainingBundles      map[*edgeProxyBundle]struct{}
 	appliedHash          string
 	appliedRevision      int64
+	telemetrySequence    int64
 	siteCounterEpoch     uint64
 	siteCounterEpochs    map[int64]uint64
 	siteStatsCursor      int64
@@ -1830,6 +1831,22 @@ func (runtime *edgeAgentRuntime) status() (string, int64, string, string, int64,
 	return runtime.appliedHash, runtime.appliedRevision, runtime.listenerError, runtime.applyError, runtime.applyErrorAtMS, runtime.applyFailures
 }
 
+// nextTelemetrySequence is shared by the full and lightweight report loops.
+// Their channel-local sequences intentionally remain independent, while this
+// monotonic value provides the Controller with one ordering boundary.
+func (runtime *edgeAgentRuntime) nextTelemetrySequence() int64 {
+	if runtime == nil {
+		return 0
+	}
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	runtime.telemetrySequence++
+	if runtime.telemetrySequence <= 0 {
+		runtime.telemetrySequence = 1
+	}
+	return runtime.telemetrySequence
+}
+
 func (runtime *edgeAgentRuntime) close() {
 	runtime.stopServer()
 	runtime.mu.Lock()
@@ -2233,11 +2250,12 @@ func edgeLiveReportLoop(ctx context.Context, client *http.Client, controller, to
 	send := func() error {
 		sequence++
 		report := NodeLiveReport{
-			ReportSessionID: sessionID,
-			CounterEpoch:    edgeCounterEpoch(edgeDefaultInterface()),
-			Sequence:        sequence,
-			SampledAtMS:     time.Now().UnixMilli(),
-			SiteStats:       runtime.liveSiteTrafficSnapshot(),
+			ReportSessionID:   sessionID,
+			CounterEpoch:      edgeCounterEpoch(edgeDefaultInterface()),
+			Sequence:          sequence,
+			TelemetrySequence: runtime.nextTelemetrySequence(),
+			SampledAtMS:       time.Now().UnixMilli(),
+			SiteStats:         runtime.liveSiteTrafficSnapshot(),
 		}
 		var ack struct{}
 		return edgeAPIRequest(ctx, client, http.MethodPost, controller+"/api/agent/live", token, report, &ack)
@@ -2640,6 +2658,7 @@ func runEdgeAgent() error {
 			report.CacheClearGeneration = runtime.cacheClearGeneration
 			report.SiteCounterEpoch = strconv.FormatUint(runtime.siteCounterEpoch, 10)
 			runtime.mu.RUnlock()
+			report.TelemetrySequence = runtime.nextTelemetrySequence()
 			report.EventSpoolError, report.EventQueueDepth = runtime.eventSpoolStatus()
 			report.EventDropped = runtime.events.droppedCount()
 			pendingStats := runtime.prepareSiteStats()

--- a/node_repository.go
+++ b/node_repository.go
@@ -125,11 +125,14 @@ type NodeCreateInput struct {
 }
 
 type NodeReport struct {
-	BootID                string                   `json:"boot_id"`
-	ReportSessionID       string                   `json:"report_session_id,omitempty"`
-	CounterEpoch          string                   `json:"counter_epoch,omitempty"`
-	SiteCounterEpoch      string                   `json:"site_counter_epoch,omitempty"`
-	Sequence              int64                    `json:"sequence"`
+	BootID           string `json:"boot_id"`
+	ReportSessionID  string `json:"report_session_id,omitempty"`
+	CounterEpoch     string `json:"counter_epoch,omitempty"`
+	SiteCounterEpoch string `json:"site_counter_epoch,omitempty"`
+	Sequence         int64  `json:"sequence"`
+	// TelemetrySequence is shared by the full and lightweight report channels.
+	// It lets the Controller reject a delayed sample from either channel.
+	TelemetrySequence     int64                    `json:"telemetry_sequence,omitempty"`
 	InterfaceName         string                   `json:"interface_name"`
 	RXBytes               int64                    `json:"rx_bytes"`
 	TXBytes               int64                    `json:"tx_bytes"`
@@ -155,11 +158,12 @@ type NodeReport struct {
 // It carries only process-stable per-site counters; the full NodeReport remains
 // responsible for site state, media, observations, events, and persistence.
 type NodeLiveReport struct {
-	ReportSessionID string                `json:"report_session_id"`
-	CounterEpoch    string                `json:"counter_epoch,omitempty"`
-	Sequence        int64                 `json:"sequence"`
-	SampledAtMS     int64                 `json:"sampled_at_ms"`
-	SiteStats       []NodeLiveSiteTraffic `json:"site_stats,omitempty"`
+	ReportSessionID   string                `json:"report_session_id"`
+	CounterEpoch      string                `json:"counter_epoch,omitempty"`
+	Sequence          int64                 `json:"sequence"`
+	TelemetrySequence int64                 `json:"telemetry_sequence,omitempty"`
+	SampledAtMS       int64                 `json:"sampled_at_ms"`
+	SiteStats         []NodeLiveSiteTraffic `json:"site_stats,omitempty"`
 }
 
 type NodeLiveSiteTraffic struct {
@@ -1028,7 +1032,7 @@ func validateNodeReport(report NodeReport) error {
 	if report.BootID == "" || len(report.BootID) > 128 || len(report.ReportSessionID) > 128 || len(report.CounterEpoch) > 128 || len(report.SiteCounterEpoch) > 128 {
 		return errors.New("invalid boot_id")
 	}
-	if report.Sequence <= 0 || report.RXBytes < 0 || report.TXBytes < 0 || report.CacheClearGeneration < 0 {
+	if report.Sequence <= 0 || report.TelemetrySequence < 0 || report.RXBytes < 0 || report.TXBytes < 0 || report.CacheClearGeneration < 0 {
 		return errors.New("invalid traffic counters")
 	}
 	if report.InterfaceName == "" || len(report.InterfaceName) > 64 || len(report.AgentVersion) > 128 || len(report.AppliedConfigHash) > 128 || len(report.ApplyError) > 1024 || len(report.ListenerError) > 1024 || len(report.EventSpoolError) > 1024 || report.EventQueueDepth < 0 || report.EventQueueDepth > edgeEventQueueLimit || report.EventDropped < 0 {
@@ -1845,6 +1849,10 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 	if err := tx.Commit(); err != nil {
 		return nodeReportCommitResult{}, err
 	}
+	// Publish the committed full-report sample to the dashboard overlay only
+	// after the transaction succeeds. The shared telemetry sequence keeps this
+	// overlay ordered with the lightweight live-report channel.
+	d.recordNodeFullTelemetry(id, report, result.acceptedSiteIDs, now)
 	result.node, err = d.controlNodeByID(id, now)
 	if err != nil {
 		return nodeReportCommitResult{}, err

--- a/node_repository_test.go
+++ b/node_repository_test.go
@@ -1392,6 +1392,45 @@ func TestSiteNodeSchedulingCanBeDisabledWithoutFixedNode(t *testing.T) {
 	}
 }
 
+func TestDisabledSiteKeepsNodeSchedulingPreference(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Date(2026, 8, 30, 14, 30, 0, 0, time.UTC)
+	node, _, err := app.db.CreateControlNode(NodeCreateInput{Name: "preferred", Address: "203.0.113.80", Port: 19080}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "disabled-site", ListenPort: freePort(t), PublicHost: "disabled.example.com", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:8096", PlaybackMode: "direct", StreamHosts: "[]", UAMode: passthroughUAMode})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.SaveSiteNodeSchedule(site.ID, true, "fixed", node.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec(`UPDATE site_node_schedules SET desired_node_id=?,applied_node_id=?,dns_status='active',config_hash='old-hash' WHERE site_id=?`, node.ID, node.ID, site.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec("UPDATE sites SET enabled=0 WHERE id=?", site.ID); err != nil {
+		t.Fatal(err)
+	}
+	schedule, err := app.db.siteNodeSchedule(site.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := app.reconcileOneSiteSchedule(context.Background(), schedule, now); err != nil {
+		t.Fatalf("reconcile disabled site: %v", err)
+	}
+	updated, err := app.db.siteNodeSchedule(site.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updated.Enabled || updated.Mode != "fixed" || updated.FixedNodeID != node.ID {
+		t.Fatalf("scheduling preference was cleared: %#v", updated)
+	}
+	if updated.DesiredNodeID != 0 || updated.AppliedNodeID != 0 || updated.DNSStatus != "disabled" {
+		t.Fatalf("disabled site runtime was not cleared: %#v", updated)
+	}
+}
+
 func TestControlNodeAutoSchedulerSkipsDepletedAndOffline(t *testing.T) {
 	app := newTestApp(t)
 	now := time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC)

--- a/site_node_scheduler.go
+++ b/site_node_scheduler.go
@@ -1238,6 +1238,60 @@ func (a *App) deleteTrackedSiteDNS(ctx context.Context, schedule SiteNodeSchedul
 	return a.finalizeDisabledSiteNodeSchedule(schedule)
 }
 
+// deleteTrackedSiteDNSForSiteDisable removes the active DNS/runtime
+// assignment when the site itself is disabled, while preserving the
+// operator's scheduling preference (enabled, mode and fixed_node_id). A site
+// can therefore be re-enabled without silently losing its selected node.
+func (a *App) deleteTrackedSiteDNSForSiteDisable(ctx context.Context, schedule SiteNodeSchedule, now time.Time) error {
+	if schedule.cfRecordID != "" {
+		cf, err := a.cloudflareForScheduling()
+		if err != nil {
+			return err
+		}
+		if err := deleteTrackedSiteDNSRemote(ctx, cf, schedule); err != nil {
+			return err
+		}
+	}
+	return a.finalizeDisabledSiteNodeRuntime(schedule, now)
+}
+
+// finalizeDisabledSiteNodeRuntime clears assignments and revokes old routes
+// without changing the site's scheduling preference. This is intentionally
+// separate from finalizeDisabledSiteNodeSchedule, which is used when an
+// operator explicitly disables scheduling and must clear that preference.
+func (a *App) finalizeDisabledSiteNodeRuntime(schedule SiteNodeSchedule, now time.Time) error {
+	if a == nil || a.db == nil || schedule.SiteID <= 0 {
+		return nil
+	}
+	tx, err := a.db.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	ids, err := siteNodeRevocationIDsTx(tx, schedule.SiteID, schedule.FixedNodeID, schedule.DesiredNodeID, schedule.AppliedNodeID)
+	if err != nil {
+		return err
+	}
+	for _, nodeID := range ids {
+		if nodeID <= 0 {
+			continue
+		}
+		if _, err := tx.Exec(`INSERT OR IGNORE INTO agent_route_revocations(node_id,site_id,public_host,created_at_ms)
+			VALUES(?,?,?,?)`, nodeID, schedule.SiteID, strings.ToLower(strings.TrimSpace(schedule.PublicHost)), now.UnixMilli()); err != nil {
+			return err
+		}
+	}
+	if err := markAgentConfigsDirtyForNodeIDsTx(tx, ids...); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`UPDATE site_node_schedules SET desired_node_id=NULL,applied_node_id=NULL,
+		cf_zone_id='',cf_record_id='',cf_record_type='',applied_address='',dns_status='disabled',
+		last_error='',config_hash='',config_pending_since_ms=0,updated_at_ms=? WHERE site_id=?`, now.UnixMilli(), schedule.SiteID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 // finalizeDisabledSiteNodeSchedule clears every assignment and remote DNS
 // handle after the external delete has completed. It is deliberately safe to
 // call for already-disabled rows left by older releases, so the scheduler can
@@ -1358,10 +1412,9 @@ func (a *App) reconcileOneSiteSchedule(ctx context.Context, schedule SiteNodeSch
 	}
 	if !site.Enabled {
 		if schedule.cfRecordID != "" {
-			return a.deleteTrackedSiteDNS(ctx, schedule)
+			return a.deleteTrackedSiteDNSForSiteDisable(ctx, schedule, now)
 		}
-		_, err := a.db.db.Exec("UPDATE site_node_schedules SET dns_status='disabled',last_error='',updated_at_ms=? WHERE site_id=?", now.UnixMilli(), schedule.SiteID)
-		return err
+		return a.finalizeDisabledSiteNodeRuntime(schedule, now)
 	}
 	if schedule.DesiredNodeID <= 0 {
 		return errors.New("no eligible node is available")

--- a/tests/traffic_page.test.js
+++ b/tests/traffic_page.test.js
@@ -672,6 +672,29 @@ test('dashboard realtime trend uses real timestamps for pointer positions', () =
   assert.equal(right.index, 2, 'hover selection must follow timestamp position rather than sample index spacing');
 });
 
+test('dashboard realtime trend merges history at the server snapshot cutoff', () => {
+  const h = makeTrafficHarness();
+  h.sandbox.Date = { now: () => 60000 };
+  const points = vm.runInContext(`(() => {
+    dashboardTrendState = { siteId: 'all', range: 'realtime' };
+    dashboardTrendData = {
+      range: 'realtime', as_of_ms: 45000, start_ms: 0, end_ms: 120000,
+      points: [
+        { timestamp_ms: 0, traffic_bytes: 100, requests: 1 },
+        { timestamp_ms: 60000, traffic_bytes: 999, requests: 9 },
+      ],
+    };
+    dashboardRealtimeTrendSamples = new Map([['all', [
+      { timestamp_ms: 40000, traffic_bytes: 50, requests: 1 },
+      { timestamp_ms: 50000, traffic_bytes: 25, requests: 1 },
+    ]]]);
+    return dashboardTrendPoints();
+  })()`, h.sandbox);
+  assert.deepEqual(Array.from(points, point => point.timestamp_ms), [0, 50000]);
+  assert.deepEqual(Array.from(points, point => point.traffic_bytes), [100, 25]);
+  assert.deepEqual(Array.from(points, point => point.requests), [1, 1]);
+});
+
 test('dashboard realtime chart uses a fixed five-minute window and sparse boundary labels', () => {
   const h = makeTrafficHarness();
   h.sandbox.Date = { now: () => 180000 };

--- a/web/static/js/pages/dashboard.js
+++ b/web/static/js/pages/dashboard.js
@@ -594,7 +594,13 @@ function upsertDashboardRealtimeSample(samples, point) {
 
 function dashboardRealtimeTrendPoints() {
   const key = dashboardTrendState.siteId === 'all' ? 'all' : String(dashboardTrendState.siteId);
-  return dashboardRealtimeTrendSamples.get(key) || [];
+  const points = dashboardRealtimeTrendSamples.get(key) || [];
+  // The history response carries the exact server-side snapshot cutoff. Keep
+  // only live samples strictly newer than it so the current minute bucket is
+  // represented once when the two sources are merged.
+  const anchor = Number(dashboardTrendData?.as_of_ms || 0);
+  if (!Number.isFinite(anchor) || anchor <= 0) return points;
+  return points.filter(point => Number(point?.timestamp_ms || 0) > anchor);
 }
 
 function dashboardRealtimeHistoricalPoints() {
@@ -603,10 +609,13 @@ function dashboardRealtimeHistoricalPoints() {
   const { start, end } = dashboardRealtimeWindowBounds();
   const windowed = historical.filter(point => {
     const timestamp = Number(point?.timestamp_ms || 0);
-    return timestamp >= start && timestamp <= end;
+    const anchor = Number(dashboardTrendData?.as_of_ms || 0);
+    return timestamp >= start && timestamp <= end && (!anchor || timestamp <= anchor);
   });
   const realtime = dashboardRealtimeTrendPoints();
   if (!realtime.length) return windowed;
+  const anchor = Number(dashboardTrendData?.as_of_ms || 0);
+  if (Number.isFinite(anchor) && anchor > 0) return windowed;
   const firstRealtime = Number(realtime[0]?.timestamp_ms || 0);
   return windowed.filter(point => Number(point?.timestamp_ms || 0) < firstRealtime);
 }


### PR DESCRIPTION
本次发布包含以下修复：

- 统一 Agent 全量与实时遥测的顺序，避免旧样本覆盖新样本。
- 修复节点迁移期间实时数据收敛和 Agent 报告状态一致性。
- 站点禁用时清理运行时 DNS/路由状态，同时保留节点调度偏好。
- 趋势历史与实时数据按服务端快照时间合并，避免当前时间桶重复或错位。
- 将趋势查询内存缓存限制为最多 128 组并主动淘汰旧缓存，避免缓存无限增长。

已通过本地验证：go test ./...、go test -race ./...、go vet ./...、169 项 Node 测试及 JavaScript 语法检查。
