### PR TITLE
feat: centralize dashboard realtime trend sampling

### DIFF
--- a/dashboard_realtime.go
+++ b/dashboard_realtime.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+// The Controller owns one fixed-cadence realtime sequence. Browsers consume
+// this sequence through SSE and the dashboard trend endpoint instead of
+// sampling independently, so every browser sees the same five-minute tail.
+const (
+	dashboardRealtimeServerInterval  = 2 * time.Second
+	dashboardRealtimeServerWindow    = 5 * time.Minute
+	dashboardRealtimeServerMaxPoints = 150
+)
+
+type dashboardRealtimeCounter struct {
+	BytesIn     int64
+	BytesOut    int64
+	Requests    int64
+	SampledAtMS int64
+}
+
+// startDashboardRealtimeSampler starts one process-wide sampler. It is
+// intentionally independent from the number of connected SSE clients.
+func (pm *ProxyManager) startDashboardRealtimeSampler(ctx context.Context) {
+	if pm == nil || ctx == nil || !pm.dashboardRealtimeStarted.CompareAndSwap(false, true) {
+		return
+	}
+	pm.captureDashboardRealtimeSample()
+	go func() {
+		ticker := time.NewTicker(dashboardRealtimeServerInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				pm.captureDashboardRealtimeSample()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (pm *ProxyManager) captureDashboardRealtimeSample() {
+	if pm == nil {
+		return
+	}
+	snapshot, err := pm.TrafficSnapshot()
+	if err != nil {
+		log.Printf("[dashboard-trend] realtime sample unavailable: %v", err)
+		return
+	}
+	sampledAtMS := snapshot.GeneratedAtMS
+	if sampledAtMS <= 0 {
+		sampledAtMS = time.Now().UnixMilli()
+	}
+
+	pm.dashboardRealtimeMu.Lock()
+	defer pm.dashboardRealtimeMu.Unlock()
+	if sampledAtMS <= pm.dashboardRealtimeLastMS {
+		return
+	}
+	if pm.dashboardRealtimePrev == nil {
+		pm.dashboardRealtimePrev = make(map[int64]dashboardRealtimeCounter)
+	}
+	if pm.dashboardRealtimeBillingMode != "" && pm.dashboardRealtimeBillingMode != snapshot.BillingMode {
+		// Billing policy changes make old traffic_bytes incomparable with new
+		// samples. Start a fresh visible window while keeping historical logs.
+		pm.dashboardRealtimePoints = nil
+		pm.dashboardRealtimePrev = make(map[int64]dashboardRealtimeCounter)
+	}
+	pm.dashboardRealtimeBillingMode = snapshot.BillingMode
+	point, next := dashboardRealtimePointFromSnapshot(snapshot, pm.dashboardRealtimePrev, sampledAtMS)
+	pm.dashboardRealtimePrev = next
+	pm.dashboardRealtimeLastMS = sampledAtMS
+	pm.dashboardRealtimePoints = appendDashboardRealtimePoint(pm.dashboardRealtimePoints, point)
+}
+
+func dashboardRealtimePointFromSnapshot(snapshot *TrafficSnapshot, previous map[int64]dashboardRealtimeCounter, sampledAtMS int64) (dashboardTrendPoint, map[int64]dashboardRealtimeCounter) {
+	point := dashboardTrendPoint{
+		TimestampMS:       sampledAtMS,
+		SiteContributions: make(map[int64]dashboardTrendPoint),
+	}
+	next := make(map[int64]dashboardRealtimeCounter)
+	if snapshot == nil {
+		point.SiteContributions = nil
+		return point, next
+	}
+	for _, site := range snapshot.LiveSites {
+		if site.ID <= 0 {
+			continue
+		}
+		current := dashboardRealtimeCounter{
+			BytesIn:     maxNonNegativeInt64(site.CumulativeBytesIn),
+			BytesOut:    maxNonNegativeInt64(site.CumulativeBytesOut),
+			Requests:    maxNonNegativeInt64(site.Requests),
+			SampledAtMS: sampledAtMS,
+		}
+		prior, exists := previous[site.ID]
+		deltaIn, deltaOut, deltaRequests := int64(0), int64(0), int64(0)
+		seconds := dashboardRealtimeServerInterval.Seconds()
+		if exists {
+			deltaIn = counterDelta(current.BytesIn, prior.BytesIn)
+			deltaOut = counterDelta(current.BytesOut, prior.BytesOut)
+			deltaRequests = counterDelta(current.Requests, prior.Requests)
+			if elapsed := time.Duration(sampledAtMS-prior.SampledAtMS) * time.Millisecond; elapsed > 0 {
+				seconds = elapsed.Seconds()
+			}
+		}
+		sitePoint := dashboardTrendPoint{
+			TimestampMS: sampledAtMS,
+			BytesIn:     deltaIn,
+			BytesOut:    deltaOut,
+			Requests:    deltaRequests,
+			DownloadBPS: float64(deltaOut) / seconds,
+			UploadBPS:   float64(deltaIn) / seconds,
+		}
+		// Keep a per-site traffic value so the frontend can render a selected
+		// site from the same authoritative aggregate sample.
+		sitePoint.Traffic = trafficBillableBytes(snapshot.BillingMode, deltaIn, deltaOut)
+		point.SiteContributions[site.ID] = sitePoint
+		point.BytesIn += deltaIn
+		point.BytesOut += deltaOut
+		point.Requests += deltaRequests
+		next[site.ID] = current
+	}
+	point.Traffic = trafficBillableBytes(snapshot.BillingMode, point.BytesIn, point.BytesOut)
+	point.DownloadBPS = float64(point.BytesOut) / dashboardRealtimeElapsedSeconds(sampledAtMS, previous)
+	point.UploadBPS = float64(point.BytesIn) / dashboardRealtimeElapsedSeconds(sampledAtMS, previous)
+	if len(point.SiteContributions) == 0 {
+		point.SiteContributions = nil
+	}
+	return point, next
+}
+
+func dashboardRealtimeElapsedSeconds(sampledAtMS int64, previous map[int64]dashboardRealtimeCounter) float64 {
+	if len(previous) > 0 {
+		oldest := int64(0)
+		for _, counter := range previous {
+			if counter.SampledAtMS > 0 && (oldest == 0 || counter.SampledAtMS < oldest) {
+				oldest = counter.SampledAtMS
+			}
+		}
+		if oldest > 0 && sampledAtMS > oldest {
+			return float64(sampledAtMS-oldest) / 1000
+		}
+	}
+	return dashboardRealtimeServerInterval.Seconds()
+}
+
+func counterDelta(current, previous int64) int64 {
+	if current >= previous {
+		return current - previous
+	}
+	return current
+}
+
+func maxNonNegativeInt64(value int64) int64 {
+	if value < 0 {
+		return 0
+	}
+	return value
+}
+
+func appendDashboardRealtimePoint(points []dashboardTrendPoint, point dashboardTrendPoint) []dashboardTrendPoint {
+	point = cloneDashboardTrendPoint(point)
+	if len(points) > 0 && points[len(points)-1].TimestampMS == point.TimestampMS {
+		points[len(points)-1] = point
+	} else {
+		points = append(points, point)
+	}
+	cutoff := point.TimestampMS - dashboardRealtimeServerWindow.Milliseconds()
+	first := 0
+	for first < len(points) && points[first].TimestampMS < cutoff {
+		first++
+	}
+	if first > 0 {
+		points = append([]dashboardTrendPoint(nil), points[first:]...)
+	}
+	if len(points) > dashboardRealtimeServerMaxPoints {
+		points = append([]dashboardTrendPoint(nil), points[len(points)-dashboardRealtimeServerMaxPoints:]...)
+	}
+	return points
+}
+
+func (pm *ProxyManager) dashboardRealtimeTrendLatest() *dashboardTrendPoint {
+	if pm == nil {
+		return nil
+	}
+	pm.dashboardRealtimeMu.RLock()
+	defer pm.dashboardRealtimeMu.RUnlock()
+	if len(pm.dashboardRealtimePoints) == 0 {
+		return nil
+	}
+	point := cloneDashboardTrendPoint(pm.dashboardRealtimePoints[len(pm.dashboardRealtimePoints)-1])
+	return &point
+}
+
+func (pm *ProxyManager) dashboardRealtimeTrendPoints(siteID *int64) []dashboardTrendPoint {
+	if pm == nil {
+		return nil
+	}
+	pm.dashboardRealtimeMu.RLock()
+	defer pm.dashboardRealtimeMu.RUnlock()
+	if siteID == nil {
+		return cloneDashboardTrendPoints(pm.dashboardRealtimePoints)
+	}
+	points := make([]dashboardTrendPoint, 0, len(pm.dashboardRealtimePoints))
+	for _, aggregate := range pm.dashboardRealtimePoints {
+		if site, ok := aggregate.SiteContributions[*siteID]; ok {
+			site.TimestampMS = aggregate.TimestampMS
+			points = append(points, cloneDashboardTrendPoint(site))
+		}
+	}
+	return points
+}
+
+func cloneDashboardTrendPoints(points []dashboardTrendPoint) []dashboardTrendPoint {
+	if len(points) == 0 {
+		return nil
+	}
+	cloned := make([]dashboardTrendPoint, len(points))
+	for i, point := range points {
+		cloned[i] = cloneDashboardTrendPoint(point)
+	}
+	return cloned
+}
+
+func cloneDashboardTrendPoint(point dashboardTrendPoint) dashboardTrendPoint {
+	if len(point.SiteContributions) == 0 {
+		point.SiteContributions = nil
+		return point
+	}
+	contributions := make(map[int64]dashboardTrendPoint, len(point.SiteContributions))
+	for siteID, sitePoint := range point.SiteContributions {
+		contributions[siteID] = cloneDashboardTrendPoint(sitePoint)
+	}
+	point.SiteContributions = contributions
+	return point
+}

--- a/dashboard_realtime_test.go
+++ b/dashboard_realtime_test.go
@@ -1,0 +1,67 @@
+package main
+
+import "testing"
+
+func TestDashboardRealtimePointFromSnapshotUsesCounterDeltas(t *testing.T) {
+	first := &TrafficSnapshot{
+		BillingMode: "bidirectional",
+		LiveSites: []SiteTraffic{{
+			ID:                 7,
+			CumulativeBytesIn:  100,
+			CumulativeBytesOut: 200,
+			Requests:           4,
+		}},
+	}
+	point, previous := dashboardRealtimePointFromSnapshot(first, nil, 1_000)
+	if point.BytesIn != 0 || point.BytesOut != 0 || point.Requests != 0 {
+		t.Fatalf("first sample must establish a baseline, got %+v", point)
+	}
+	if got := point.SiteContributions[7].Traffic; got != 0 {
+		t.Fatalf("first sample traffic=%d, want 0", got)
+	}
+
+	second := &TrafficSnapshot{
+		BillingMode: "bidirectional",
+		LiveSites: []SiteTraffic{{
+			ID:                 7,
+			CumulativeBytesIn:  140,
+			CumulativeBytesOut: 260,
+			Requests:           5,
+		}},
+	}
+	point, next := dashboardRealtimePointFromSnapshot(second, previous, 3_000)
+	if point.BytesIn != 40 || point.BytesOut != 60 || point.Requests != 1 {
+		t.Fatalf("aggregate deltas=%d/%d/%d, want 40/60/1", point.BytesIn, point.BytesOut, point.Requests)
+	}
+	if point.DownloadBPS != 30 || point.UploadBPS != 20 {
+		t.Fatalf("aggregate rates=%v/%v, want 30/20", point.DownloadBPS, point.UploadBPS)
+	}
+	if point.Traffic != 200 {
+		t.Fatalf("aggregate traffic=%d, want 200", point.Traffic)
+	}
+	contribution, ok := point.SiteContributions[7]
+	if !ok || contribution.BytesIn != 40 || contribution.BytesOut != 60 || contribution.Requests != 1 {
+		t.Fatalf("site contribution=%+v, present=%v", contribution, ok)
+	}
+	if next[7].BytesIn != 140 || next[7].BytesOut != 260 || next[7].Requests != 5 {
+		t.Fatalf("next baseline=%+v", next[7])
+	}
+}
+
+func TestAppendDashboardRealtimePointBoundsAndReplacement(t *testing.T) {
+	points := make([]dashboardTrendPoint, 0, dashboardRealtimeServerMaxPoints+10)
+	for i := int64(0); i < dashboardRealtimeServerMaxPoints+10; i++ {
+		points = appendDashboardRealtimePoint(points, dashboardTrendPoint{
+			TimestampMS: i * dashboardRealtimeServerInterval.Milliseconds(),
+			DownloadBPS: float64(i),
+		})
+	}
+	if len(points) != dashboardRealtimeServerMaxPoints {
+		t.Fatalf("point count=%d, want %d", len(points), dashboardRealtimeServerMaxPoints)
+	}
+	latest := points[len(points)-1].TimestampMS
+	points = appendDashboardRealtimePoint(points, dashboardTrendPoint{TimestampMS: latest, DownloadBPS: 999})
+	if len(points) != dashboardRealtimeServerMaxPoints || points[len(points)-1].DownloadBPS != 999 {
+		t.Fatalf("duplicate timestamp was not replaced: len=%d latest=%+v", len(points), points[len(points)-1])
+	}
+}

--- a/dashboard_trends.go
+++ b/dashboard_trends.go
@@ -58,13 +58,14 @@ func (pm *ProxyManager) cacheDashboardTrend(key string, response *dashboardTrend
 }
 
 type dashboardTrendPoint struct {
-	TimestampMS int64   `json:"timestamp_ms"`
-	Traffic     int64   `json:"traffic_bytes"`
-	BytesIn     int64   `json:"bytes_in"`
-	BytesOut    int64   `json:"bytes_out"`
-	Requests    int64   `json:"requests"`
-	DownloadBPS float64 `json:"download_bps"`
-	UploadBPS   float64 `json:"upload_bps"`
+	TimestampMS       int64                         `json:"timestamp_ms"`
+	Traffic           int64                         `json:"traffic_bytes"`
+	BytesIn           int64                         `json:"bytes_in"`
+	BytesOut          int64                         `json:"bytes_out"`
+	Requests          int64                         `json:"requests"`
+	DownloadBPS       float64                       `json:"download_bps"`
+	UploadBPS         float64                       `json:"upload_bps"`
+	SiteContributions map[int64]dashboardTrendPoint `json:"site_contributions,omitempty"`
 }
 
 // dashboardTrendBaseline is the last cumulative Agent counter that is
@@ -91,10 +92,11 @@ type dashboardTrendsResponse struct {
 	// Keep this field in every response, including an empty object. The
 	// dashboard uses its presence to distinguish a request-time as_of_ms
 	// fallback from a durable live baseline when merging the client tail.
-	LiveBaselines map[int64]dashboardTrendBaseline `json:"live_baselines"`
-	BucketSeconds int64                            `json:"bucket_seconds"`
-	Points        []dashboardTrendPoint            `json:"points"`
-	SiteSeries    []dashboardTrendSite             `json:"site_series"`
+	LiveBaselines  map[int64]dashboardTrendBaseline `json:"live_baselines"`
+	BucketSeconds  int64                            `json:"bucket_seconds"`
+	Points         []dashboardTrendPoint            `json:"points"`
+	SiteSeries     []dashboardTrendSite             `json:"site_series"`
+	RealtimePoints []dashboardTrendPoint            `json:"realtime_points"`
 }
 
 // dashboardTrendSite carries the same time buckets as the aggregate chart,
@@ -459,6 +461,7 @@ func (pm *ProxyManager) dashboardTrendsUncoalesced(siteID *int64, rangeName stri
 		BucketSeconds:  int64(bucket / time.Second),
 		Points:         points,
 		SiteSeries:     siteSeries,
+		RealtimePoints: pm.dashboardRealtimeTrendPoints(siteID),
 	}
 	pm.cacheDashboardTrend(cacheKey, response, now.Add(cacheTTL))
 	return response, nil

--- a/dashboard_trends.go
+++ b/dashboard_trends.go
@@ -87,8 +87,11 @@ type dashboardTrendsResponse struct {
 	EndMS          int64  `json:"end_ms"`
 	// AsOfMS is the history snapshot cutoff. Realtime points newer than this
 	// instant can be merged without double-counting the current bucket.
-	AsOfMS        int64                            `json:"as_of_ms"`
-	LiveBaselines map[int64]dashboardTrendBaseline `json:"live_baselines,omitempty"`
+	AsOfMS int64 `json:"as_of_ms"`
+	// Keep this field in every response, including an empty object. The
+	// dashboard uses its presence to distinguish a request-time as_of_ms
+	// fallback from a durable live baseline when merging the client tail.
+	LiveBaselines map[int64]dashboardTrendBaseline `json:"live_baselines"`
 	BucketSeconds int64                            `json:"bucket_seconds"`
 	Points        []dashboardTrendPoint            `json:"points"`
 	SiteSeries    []dashboardTrendSite             `json:"site_series"`

--- a/main.go
+++ b/main.go
@@ -211,6 +211,7 @@ func main() {
 	// Traffic flush goroutine with context
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	pm.startDashboardRealtimeSampler(ctx)
 	assetCache.startReconcile(ctx)
 
 	go func() {

--- a/proxy_lifecycle.go
+++ b/proxy_lifecycle.go
@@ -481,6 +481,7 @@ func (pm *ProxyManager) dashboardSnapshotFromSites(sites []Site, monthlyBySite m
 	if snap.UptimeSeconds < 0 {
 		snap.UptimeSeconds = 0
 	}
+	snap.RealtimeTrend = pm.dashboardRealtimeTrendLatest()
 	return snap
 }
 

--- a/proxy_manager.go
+++ b/proxy_manager.go
@@ -126,30 +126,36 @@ func (inst *ProxyInstance) trafficPendingRequests() *atomic.Int64 {
 }
 
 type ProxyManager struct {
-	mu                      sync.RWMutex
-	lifecycleMu             sync.Mutex
-	proxies                 map[int64]*ProxyInstance
-	publicHosts             map[string]int64
-	publicHostModes         map[string]string
-	pathPrefixes            map[string]int64
-	upstreamHeaderKey       []byte
-	trustedProxies          []*net.IPNet
-	hostOnlyIngressSafe     bool
-	shutdownStarted         atomic.Bool
-	database                *DB
-	dynamicRuntime          *dynamicRuntime
-	dynamicRouteKey         []byte
-	dynamicTransportFactory dynamicTransportFactory
-	dynamicAvailable        bool
-	dynamicPanelHost        string
-	dynamicPanelPort        int
-	dynamicInterfaceAddrs   dynamicInterfaceAddrsFunc
-	assetCache              *assetCache
-	siteTLSConfig           *tls.Config
-	accountRetention        *accountRetentionTracker
-	trendCacheMu            sync.Mutex
-	trendCache              map[string]dashboardTrendCacheEntry
-	dashboardTrendGroup     singleflight.Group
+	mu                           sync.RWMutex
+	lifecycleMu                  sync.Mutex
+	proxies                      map[int64]*ProxyInstance
+	publicHosts                  map[string]int64
+	publicHostModes              map[string]string
+	pathPrefixes                 map[string]int64
+	upstreamHeaderKey            []byte
+	trustedProxies               []*net.IPNet
+	hostOnlyIngressSafe          bool
+	shutdownStarted              atomic.Bool
+	database                     *DB
+	dynamicRuntime               *dynamicRuntime
+	dynamicRouteKey              []byte
+	dynamicTransportFactory      dynamicTransportFactory
+	dynamicAvailable             bool
+	dynamicPanelHost             string
+	dynamicPanelPort             int
+	dynamicInterfaceAddrs        dynamicInterfaceAddrsFunc
+	assetCache                   *assetCache
+	siteTLSConfig                *tls.Config
+	accountRetention             *accountRetentionTracker
+	trendCacheMu                 sync.Mutex
+	trendCache                   map[string]dashboardTrendCacheEntry
+	dashboardTrendGroup          singleflight.Group
+	dashboardRealtimeMu          sync.RWMutex
+	dashboardRealtimePoints      []dashboardTrendPoint
+	dashboardRealtimePrev        map[int64]dashboardRealtimeCounter
+	dashboardRealtimeLastMS      int64
+	dashboardRealtimeBillingMode string
+	dashboardRealtimeStarted     atomic.Bool
 }
 
 // ProxyRuntimeStat is a non-persistent edge snapshot. Node scheduling quotas

--- a/tests/traffic_page.test.js
+++ b/tests/traffic_page.test.js
@@ -815,6 +815,25 @@ test('dashboard consumes one Controller realtime window for every browser', () =
   assert.equal(result.site[0].bytes_out, 24);
 });
 
+test('dashboard keeps the selected site chart live from the Controller SSE point', () => {
+  const h = makeTrafficHarness();
+  const now = Date.now();
+  const result = vm.runInContext(`(() => {
+    dashboardTrendState = { siteId: '7', range: 'realtime' };
+    dashboardControllerRealtimeEnabled = true;
+    dashboardAppendServerRealtimeTrendSample({
+      timestamp_ms: ${now},
+      site_contributions: {
+        '7': { timestamp_ms: ${now}, download_bps: 42, bytes_out: 84 },
+      },
+    });
+    return dashboardRealtimeTrendSamples.get('7');
+  })()`, h.sandbox);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].download_bps, 42);
+  assert.equal(result[0].bytes_out, 84);
+});
+
 test('dashboard stops generating browser-specific trend points after Controller data arrives', async () => {
   const elements = { 'dash-table': makeElement('dash-table'), 's-cache': makeElement('s-cache') };
   const sandbox = {

--- a/tests/traffic_page.test.js
+++ b/tests/traffic_page.test.js
@@ -779,6 +779,61 @@ test('dashboard realtime trend persists recent points across a page refresh', ()
   assert.equal(vm.runInContext('dashboardRealtimePersistedBillingMode', h.sandbox), 'bidirectional');
 });
 
+test('dashboard consumes one Controller realtime window for every browser', () => {
+  const h = makeTrafficHarness();
+  const now = Date.now();
+  const result = vm.runInContext(`(() => {
+    dashboardTrendState = { siteId: 'all', range: 'realtime' };
+    dashboardRealtimeTrendSamples = new Map([['all', [
+      { timestamp_ms: ${now - 5000}, download_bps: 999 },
+    ]]]);
+    dashboardRealtimeTrendSiteSamples = new Map();
+    dashboardMergeServerRealtimePoints({
+      realtime_points: [{
+        timestamp_ms: ${now - 2000},
+        download_bps: 120,
+        upload_bps: 4,
+        bytes_in: 8,
+        bytes_out: 24,
+        requests: 2,
+        traffic_bytes: 64,
+        site_contributions: {
+          '7': { timestamp_ms: ${now - 2000}, download_bps: 120, bytes_in: 8, bytes_out: 24, requests: 2, traffic_bytes: 64 },
+        },
+      }],
+    });
+    return {
+      enabled: dashboardControllerRealtimeEnabled,
+      all: dashboardRealtimeTrendSamples.get('all'),
+      site: dashboardRealtimeTrendSiteSamples.get('7'),
+    };
+  })()`, h.sandbox);
+  assert.equal(result.enabled, true);
+  assert.deepEqual(Array.from(result.all, point => point.timestamp_ms), [now - 2000]);
+  assert.equal(result.all[0].download_bps, 120);
+  assert.equal(result.site.length, 1);
+  assert.equal(result.site[0].bytes_out, 24);
+});
+
+test('dashboard stops generating browser-specific trend points after Controller data arrives', async () => {
+  const elements = { 'dash-table': makeElement('dash-table'), 's-cache': makeElement('s-cache') };
+  const sandbox = {
+    window: {}, document: makeDocument(elements), console,
+    Date: { now: () => 3000 },
+    Toast: { error() {}, success() {}, info() {} },
+    fetch: async () => okJson([{ id: 1, name: 'Alpha', target_url: 'http://a.example', ua_mode: 'infuse', listen_port: 8001, running: true, traffic_used: 0, cache_size_bytes: 0 }]),
+    Router: { current: 'dashboard' },
+    setInterval() { return 1; }, clearInterval() {}, setTimeout() { return 0; }, clearTimeout() {},
+  };
+  vm.createContext(sandbox);
+  loadInto(sandbox, 'api.js', 'pages/dashboard.js');
+  await vm.runInContext('loadDashboardTable()', sandbox);
+  vm.runInContext(`dashboardMergeServerRealtimePoints({ realtime_points: [{ timestamp_ms: 2000, download_bps: 25, site_contributions: {} }] })`, sandbox);
+  vm.runInContext("updateDashboardSiteSpeeds([{id:1, sampled_at_ms:3000, cumulative_bytes_in:0, cumulative_bytes_out:1000, running:true}], 3000, 'outbound')", sandbox);
+  assert.equal(vm.runInContext("dashboardRealtimeTrendSamples.get('all').length", sandbox), 1, 'SSE live speed refresh must not add a browser-only timestamp');
+  assert.equal(vm.runInContext("dashboardRealtimeTrendSamples.get('all')[0].timestamp_ms", sandbox), 2000);
+});
+
 test('dashboard realtime refresh keeps persisted points when mixed-site history has a request-time cutoff', () => {
   const h = makeTrafficHarness();
   const now = Date.now();

--- a/tests/traffic_page.test.js
+++ b/tests/traffic_page.test.js
@@ -779,6 +779,56 @@ test('dashboard realtime trend persists recent points across a page refresh', ()
   assert.equal(vm.runInContext('dashboardRealtimePersistedBillingMode', h.sandbox), 'bidirectional');
 });
 
+test('dashboard realtime refresh keeps persisted points when mixed-site history has a request-time cutoff', () => {
+  const h = makeTrafficHarness();
+  const now = Date.now();
+  const points = vm.runInContext(`(() => {
+    dashboardTrendState = { siteId: 'all', range: 'realtime' };
+    dashboardTrendData = {
+      range: 'realtime',
+      as_of_ms: ${now},
+      points: [],
+      // A mixed local/Agent view intentionally has no single aggregate
+      // persisted watermark. The request-time as_of_ms must not erase the
+      // browser-restored live point that arrived just before refresh.
+      site_series: [{ site_id: 1, site_name: 'Agent' }, { site_id: 2, site_name: 'Local' }],
+      live_baselines: { '1': { sampled_at_ms: ${now - 5000}, bytes_in: 10, bytes_out: 20, requests: 1 } },
+    };
+    dashboardRealtimeTrendSamples = new Map([['all', [
+      { timestamp_ms: ${now - 1000}, download_bps: 123, upload_bps: 4, bytes_in: 1, bytes_out: 2, requests: 1 },
+    ]]]);
+    dashboardRealtimeTrendSiteSamples = new Map();
+    return dashboardRealtimeTrendPoints();
+  })()`, h.sandbox);
+  assert.equal(points.length, 1, 'request-time as_of_ms must not discard a restored realtime point');
+  assert.equal(points[0].download_bps, 123);
+});
+
+test('dashboard realtime chart keeps the full live tail across a moving baseline', () => {
+  const h = makeTrafficHarness();
+  const now = Date.now();
+  const points = vm.runInContext(`(() => {
+    dashboardTrendState = { siteId: 'all', range: 'realtime' };
+    dashboardTrendData = {
+      range: 'realtime',
+      billing_mode: 'outbound',
+      live_baselines: { '1': { sampled_at_ms: ${now - 2000}, bytes_in: 0, bytes_out: 100, requests: 1 } },
+      site_series: [{ site_id: 1, site_name: 'Agent' }],
+    };
+    dashboardRealtimeTrendSamples = new Map([['all', [
+      // This point is already represented by the moving baseline, but it is
+      // still part of the visible five-minute chart tail.
+      { timestamp_ms: ${now - 10000}, download_bps: 50, upload_bps: 0, bytes_in: 0, bytes_out: 50, requests: 1, cumulative_bytes_out: 50 },
+      // Only points newer than the baseline are recalculated from counters.
+      { timestamp_ms: ${now - 1000}, download_bps: 999, upload_bps: 0, bytes_in: 0, bytes_out: 20, requests: 1, cumulative_bytes_out: 120 },
+    ]]]);
+    return dashboardTrendChartPoints();
+  })()`, h.sandbox);
+  assert.deepEqual(Array.from(points, point => point.timestamp_ms), [now - 10000, now - 1000]);
+  assert.equal(points[0].download_bps, 50);
+  assert.equal(points[1].download_bps, 20, 'new samples should still use the latest persisted baseline');
+});
+
 test('dashboard trend pointer coordinates use the plot bounds and keep the crosshair on the pointer', () => {
   const { sandbox } = makeTrafficHarness();
   const state = vm.runInContext(`dashboardTrendPointerState(

--- a/traffic_repository.go
+++ b/traffic_repository.go
@@ -47,19 +47,20 @@ type SiteTraffic struct {
 // TrafficSnapshot is the single authoritative global traffic payload shared by
 // /api/dashboard, /api/traffic/overview and SSE events.
 type TrafficSnapshot struct {
-	TotalSites      int           `json:"total_sites"`
-	OnlineSites     int           `json:"online_sites"`
-	RunningSites    int           `json:"running_sites"`
-	TotalTraffic    int64         `json:"total_traffic"`
-	MonthlyTraffic  int64         `json:"monthly_traffic"`
-	BillingMode     string        `json:"billing_mode"`
-	TrafficResetDay int           `json:"traffic_reset_day"`
-	TotalRequests   int64         `json:"total_requests"`
-	UptimeSeconds   int64         `json:"uptime_seconds"`
-	PanelDomain     string        `json:"panel_domain,omitempty"`
-	PanelAccessURL  string        `json:"panel_access_url,omitempty"`
-	GeneratedAtMS   int64         `json:"generated_at_ms"`
-	LiveSites       []SiteTraffic `json:"live_sites"`
+	TotalSites      int                  `json:"total_sites"`
+	OnlineSites     int                  `json:"online_sites"`
+	RunningSites    int                  `json:"running_sites"`
+	TotalTraffic    int64                `json:"total_traffic"`
+	MonthlyTraffic  int64                `json:"monthly_traffic"`
+	BillingMode     string               `json:"billing_mode"`
+	TrafficResetDay int                  `json:"traffic_reset_day"`
+	TotalRequests   int64                `json:"total_requests"`
+	UptimeSeconds   int64                `json:"uptime_seconds"`
+	PanelDomain     string               `json:"panel_domain,omitempty"`
+	PanelAccessURL  string               `json:"panel_access_url,omitempty"`
+	GeneratedAtMS   int64                `json:"generated_at_ms"`
+	LiveSites       []SiteTraffic        `json:"live_sites"`
+	RealtimeTrend   *dashboardTrendPoint `json:"realtime_trend,omitempty"`
 }
 
 // NodeSiteLiveTraffic is the last persisted runtime sample from an applied

--- a/web/static/js/pages/dashboard.js
+++ b/web/static/js/pages/dashboard.js
@@ -650,6 +650,19 @@ function dashboardAppendServerRealtimeTrendSample(value) {
       dashboardRealtimeTrendSiteSamples.set(siteID, samples);
     });
   }
+  // When a site is selected, its chart reads the site-keyed map. Keep that
+  // view on the same SSE tick so it remains live between 15-second trend
+  // endpoint refreshes.
+  if (dashboardTrendState.siteId !== 'all' && point.site_contributions && typeof point.site_contributions === 'object') {
+    const siteID = String(dashboardTrendState.siteId);
+    const contribution = point.site_contributions[siteID];
+    if (contribution) {
+      const selected = dashboardRealtimeTrendSamples.get(siteID) || [];
+      upsertDashboardRealtimeSample(selected, dashboardNormalizeRealtimePoint({ ...contribution, timestamp_ms: point.timestamp_ms }));
+      pruneDashboardRealtimeSamples(selected);
+      dashboardRealtimeTrendSamples.set(siteID, selected);
+    }
+  }
   persistDashboardRealtimeSamples();
   return true;
 }

--- a/web/static/js/pages/dashboard.js
+++ b/web/static/js/pages/dashboard.js
@@ -602,7 +602,7 @@ function dashboardRealtimeTrendPoints() {
   const key = dashboardTrendState.siteId === 'all' ? 'all' : String(dashboardTrendState.siteId);
   const points = dashboardRealtimeTrendSamples.get(key) || [];
   const baseline = dashboardRealtimeBaselineForKey(key);
-  const anchor = Number(baseline?.sampled_at_ms || dashboardTrendData?.as_of_ms || 0);
+  const anchor = dashboardRealtimeHistoryCutoffMS(baseline);
   const newer = !Number.isFinite(anchor) || anchor <= 0
     ? points
     : points.filter(point => Number(point?.timestamp_ms || 0) > anchor);
@@ -662,10 +662,23 @@ function dashboardRealtimeBaselineForKey(key) {
   return aggregate.sampled_at_ms > 0 ? aggregate : null;
 }
 
+function dashboardRealtimeHistoryCutoffMS(baseline = null) {
+  const persisted = Number(baseline?.sampled_at_ms || 0);
+  if (Number.isFinite(persisted) && persisted > 0) return persisted;
+  // Current responses include live_baselines even when a mixed local/Agent
+  // selection cannot produce one complete watermark. In that case `as_of_ms`
+  // is only a request-time fallback and must not erase browser-restored live
+  // samples after a refresh. Older responses without live_baselines retain
+  // the legacy as_of_ms cutoff for compatibility.
+  if (dashboardTrendData?.live_baselines && typeof dashboardTrendData.live_baselines === 'object') return 0;
+  const fallback = Number(dashboardTrendData?.as_of_ms || 0);
+  return Number.isFinite(fallback) && fallback > 0 ? fallback : 0;
+}
+
 function dashboardTrendCutoffMS() {
   const key = dashboardTrendState.siteId === 'all' ? 'all' : String(dashboardTrendState.siteId);
   const baseline = dashboardRealtimeBaselineForKey(key);
-  const value = Number(baseline?.sampled_at_ms || dashboardTrendData?.as_of_ms || 0);
+  const value = dashboardRealtimeHistoryCutoffMS(baseline);
   return Number.isFinite(value) && value > 0 ? value : 0;
 }
 
@@ -703,10 +716,66 @@ function dashboardTrendPoints() {
 
 function dashboardTrendChartPoints() {
   if (dashboardTrendState.range === 'realtime') {
-    const realtimePoints = dashboardRealtimeTrendPoints();
+    // Keep the complete five-minute client-side tail for drawing. The
+    // history merge below intentionally returns only samples newer than the
+    // persisted watermark, but dropping older live samples here made every
+    // 15-second trend refresh (and every page reload) collapse the chart to a
+    // nearly empty or all-zero tail.
+    const realtimePoints = dashboardRealtimeChartTrendPoints();
     if (realtimePoints.length) return realtimePoints;
   }
   return dashboardTrendPoints();
+}
+
+function dashboardRealtimeChartTrendPoints() {
+  const key = dashboardTrendState.siteId === 'all' ? 'all' : String(dashboardTrendState.siteId);
+  const points = dashboardRealtimeTrendSamples.get(key) || [];
+  if (!points.length) return [];
+  const baseline = dashboardRealtimeBaselineForKey(key);
+  const anchor = dashboardRealtimeHistoryCutoffMS(baseline);
+  if (!baseline || !Number.isFinite(anchor) || anchor <= 0) return points;
+
+  let previous = {
+    bytesIn: Math.max(0, Number(baseline.bytes_in || 0)),
+    bytesOut: Math.max(0, Number(baseline.bytes_out || 0)),
+    requests: Math.max(0, Number(baseline.requests || 0)),
+    timestamp: anchor,
+  };
+  return points.map(point => {
+    const timestamp = Number(point?.timestamp_ms || 0);
+    // Samples at or before the durable watermark already contain the deltas
+    // captured during their original live interval. Keep them as-is so a
+    // trend API refresh cannot erase the visible history.
+    if (!Number.isFinite(timestamp) || timestamp <= anchor) return point;
+    const hasCumulative = point.cumulative_bytes_in !== undefined
+      || point.cumulative_bytes_out !== undefined
+      || point.cumulative_requests !== undefined;
+    if (!hasCumulative) return point;
+    const current = {
+      bytesIn: Math.max(0, Number(point.cumulative_bytes_in || 0)),
+      bytesOut: Math.max(0, Number(point.cumulative_bytes_out || 0)),
+      requests: Math.max(0, Number(point.cumulative_requests || 0)),
+      timestamp,
+    };
+    const deltaIn = current.bytesIn >= previous.bytesIn ? current.bytesIn - previous.bytesIn : current.bytesIn;
+    const deltaOut = current.bytesOut >= previous.bytesOut ? current.bytesOut - previous.bytesOut : current.bytesOut;
+    const deltaRequests = current.requests >= previous.requests ? current.requests - previous.requests : current.requests;
+    const seconds = Math.max(0, (current.timestamp - previous.timestamp) / 1000);
+    const next = {
+      ...point,
+      bytes_in: deltaIn,
+      bytes_out: deltaOut,
+      requests: deltaRequests,
+      download_bps: seconds > 0 ? deltaOut / seconds : 0,
+      upload_bps: seconds > 0 ? deltaIn / seconds : 0,
+    };
+    if (point.traffic_bytes !== undefined) {
+      const mode = dashboardTrendData?.billing_mode;
+      next.traffic_bytes = mode === 'outbound' ? deltaOut : 2 * (deltaIn + deltaOut);
+    }
+    previous = current;
+    return next;
+  });
 }
 
 function dashboardRealtimeChartBounds(points) {

--- a/web/static/js/pages/dashboard.js
+++ b/web/static/js/pages/dashboard.js
@@ -20,6 +20,10 @@ let dashboardRealtimeTrendSiteSamples = new Map();
 let dashboardLatestRatesBySite = new Map();
 let dashboardBillingMode = null;
 let dashboardRealtimePersistedBillingMode = null;
+// Once the Controller exposes its authoritative realtime sequence, the
+// browser only renders/merges those points. The local path remains as a
+// compatibility fallback for older Controllers and unit harnesses.
+let dashboardControllerRealtimeEnabled = false;
 const dashboardRealtimeStorageKey = 'meridian.dashboard.realtime-trends.v1';
 let dashboardLastSnapshotMS = 0;
 let dashboardLastObservedSiteCount = -1;
@@ -576,6 +580,78 @@ function restoreDashboardRealtimeSamples(now = Date.now()) {
   const billingMode = String(payload.billing_mode || '').toLowerCase();
   dashboardRealtimePersistedBillingMode = billingMode === 'outbound' || billingMode === 'bidirectional' ? billingMode : null;
   return all.length > 0 || sites.size > 0;
+}
+
+function dashboardMergeServerRealtimePoints(data) {
+  if (!data || !Object.prototype.hasOwnProperty.call(data, 'realtime_points')) return;
+  dashboardControllerRealtimeEnabled = true;
+  const key = dashboardTrendState.siteId === 'all' ? 'all' : String(dashboardTrendState.siteId);
+  const normalized = dashboardNormalizeRealtimeSamples(data.realtime_points, Date.now());
+  const mergeAuthoritative = (existing, serverPoints) => {
+    if (!serverPoints.length) return [];
+    const latestServer = Number(serverPoints[serverPoints.length - 1]?.timestamp_ms || 0);
+    // Keep only points that could have arrived through the in-flight SSE
+    // stream after this HTTP response. Older persisted points and points from
+    // a previous Controller process must never outrank the server window.
+    const tailLimit = latestServer + (dashboardRealtimeSampleIntervalMS * 3);
+    const tail = (existing || []).filter(point => {
+      const timestamp = Number(point?.timestamp_ms || 0);
+      return timestamp > latestServer && timestamp <= tailLimit;
+    });
+    const merged = serverPoints.slice();
+    tail.forEach(point => upsertDashboardRealtimeSample(merged, point));
+    pruneDashboardRealtimeSamples(merged);
+    return merged;
+  };
+  const existing = dashboardRealtimeTrendSamples.get(key) || [];
+  const merged = mergeAuthoritative(existing, normalized);
+  if (merged.length) dashboardRealtimeTrendSamples.set(key, merged);
+  else dashboardRealtimeTrendSamples.delete(key);
+
+  if (key === 'all') {
+    // The aggregate server point carries each site's contribution. Rebuild
+    // the per-site view from the same authoritative window so selecting a
+    // site in another browser produces the same line.
+    const existingSites = dashboardRealtimeTrendSiteSamples;
+    dashboardRealtimeTrendSiteSamples = new Map();
+    const serverSites = new Map();
+    normalized.forEach(point => {
+      if (!point.site_contributions || typeof point.site_contributions !== 'object') return;
+      Object.keys(point.site_contributions).forEach(siteID => {
+        const contribution = dashboardNormalizeRealtimePoint({ ...point.site_contributions[siteID], timestamp_ms: point.timestamp_ms });
+        if (!contribution) return;
+        const samples = serverSites.get(siteID) || [];
+        upsertDashboardRealtimeSample(samples, contribution);
+        serverSites.set(siteID, samples);
+      });
+    });
+    serverSites.forEach((serverPoints, siteID) => {
+      const mergedSite = mergeAuthoritative(existingSites.get(siteID) || [], serverPoints);
+      if (mergedSite.length) dashboardRealtimeTrendSiteSamples.set(siteID, mergedSite);
+    });
+  }
+  persistDashboardRealtimeSamples();
+}
+
+function dashboardAppendServerRealtimeTrendSample(value) {
+  const point = dashboardNormalizeRealtimePoint(value);
+  if (!point) return false;
+  const all = dashboardRealtimeTrendSamples.get('all') || [];
+  upsertDashboardRealtimeSample(all, point);
+  pruneDashboardRealtimeSamples(all);
+  dashboardRealtimeTrendSamples.set('all', all);
+  if (point.site_contributions && typeof point.site_contributions === 'object') {
+    Object.keys(point.site_contributions).forEach(siteID => {
+      const contribution = dashboardNormalizeRealtimePoint({ ...point.site_contributions[siteID], timestamp_ms: point.timestamp_ms });
+      if (!contribution) return;
+      const samples = dashboardRealtimeTrendSiteSamples.get(siteID) || [];
+      upsertDashboardRealtimeSample(samples, contribution);
+      pruneDashboardRealtimeSamples(samples);
+      dashboardRealtimeTrendSiteSamples.set(siteID, samples);
+    });
+  }
+  persistDashboardRealtimeSamples();
+  return true;
 }
 
 function upsertDashboardRealtimeSample(samples, point) {
@@ -1145,6 +1221,7 @@ async function loadDashboardTrends() {
       if (endInput) endInput.value = customDefault.end;
     }
     dashboardTrendData = data;
+    dashboardMergeServerRealtimePoints(data);
     for (const samples of dashboardRealtimeTrendSamples.values()) pruneDashboardRealtimeSamples(samples);
     for (const samples of dashboardRealtimeTrendSiteSamples.values()) pruneDashboardRealtimeSamples(samples);
     reconcileDashboardTrendSiteSelection();
@@ -1294,9 +1371,11 @@ function updateDashboardLive(stats) {
   const uptimeEl = document.getElementById('s-uptime');
   if (uptimeEl) uptimeEl.textContent = formatUptime(stats.uptime_seconds || 0);
 
-  const requestsEl = document.getElementById('s-requests');
-  if (requestsEl) requestsEl.textContent = formatNumber(stats.total_requests || 0) + ' 请求';
-  updateDashboardSiteSpeeds(stats.live_sites || [], generatedAt, dashboardBillingMode);
+	const requestsEl = document.getElementById('s-requests');
+	if (requestsEl) requestsEl.textContent = formatNumber(stats.total_requests || 0) + ' 请求';
+  if (stats?.realtime_trend) dashboardControllerRealtimeEnabled = true;
+	updateDashboardSiteSpeeds(stats.live_sites || [], generatedAt, dashboardBillingMode);
+  if (stats?.realtime_trend) dashboardAppendServerRealtimeTrendSample(stats.realtime_trend);
   updateDashboardTrendRealtime();
 }
 
@@ -1438,6 +1517,22 @@ function updateDashboardSiteSpeeds(liveSites, snapshotMS, billingModeOverride) {
     totalCumulativeRequests += Math.max(0, Number(sample?.requests || 0));
   });
   const sampledAt = Number(snapshotMS || Date.now());
+  if (dashboardControllerRealtimeEnabled) {
+    dashboardSites = dashboardSites.map(site => {
+      const siteID = Number(site.id);
+      const live = liveMap.get(siteID);
+      if (!live) return site;
+      const speed = dashboardLiveSpeeds.get(siteID);
+      if (!speed) {
+        const { _liveSpeed, ...siteWithoutSpeed } = site;
+        return { ...siteWithoutSpeed, ...live };
+      }
+      return { ...site, ...live, _liveSpeed: speed };
+    });
+    renderDashboardTableRows();
+    persistDashboardRealtimeSamples();
+    return;
+  }
   const appendRealtimeTrendSample = (key, sample, sampleTimestamp = sampledAt, contributions = null) => {
     const samples = dashboardRealtimeTrendSamples.get(key) || [];
     const bytesIn = Math.max(0, Number(sample?.bytesIn || 0));


### PR DESCRIPTION
## Changes
- sample dashboard realtime trends once in the Controller
- keep a bounded five-minute server window for all browsers
- merge short in-flight SSE data without browser-specific drift
- keep selected-site trends live on Controller ticks

## Validation
- go test -race ./...
- go vet ./...
- node --test tests/*.test.js
- JavaScript syntax checks
- visual dashboard trend check