### PR TITLE
fix: order telemetry and stabilize realtime trends

### DIFF
--- a/agent_live_test.go
+++ b/agent_live_test.go
@@ -64,6 +64,56 @@ func TestNodeLiveReportOverlaysDashboardWithoutPersistingTraffic(t *testing.T) {
 	}
 }
 
+func TestDashboardTrendSnapshotReturnsPersistedAgentBaseline(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	node, enrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "trend-baseline-node", Address: "203.0.113.74", Port: 19074}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, token, err := app.db.EnrollControlNode(enrollment, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	site, err := app.db.CreateSiteRecord(Site{Name: "trend-baseline-site", ListenPort: freePort(t), PublicHost: "trend-baseline.example", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:1", PlaybackMode: "direct", MainVideoStreamMode: "proxy", StreamHosts: "[]", UAMode: passthroughUAMode})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.SaveSiteNodeSchedule(site.ID, true, "fixed", node.ID, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec("UPDATE site_node_schedules SET applied_node_id=?, dns_status='active' WHERE site_id=?", node.ID, site.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.RecordNodeReport(token, NodeReport{
+		BootID: "trend-baseline-boot", ReportSessionID: "trend-baseline-session", CounterEpoch: "kernel:eth0", SiteCounterEpoch: "1",
+		Sequence: 1, TelemetrySequence: 1, InterfaceName: "eth0", SiteStats: []NodeSiteStat{{SiteID: site.ID, Host: site.PublicHost, BytesIn: 10, BytesOut: 20, CumulativeBytesIn: 110, CumulativeBytesOut: 220, RequestCount: 11, CounterEpoch: 1}},
+	}, now); err != nil {
+		t.Fatal(err)
+	}
+	_, baselines, err := app.db.GetTrafficTrendLogsGroupedSnapshot(&site.ID, now.Add(-time.Minute), now.Add(time.Minute), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseline, ok := baselines[site.ID]
+	if !ok {
+		t.Fatalf("missing Agent trend baseline: %#v", baselines)
+	}
+	if baseline.BytesIn != 110 || baseline.BytesOut != 220 || baseline.Requests != 11 || baseline.SampledAtMS != now.UnixMilli() {
+		t.Fatalf("baseline=%+v, want counters 110/220/11 at %d", baseline, now.UnixMilli())
+	}
+	trend, err := app.pm.dashboardTrends(&site.ID, "realtime")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if trend.AsOfMS != now.UnixMilli() {
+		t.Fatalf("dashboard AsOfMS=%d, want persisted Agent watermark %d", trend.AsOfMS, now.UnixMilli())
+	}
+	if got := trend.LiveBaselines[site.ID]; got != baseline {
+		t.Fatalf("dashboard live baseline=%+v, want %+v", got, baseline)
+	}
+}
+
 func TestNodeTelemetrySequenceOrdersFullAndLiveChannels(t *testing.T) {
 	app := newTestApp(t)
 	now := time.Now().UTC()

--- a/dashboard_trends.go
+++ b/dashboard_trends.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -66,6 +67,17 @@ type dashboardTrendPoint struct {
 	UploadBPS   float64 `json:"upload_bps"`
 }
 
+// dashboardTrendBaseline is the last cumulative Agent counter that is
+// durably represented by node_site_traffic_logs. Realtime samples after this
+// watermark can be converted to deltas without using the Controller wall
+// clock as a proxy for persisted history.
+type dashboardTrendBaseline struct {
+	BytesIn     int64 `json:"bytes_in"`
+	BytesOut    int64 `json:"bytes_out"`
+	Requests    int64 `json:"requests"`
+	SampledAtMS int64 `json:"sampled_at_ms"`
+}
+
 type dashboardTrendsResponse struct {
 	SiteID         string `json:"site_id"`
 	Range          string `json:"range"`
@@ -75,10 +87,11 @@ type dashboardTrendsResponse struct {
 	EndMS          int64  `json:"end_ms"`
 	// AsOfMS is the history snapshot cutoff. Realtime points newer than this
 	// instant can be merged without double-counting the current bucket.
-	AsOfMS        int64                 `json:"as_of_ms"`
-	BucketSeconds int64                 `json:"bucket_seconds"`
-	Points        []dashboardTrendPoint `json:"points"`
-	SiteSeries    []dashboardTrendSite  `json:"site_series"`
+	AsOfMS        int64                            `json:"as_of_ms"`
+	LiveBaselines map[int64]dashboardTrendBaseline `json:"live_baselines,omitempty"`
+	BucketSeconds int64                            `json:"bucket_seconds"`
+	Points        []dashboardTrendPoint            `json:"points"`
+	SiteSeries    []dashboardTrendSite             `json:"site_series"`
 }
 
 // dashboardTrendSite carries the same time buckets as the aggregate chart,
@@ -179,22 +192,76 @@ func dashboardTrendWindowWithLocation(name string, now, customStart, customEnd t
 }
 
 func (pm *ProxyManager) pendingDashboardTraffic(siteID *int64) map[int64]dashboardPendingTraffic {
-	result := make(map[int64]dashboardPendingTraffic)
+	result, _, unlock := pm.lockLocalDashboardTrendSnapshot(siteID, time.Now())
+	unlock()
+	return result
+}
+
+// lockLocalDashboardTrendSnapshot pins every selected local proxy while the
+// caller takes the SQLite history snapshot. Holding trafficMu across that
+// read makes the in-memory cumulative/pending split and traffic_logs observe
+// one consistent point in time; the returned unlock function must be called
+// on every path.
+func (pm *ProxyManager) lockLocalDashboardTrendSnapshot(siteID *int64, sampledAt time.Time) (map[int64]dashboardPendingTraffic, map[int64]dashboardTrendBaseline, func()) {
+	pendingResult := make(map[int64]dashboardPendingTraffic)
+	baselineResult := make(map[int64]dashboardTrendBaseline)
+	if pm == nil {
+		return pendingResult, baselineResult, func() {}
+	}
 	pm.mu.RLock()
-	defer pm.mu.RUnlock()
+	ids := make([]int64, 0, len(pm.proxies))
+	instances := make(map[int64]*ProxyInstance)
 	for id, inst := range pm.proxies {
 		if siteID != nil && *siteID != id {
 			continue
 		}
-		inst.trafficMu.Lock()
-		result[id] = dashboardPendingTraffic{
-			BytesIn:  inst.trafficBytesIn().Load(),
-			BytesOut: inst.trafficBytesOut().Load(),
-			Requests: inst.trafficPendingRequests().Load(),
-		}
-		inst.trafficMu.Unlock()
+		ids = append(ids, id)
+		instances[id] = inst
 	}
-	return result
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	for _, id := range ids {
+		inst := instances[id]
+		inst.trafficMu.Lock()
+		pendingIn := inst.trafficBytesIn().Load()
+		pendingOut := inst.trafficBytesOut().Load()
+		pendingRequests := inst.trafficPendingRequests().Load()
+		baselineIn := inst.trafficCumulativeIn().Load() - pendingIn
+		baselineOut := inst.trafficCumulativeOut().Load() - pendingOut
+		baselineRequests := inst.trafficRequests().Load() - pendingRequests
+		if baselineIn < 0 {
+			baselineIn = 0
+		}
+		if baselineOut < 0 {
+			baselineOut = 0
+		}
+		if baselineRequests < 0 {
+			baselineRequests = 0
+		}
+		pendingResult[id] = dashboardPendingTraffic{
+			BytesIn: pendingIn, BytesOut: pendingOut, Requests: pendingRequests,
+		}
+		baselineResult[id] = dashboardTrendBaseline{
+			BytesIn: baselineIn, BytesOut: baselineOut, Requests: baselineRequests,
+			SampledAtMS: sampledAt.UnixMilli(),
+		}
+	}
+	return pendingResult, baselineResult, func() {
+		for index := len(ids) - 1; index >= 0; index-- {
+			instances[ids[index]].trafficMu.Unlock()
+		}
+		pm.mu.RUnlock()
+	}
+}
+
+// localDashboardTrendBaselines returns the controller-local cumulative
+// counters that are already represented by traffic_logs at the same snapshot
+// as pendingDashboardTraffic. Agent baselines come from SQLite; local proxy
+// baselines are derived by subtracting the unflushed counters from the
+// process-stable cumulative counters.
+func (pm *ProxyManager) localDashboardTrendBaselines(siteID *int64, sampledAt time.Time) map[int64]dashboardTrendBaseline {
+	_, baselines, unlock := pm.lockLocalDashboardTrendSnapshot(siteID, sampledAt)
+	unlock()
+	return baselines
 }
 
 func dashboardTrendPoints(start, end time.Time, bucket time.Duration, rangeName string, billingMode string, logs []TrafficLog, pending dashboardPendingTraffic, now ...time.Time) []dashboardTrendPoint {
@@ -305,7 +372,9 @@ func (pm *ProxyManager) dashboardTrendsUncoalesced(siteID *int64, rangeName stri
 	if cached := pm.dashboardTrendCached(cacheKey, now); cached != nil {
 		return cached, nil
 	}
-	logs, err := pm.database.GetTrafficTrendLogsGrouped(siteID, start, end, bucket)
+	pendingBySite, localBaselines, unlockLocal := pm.lockLocalDashboardTrendSnapshot(siteID, now)
+	defer unlockLocal()
+	logs, liveBaselines, err := pm.database.GetTrafficTrendLogsGroupedSnapshot(siteID, start, end, bucket)
 	if err != nil {
 		return nil, err
 	}
@@ -323,7 +392,11 @@ func (pm *ProxyManager) dashboardTrendsUncoalesced(siteID *int64, rangeName stri
 	for _, logRow := range logs {
 		logsBySite[logRow.SiteID] = append(logsBySite[logRow.SiteID], logRow)
 	}
-	pendingBySite := pm.pendingDashboardTraffic(siteID)
+	for localSiteID, baseline := range localBaselines {
+		if _, exists := liveBaselines[localSiteID]; !exists {
+			liveBaselines[localSiteID] = baseline
+		}
+	}
 	var aggregatePending dashboardPendingTraffic
 	for _, value := range pendingBySite {
 		aggregatePending.BytesIn += value.BytesIn
@@ -339,6 +412,33 @@ func (pm *ProxyManager) dashboardTrendsUncoalesced(siteID *int64, rangeName stri
 			Points:   dashboardTrendPoints(start, end, bucket, name, billingMode, logsBySite[site.ID], pendingBySite[site.ID], now),
 		})
 	}
+	// AsOfMS is a real persisted-history watermark whenever every selected
+	// site is backed by an Agent counter baseline. Mixed local/Agent views keep
+	// the request-time fallback because no single timestamp can describe both
+	// sources; their per-site baselines are still returned for exact merges.
+	asOfMS := now.UnixMilli()
+	if len(selectedSites) > 0 {
+		complete := true
+		earliest := int64(0)
+		for _, site := range selectedSites {
+			baseline, ok := liveBaselines[site.ID]
+			if !ok || baseline.SampledAtMS <= 0 {
+				complete = false
+				break
+			}
+			if earliest == 0 || baseline.SampledAtMS < earliest {
+				earliest = baseline.SampledAtMS
+			}
+		}
+		if complete && earliest > 0 {
+			asOfMS = earliest
+		}
+	}
+	if siteID != nil {
+		if baseline, ok := liveBaselines[*siteID]; ok && baseline.SampledAtMS > 0 {
+			asOfMS = baseline.SampledAtMS
+		}
+	}
 	response := &dashboardTrendsResponse{
 		SiteID: func() string {
 			if siteID == nil {
@@ -351,7 +451,8 @@ func (pm *ProxyManager) dashboardTrendsUncoalesced(siteID *int64, rangeName stri
 		TimezoneOffset: settings.ScheduleTimezone,
 		StartMS:        start.UnixMilli(),
 		EndMS:          end.UnixMilli(),
-		AsOfMS:         now.UnixMilli(),
+		AsOfMS:         asOfMS,
+		LiveBaselines:  liveBaselines,
 		BucketSeconds:  int64(bucket / time.Second),
 		Points:         points,
 		SiteSeries:     siteSeries,

--- a/edge_agent.go
+++ b/edge_agent.go
@@ -531,12 +531,17 @@ type edgeAgentRuntime struct {
 	eventSpoolError      string
 	events               edgeEventStore
 	stats                edgeSiteStats
-	telemetryMu          sync.Mutex
-	mediaCounts          map[int64]NodeMediaCount
-	retention            map[int64]NodeRetentionStatus
-	observations         []NodeDynamicObservation
-	siteReported         map[int64]ProxyRuntimeStat
-	trafficCounters      map[int64]*edgeSiteTrafficCounter
+	// telemetrySampleMu serializes the complete snapshot operation shared by
+	// the full and lightweight report loops. TelemetrySequence is allocated
+	// only after the snapshot is captured while this lock is held, so a larger
+	// sequence can never refer to an older counter snapshot.
+	telemetrySampleMu sync.Mutex
+	telemetryMu       sync.Mutex
+	mediaCounts       map[int64]NodeMediaCount
+	retention         map[int64]NodeRetentionStatus
+	observations      []NodeDynamicObservation
+	siteReported      map[int64]ProxyRuntimeStat
+	trafficCounters   map[int64]*edgeSiteTrafficCounter
 	// trafficHosts keeps the Controller host alongside the process-stable
 	// counter. A route can disappear from the current bundle while an admitted
 	// stream is still draining; its counter must remain reportable.
@@ -1060,6 +1065,43 @@ func (runtime *edgeAgentRuntime) liveSiteTrafficSnapshot() []NodeLiveSiteTraffic
 	}
 	runtime.mu.RUnlock()
 	return result
+}
+
+// sampleTelemetry runs one complete telemetry capture under the shared
+// sampler lock and allocates the ordering sequence afterwards. The callback
+// must capture all data represented by the sequence before returning.
+func (runtime *edgeAgentRuntime) sampleTelemetry(capture func()) (sequence, sampledAtMS int64) {
+	if runtime == nil {
+		return 0, 0
+	}
+	runtime.telemetrySampleMu.Lock()
+	defer runtime.telemetrySampleMu.Unlock()
+	if capture != nil {
+		capture()
+	}
+	sequence = runtime.nextTelemetrySequence()
+	sampledAtMS = time.Now().UnixMilli()
+	return sequence, sampledAtMS
+}
+
+func (runtime *edgeAgentRuntime) captureFullTelemetry(bootID string, sequence int64) (NodeReport, edgeSiteStatsPending, edgeTelemetryPending, error) {
+	if runtime == nil {
+		return NodeReport{}, edgeSiteStatsPending{}, edgeTelemetryPending{}, errors.New("nil Agent runtime")
+	}
+	runtime.telemetrySampleMu.Lock()
+	defer runtime.telemetrySampleMu.Unlock()
+	report, err := edgeCollect(bootID, sequence)
+	if err != nil {
+		return NodeReport{}, edgeSiteStatsPending{}, edgeTelemetryPending{}, err
+	}
+	pendingStats := runtime.prepareSiteStats()
+	pendingTelemetry := runtime.prepareTelemetry()
+	report.TelemetrySequence = runtime.nextTelemetrySequence()
+	report.SiteStats = pendingStats.stats
+	report.MediaCounts = pendingTelemetry.media
+	report.Retention = pendingTelemetry.retention
+	report.Observations = pendingTelemetry.observations
+	return report, pendingStats, pendingTelemetry, nil
 }
 
 func (runtime *edgeAgentRuntime) commitSiteStatsWithACK(pending edgeSiteStatsPending, acknowledged map[int64]bool) {
@@ -2249,13 +2291,17 @@ func edgeLiveReportLoop(ctx context.Context, client *http.Client, controller, to
 	sequence := int64(0)
 	send := func() error {
 		sequence++
+		var stats []NodeLiveSiteTraffic
+		telemetrySequence, sampledAtMS := runtime.sampleTelemetry(func() {
+			stats = runtime.liveSiteTrafficSnapshot()
+		})
 		report := NodeLiveReport{
 			ReportSessionID:   sessionID,
 			CounterEpoch:      edgeCounterEpoch(edgeDefaultInterface()),
 			Sequence:          sequence,
-			TelemetrySequence: runtime.nextTelemetrySequence(),
-			SampledAtMS:       time.Now().UnixMilli(),
-			SiteStats:         runtime.liveSiteTrafficSnapshot(),
+			TelemetrySequence: telemetrySequence,
+			SampledAtMS:       sampledAtMS,
+			SiteStats:         stats,
 		}
 		var ack struct{}
 		return edgeAPIRequest(ctx, client, http.MethodPost, controller+"/api/agent/live", token, report, &ack)
@@ -2649,7 +2695,7 @@ func runEdgeAgent() error {
 		}
 		refreshImmediately := false
 		sequence++
-		report, collectErr := edgeCollect(bootID, sequence)
+		report, pendingStats, pendingTelemetry, collectErr := runtime.captureFullTelemetry(bootID, sequence)
 		if collectErr != nil {
 			fmt.Fprintf(os.Stderr, "Meridian Agent traffic collection failed: %v\n", collectErr)
 		} else {
@@ -2658,13 +2704,8 @@ func runEdgeAgent() error {
 			report.CacheClearGeneration = runtime.cacheClearGeneration
 			report.SiteCounterEpoch = strconv.FormatUint(runtime.siteCounterEpoch, 10)
 			runtime.mu.RUnlock()
-			report.TelemetrySequence = runtime.nextTelemetrySequence()
 			report.EventSpoolError, report.EventQueueDepth = runtime.eventSpoolStatus()
 			report.EventDropped = runtime.events.droppedCount()
-			pendingStats := runtime.prepareSiteStats()
-			pendingTelemetry := runtime.prepareTelemetry()
-			report.SiteStats = pendingStats.stats
-			report.MediaCounts, report.Retention, report.Observations = pendingTelemetry.media, pendingTelemetry.retention, pendingTelemetry.observations
 			report.Events = edgeReportEventsByBudget(report, runtime.events.snapshot())
 			ack, wsErr := wsReporter.report(ctx, report)
 			if wsErr != nil {

--- a/edge_agent_test.go
+++ b/edge_agent_test.go
@@ -108,6 +108,39 @@ func TestEdgeTrafficCounterEpochAdvancesAfterRetirement(t *testing.T) {
 	}
 }
 
+func TestAgentTelemetrySequenceIsBoundToSnapshotOrder(t *testing.T) {
+	runtime := &edgeAgentRuntime{}
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	firstDone := make(chan int64, 1)
+	go func() {
+		sequence, _ := runtime.sampleTelemetry(func() {
+			close(firstEntered)
+			<-releaseFirst
+		})
+		firstDone <- sequence
+	}()
+	<-firstEntered
+
+	secondEntered := make(chan struct{})
+	secondDone := make(chan int64, 1)
+	go func() {
+		sequence, _ := runtime.sampleTelemetry(func() { close(secondEntered) })
+		secondDone <- sequence
+	}()
+	select {
+	case <-secondEntered:
+		t.Fatal("second telemetry snapshot ran before the first snapshot released its sampler lock")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(releaseFirst)
+	firstSequence := <-firstDone
+	secondSequence := <-secondDone
+	if firstSequence <= 0 || secondSequence != firstSequence+1 {
+		t.Fatalf("telemetry sequence order=%d,%d, want consecutive snapshot order", firstSequence, secondSequence)
+	}
+}
+
 func TestEdgeSiteStatsRetainRemovedRouteUntilControllerAcknowledgesIt(t *testing.T) {
 	runtime := &edgeAgentRuntime{}
 	counter := runtime.trafficCounterFor(42, "tail.example.test")

--- a/tests/traffic_page.test.js
+++ b/tests/traffic_page.test.js
@@ -711,6 +711,39 @@ test('dashboard realtime chart uses a fixed five-minute window and sparse bounda
   assert.equal(vm.runInContext('dashboardTrendAxisLabel(1, [{ timestamp_ms: 179000 } , { timestamp_ms: 180000 }], "realtime", -120000, 180000)', h.sandbox), 180000);
 });
 
+test('dashboard realtime paths stay anchored to both chart boundaries', () => {
+  const h = makeTrafficHarness();
+  const padded = vm.runInContext(`dashboardTrendPaddedPathPoints(
+    [{ x: 120, y: 80 }, { x: 180, y: 80 }], 20, 280, 180, true
+  )`, h.sandbox);
+  assert.equal(padded[0].x, 20);
+  assert.equal(padded.at(-1).x, 280);
+  assert.equal(padded[0].y, 180);
+  assert.equal(padded.at(-1).y, 180);
+  assert.equal(padded.length, 4);
+});
+
+test('dashboard realtime Agent baseline converts cumulative samples into a lossless tail', () => {
+  const h = makeTrafficHarness();
+  const points = vm.runInContext(`(() => {
+    dashboardTrendState = { siteId: '7', range: 'realtime' };
+    dashboardTrendData = {
+      range: 'realtime', as_of_ms: 4000, billing_mode: 'outbound',
+      live_baselines: { '7': { bytes_in: 100, bytes_out: 200, requests: 10, sampled_at_ms: 4000 } },
+      points: [{ timestamp_ms: 0, traffic_bytes: 100, requests: 1 }],
+    };
+    dashboardRealtimeTrendSamples = new Map([['7', [
+      { timestamp_ms: 3000, cumulative_bytes_in: 110, cumulative_bytes_out: 220, cumulative_requests: 11, traffic_bytes: 0 },
+      { timestamp_ms: 6000, cumulative_bytes_in: 130, cumulative_bytes_out: 260, cumulative_requests: 13, traffic_bytes: 0 },
+      { timestamp_ms: 8000, cumulative_bytes_in: 135, cumulative_bytes_out: 270, cumulative_requests: 14, traffic_bytes: 0 },
+    ]]]);
+    return dashboardRealtimeTrendPoints();
+  })()`, h.sandbox);
+  assert.deepEqual(Array.from(points, point => point.timestamp_ms), [6000, 8000]);
+  assert.deepEqual(Array.from(points, point => [point.bytes_out, point.requests]), [[60, 3], [10, 1]]);
+  assert.deepEqual(Array.from(points, point => point.download_bps), [30, 5]);
+});
+
 test('dashboard realtime trend persists recent points across a page refresh', () => {
   let stored = null;
   const storage = {

--- a/traffic_repository.go
+++ b/traffic_repository.go
@@ -366,11 +366,11 @@ func (d *DB) GetTrafficTrendLogs(siteID *int64, start, end time.Time) ([]Traffic
 	return d.GetTrafficTrendLogsGrouped(siteID, start, end, time.Minute)
 }
 
-// GetTrafficTrendLogsGrouped aggregates both controller and node traffic at
-// the requested bucket in SQLite, keeping long dashboard ranges out of the Go
-// heap. The returned rows are already ordered and can be fed directly to the
-// dashboard bucket merger.
-func (d *DB) GetTrafficTrendLogsGrouped(siteID *int64, start, end time.Time, bucket time.Duration) ([]TrafficLog, error) {
+type trafficTrendRowsQueryer interface {
+	Query(query string, args ...any) (*sql.Rows, error)
+}
+
+func queryTrafficTrendLogsGrouped(queryer trafficTrendRowsQueryer, siteID *int64, start, end time.Time, bucket time.Duration) ([]TrafficLog, error) {
 	bucketMS := bucket.Milliseconds()
 	if bucketMS < 1 {
 		bucketMS = time.Minute.Milliseconds()
@@ -393,7 +393,7 @@ func (d *DB) GetTrafficTrendLogsGrouped(siteID *int64, start, end time.Time, buc
 		args = append(args, *siteID)
 	}
 	query += " GROUP BY site_id, bucket_ms ORDER BY bucket_ms, site_id"
-	rows, err := d.db.Query(query, args...)
+	rows, err := queryer.Query(query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -411,4 +411,63 @@ func (d *DB) GetTrafficTrendLogsGrouped(siteID *int64, start, end time.Time, buc
 		return nil, err
 	}
 	return logs, nil
+}
+
+// GetTrafficTrendLogsGrouped aggregates both controller and node traffic at
+// the requested bucket in SQLite, keeping long dashboard ranges out of the Go
+// heap. The returned rows are already ordered and can be fed directly to the
+// dashboard bucket merger.
+func (d *DB) GetTrafficTrendLogsGrouped(siteID *int64, start, end time.Time, bucket time.Duration) ([]TrafficLog, error) {
+	return queryTrafficTrendLogsGrouped(d.db, siteID, start, end, bucket)
+}
+
+// GetTrafficTrendLogsGroupedSnapshot reads trend rows and the Agent counter
+// baselines from one SQLite read transaction. The baseline timestamp is the
+// exact moment the last full report was committed, rather than the HTTP
+// request wall clock, so the dashboard can merge the live tail without a gap.
+func (d *DB) GetTrafficTrendLogsGroupedSnapshot(siteID *int64, start, end time.Time, bucket time.Duration) ([]TrafficLog, map[int64]dashboardTrendBaseline, error) {
+	tx, err := d.db.Begin()
+	if err != nil {
+		return nil, nil, err
+	}
+	defer tx.Rollback()
+	logs, err := queryTrafficTrendLogsGrouped(tx, siteID, start, end, bucket)
+	if err != nil {
+		return nil, nil, err
+	}
+	query := `SELECT c.site_id, c.last_bytes_in, c.last_bytes_out, c.last_request_count, c.updated_at_ms
+		FROM node_site_counters c
+		JOIN site_node_schedules sch ON sch.site_id=c.site_id AND sch.applied_node_id=c.node_id
+		JOIN sites s ON s.id=c.site_id
+		WHERE sch.enabled=1 AND s.enabled=1 AND c.updated_at_ms>0`
+	args := make([]any, 0, 1)
+	if siteID != nil {
+		query += " AND c.site_id=?"
+		args = append(args, *siteID)
+	}
+	rows, err := tx.Query(query, args...)
+	if err != nil {
+		return nil, nil, err
+	}
+	baselines := make(map[int64]dashboardTrendBaseline)
+	for rows.Next() {
+		var siteIDValue int64
+		var baseline dashboardTrendBaseline
+		if err := rows.Scan(&siteIDValue, &baseline.BytesIn, &baseline.BytesOut, &baseline.Requests, &baseline.SampledAtMS); err != nil {
+			rows.Close()
+			return nil, nil, err
+		}
+		baselines[siteIDValue] = baseline
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, nil, err
+	}
+	return logs, baselines, nil
 }

--- a/web/static/js/pages/dashboard.js
+++ b/web/static/js/pages/dashboard.js
@@ -481,6 +481,12 @@ function dashboardNormalizeRealtimePoint(value) {
     bytes_out: numberOrZero(value.bytes_out),
     requests: numberOrZero(value.requests),
   };
+  // Cumulative counters let the realtime tail start from the exact
+  // persisted Agent baseline returned by the Controller. Older localStorage
+  // entries may omit them and continue through the legacy timestamp merge.
+  if (value.cumulative_bytes_in !== undefined) point.cumulative_bytes_in = numberOrZero(value.cumulative_bytes_in);
+  if (value.cumulative_bytes_out !== undefined) point.cumulative_bytes_out = numberOrZero(value.cumulative_bytes_out);
+  if (value.cumulative_requests !== undefined) point.cumulative_requests = numberOrZero(value.cumulative_requests);
   if (value.traffic_bytes !== undefined) point.traffic_bytes = numberOrZero(value.traffic_bytes);
   if (value.site_contributions && typeof value.site_contributions === 'object' && !Array.isArray(value.site_contributions)) {
     const contributions = {};
@@ -595,12 +601,72 @@ function upsertDashboardRealtimeSample(samples, point) {
 function dashboardRealtimeTrendPoints() {
   const key = dashboardTrendState.siteId === 'all' ? 'all' : String(dashboardTrendState.siteId);
   const points = dashboardRealtimeTrendSamples.get(key) || [];
-  // The history response carries the exact server-side snapshot cutoff. Keep
-  // only live samples strictly newer than it so the current minute bucket is
-  // represented once when the two sources are merged.
-  const anchor = Number(dashboardTrendData?.as_of_ms || 0);
-  if (!Number.isFinite(anchor) || anchor <= 0) return points;
-  return points.filter(point => Number(point?.timestamp_ms || 0) > anchor);
+  const baseline = dashboardRealtimeBaselineForKey(key);
+  const anchor = Number(baseline?.sampled_at_ms || dashboardTrendData?.as_of_ms || 0);
+  const newer = !Number.isFinite(anchor) || anchor <= 0
+    ? points
+    : points.filter(point => Number(point?.timestamp_ms || 0) > anchor);
+  if (!baseline || !newer.length || !Number.isFinite(Number(baseline.sampled_at_ms)) || Number(baseline.sampled_at_ms) <= 0) return newer;
+  let previous = {
+    bytesIn: Math.max(0, Number(baseline.bytes_in || 0)),
+    bytesOut: Math.max(0, Number(baseline.bytes_out || 0)),
+    requests: Math.max(0, Number(baseline.requests || 0)),
+    timestamp: Number(baseline.sampled_at_ms),
+  };
+  return newer.map(point => {
+    const hasCumulative = point.cumulative_bytes_in !== undefined || point.cumulative_bytes_out !== undefined || point.cumulative_requests !== undefined;
+    if (!hasCumulative) return point;
+    const current = {
+      bytesIn: Math.max(0, Number(point.cumulative_bytes_in || 0)),
+      bytesOut: Math.max(0, Number(point.cumulative_bytes_out || 0)),
+      requests: Math.max(0, Number(point.cumulative_requests || 0)),
+      timestamp: Number(point.timestamp_ms || previous.timestamp),
+    };
+    const deltaIn = current.bytesIn >= previous.bytesIn ? current.bytesIn - previous.bytesIn : current.bytesIn;
+    const deltaOut = current.bytesOut >= previous.bytesOut ? current.bytesOut - previous.bytesOut : current.bytesOut;
+    const deltaRequests = current.requests >= previous.requests ? current.requests - previous.requests : current.requests;
+    const seconds = Math.max(0, (current.timestamp - previous.timestamp) / 1000);
+    const next = {
+      ...point,
+      bytes_in: deltaIn,
+      bytes_out: deltaOut,
+      requests: deltaRequests,
+      download_bps: seconds > 0 ? deltaOut / seconds : 0,
+      upload_bps: seconds > 0 ? deltaIn / seconds : 0,
+    };
+    if (point.traffic_bytes !== undefined) {
+      const mode = dashboardTrendData?.billing_mode;
+      next.traffic_bytes = mode === 'outbound' ? deltaOut : 2 * (deltaIn + deltaOut);
+    }
+    previous = current;
+    return next;
+  });
+}
+
+function dashboardRealtimeBaselineForKey(key) {
+  const raw = dashboardTrendData?.live_baselines;
+  if (!raw || typeof raw !== 'object') return null;
+  if (key !== 'all') return raw[key] || raw[String(key)] || null;
+  const series = Array.isArray(dashboardTrendData?.site_series) ? dashboardTrendData.site_series : [];
+  if (!series.length) return null;
+  const aggregate = { bytes_in: 0, bytes_out: 0, requests: 0, sampled_at_ms: 0 };
+  for (const site of series) {
+    const baseline = raw[String(site.site_id)] || raw[site.site_id];
+    if (!baseline || Number(baseline.sampled_at_ms || 0) <= 0) return null;
+    aggregate.bytes_in += Math.max(0, Number(baseline.bytes_in || 0));
+    aggregate.bytes_out += Math.max(0, Number(baseline.bytes_out || 0));
+    aggregate.requests += Math.max(0, Number(baseline.requests || 0));
+    const sampledAt = Number(baseline.sampled_at_ms);
+    if (!aggregate.sampled_at_ms || sampledAt < aggregate.sampled_at_ms) aggregate.sampled_at_ms = sampledAt;
+  }
+  return aggregate.sampled_at_ms > 0 ? aggregate : null;
+}
+
+function dashboardTrendCutoffMS() {
+  const key = dashboardTrendState.siteId === 'all' ? 'all' : String(dashboardTrendState.siteId);
+  const baseline = dashboardRealtimeBaselineForKey(key);
+  const value = Number(baseline?.sampled_at_ms || dashboardTrendData?.as_of_ms || 0);
+  return Number.isFinite(value) && value > 0 ? value : 0;
 }
 
 function dashboardRealtimeHistoricalPoints() {
@@ -609,12 +675,12 @@ function dashboardRealtimeHistoricalPoints() {
   const { start, end } = dashboardRealtimeWindowBounds();
   const windowed = historical.filter(point => {
     const timestamp = Number(point?.timestamp_ms || 0);
-    const anchor = Number(dashboardTrendData?.as_of_ms || 0);
+    const anchor = dashboardTrendCutoffMS();
     return timestamp >= start && timestamp <= end && (!anchor || timestamp <= anchor);
   });
   const realtime = dashboardRealtimeTrendPoints();
   if (!realtime.length) return windowed;
-  const anchor = Number(dashboardTrendData?.as_of_ms || 0);
+  const anchor = dashboardTrendCutoffMS();
   if (Number.isFinite(anchor) && anchor > 0) return windowed;
   const firstRealtime = Number(realtime[0]?.timestamp_ms || 0);
   return windowed.filter(point => Number(point?.timestamp_ms || 0) < firstRealtime);
@@ -698,6 +764,15 @@ function dashboardRoundRect(ctx, x, y, width, height, radius) {
   ctx.closePath();
 }
 
+function dashboardTrendPaddedPathPoints(points, left, right, baselineY, realtime) {
+  if (!realtime || !Array.isArray(points) || !points.length) return points || [];
+  const padded = points.slice();
+  const epsilon = 0.5;
+  if (padded[0].x > left + epsilon) padded.unshift({ x: left, y: baselineY, synthetic: true });
+  if (padded[padded.length - 1].x < right - epsilon) padded.push({ x: right, y: baselineY, synthetic: true });
+  return padded;
+}
+
 function drawDashboardTrendChart(metric) {
   const chart = dashboardTrendCharts.get(metric);
   const points = dashboardTrendChartPoints();
@@ -749,9 +824,18 @@ function drawDashboardTrendChart(metric) {
   const canvasSeries = series.map(item => ({ ...item, points: item.values.map((value, index) => ({
     x: xForTimestamp(points[index]?.timestamp_ms),
     y: top + plotH * (1 - (value / (scale.max || 1))),
-  })) }));
+  })), pathPoints: [] }));
   canvasSeries.forEach(item => {
-    const pointsOnCanvas = item.points;
+    item.pathPoints = dashboardTrendPaddedPathPoints(
+      item.points,
+      left,
+      width - right,
+      top + plotH,
+      dashboardTrendState.range === 'realtime',
+    );
+  });
+  canvasSeries.forEach(item => {
+    const pointsOnCanvas = item.pathPoints;
     ctx.beginPath();
     pointsOnCanvas.forEach((point, index) => index ? ctx.lineTo(point.x, point.y) : ctx.moveTo(point.x, point.y));
     if (metric !== 'speed') {
@@ -1276,6 +1360,14 @@ function updateDashboardSiteSpeeds(liveSites, snapshotMS, billingModeOverride) {
       totalRateIn += Math.max(0, Number(latest.up || 0));
     }
   }
+  let totalCumulativeIn = 0;
+  let totalCumulativeOut = 0;
+  let totalCumulativeRequests = 0;
+  dashboardSpeedSamples.forEach(sample => {
+    totalCumulativeIn += Math.max(0, Number(sample?.bytesIn || 0));
+    totalCumulativeOut += Math.max(0, Number(sample?.bytesOut || 0));
+    totalCumulativeRequests += Math.max(0, Number(sample?.requests || 0));
+  });
   const sampledAt = Number(snapshotMS || Date.now());
   const appendRealtimeTrendSample = (key, sample, sampleTimestamp = sampledAt, contributions = null) => {
     const samples = dashboardRealtimeTrendSamples.get(key) || [];
@@ -1289,6 +1381,9 @@ function updateDashboardSiteSpeeds(liveSites, snapshotMS, billingModeOverride) {
       bytes_out: bytesOut,
       requests: Math.max(0, Number(sample?.requests || 0)),
     };
+    if (sample?.cumulativeBytesIn !== undefined) point.cumulative_bytes_in = Math.max(0, Number(sample.cumulativeBytesIn || 0));
+    if (sample?.cumulativeBytesOut !== undefined) point.cumulative_bytes_out = Math.max(0, Number(sample.cumulativeBytesOut || 0));
+    if (sample?.cumulativeRequests !== undefined) point.cumulative_requests = Math.max(0, Number(sample.cumulativeRequests || 0));
     if (billingKnown) point.traffic_bytes = billingMode === 'outbound' ? bytesOut : 2 * (bytesIn + bytesOut);
     if (contributions && Object.keys(contributions).length) point.site_contributions = contributions;
     upsertDashboardRealtimeSample(samples, point);
@@ -1310,11 +1405,26 @@ function updateDashboardSiteSpeeds(liveSites, snapshotMS, billingModeOverride) {
       bytes_out: Math.max(0, Number(delta.bytesOut || 0)),
       requests: Math.max(0, Number(delta.requests || 0)),
     };
+    const cumulative = dashboardSpeedSamples.get(siteID);
+    if (cumulative) {
+      contributions[String(siteID)].cumulative_bytes_in = Math.max(0, Number(cumulative.bytesIn || 0));
+      contributions[String(siteID)].cumulative_bytes_out = Math.max(0, Number(cumulative.bytesOut || 0));
+      contributions[String(siteID)].cumulative_requests = Math.max(0, Number(cumulative.requests || 0));
+    }
     if (billingKnown) contributions[String(siteID)].traffic_bytes = billingMode === 'outbound'
       ? contributions[String(siteID)].bytes_out
       : 2 * (contributions[String(siteID)].bytes_in + contributions[String(siteID)].bytes_out);
   }
-  appendRealtimeTrendSample('all', { download_bps: totalRateOut, upload_bps: totalRateIn, bytesIn: totalDeltaIn, bytesOut: totalDeltaOut, requests: totalDeltaRequests }, sampledAt, contributions);
+  appendRealtimeTrendSample('all', {
+    download_bps: totalRateOut,
+    upload_bps: totalRateIn,
+    bytesIn: totalDeltaIn,
+    bytesOut: totalDeltaOut,
+    requests: totalDeltaRequests,
+    cumulativeBytesIn: totalCumulativeIn,
+    cumulativeBytesOut: totalCumulativeOut,
+    cumulativeRequests: totalCumulativeRequests,
+  }, sampledAt, contributions);
 
   // Site charts use the same controller snapshot timestamp rather than the
   // Agent's last site sample timestamp. Otherwise a site that reports less
@@ -1326,6 +1436,7 @@ function updateDashboardSiteSpeeds(liveSites, snapshotMS, billingModeOverride) {
       upload_bps: Math.max(0, Number(latest?.up || 0)),
     };
     const delta = trendDeltas.get(siteID) || {};
+    const currentSample = dashboardSpeedSamples.get(siteID);
     const siteSamples = dashboardRealtimeTrendSiteSamples.get(String(siteID)) || [];
     const siteSample = {
       timestamp_ms: sampledAt,
@@ -1334,9 +1445,18 @@ function updateDashboardSiteSpeeds(liveSites, snapshotMS, billingModeOverride) {
       bytes_in: Math.max(0, Number(delta.bytesIn || 0)),
       bytes_out: Math.max(0, Number(delta.bytesOut || 0)),
       requests: Math.max(0, Number(delta.requests || 0)),
+      cumulative_bytes_in: Math.max(0, Number(currentSample?.bytesIn || 0)),
+      cumulative_bytes_out: Math.max(0, Number(currentSample?.bytesOut || 0)),
+      cumulative_requests: Math.max(0, Number(currentSample?.requests || 0)),
     };
     if (billingKnown) siteSample.traffic_bytes = billingMode === 'outbound' ? siteSample.bytes_out : 2 * (siteSample.bytes_in + siteSample.bytes_out);
-    appendRealtimeTrendSample(String(siteID), { ...rate, ...delta }, sampledAt);
+    appendRealtimeTrendSample(String(siteID), {
+      ...rate,
+      ...delta,
+      cumulativeBytesIn: Math.max(0, Number(currentSample?.bytesIn || 0)),
+      cumulativeBytesOut: Math.max(0, Number(currentSample?.bytesOut || 0)),
+      cumulativeRequests: Math.max(0, Number(currentSample?.requests || 0)),
+    }, sampledAt);
     upsertDashboardRealtimeSample(siteSamples, siteSample);
     pruneDashboardRealtimeSamples(siteSamples);
     dashboardRealtimeTrendSiteSamples.set(String(siteID), siteSamples);


### PR DESCRIPTION
## Changes

- serialize Agent telemetry sampling so shared sequences match snapshot order
- merge dashboard history with persisted Agent counter baselines
- keep realtime trend paths anchored to the complete fixed window

## Validation

- go test ./...
- go test -race ./...
- go vet ./...
- node --test tests/*.test.js