### PR TITLE
fix: support emos(Emya) external subtitles and repeated ingress prefix

### DIFF
--- a/dynamic_redirect_runtime_test.go
+++ b/dynamic_redirect_runtime_test.go
@@ -184,6 +184,8 @@ func TestDynamicRedirectRuntimeEligibilityIsNarrow(t *testing.T) {
 		{name: "item download", method: http.MethodGet, path: "/Items/42/Download", want: true},
 		{name: "Emya video GET", method: http.MethodGet, path: "/emby/emya/video?server=emos", want: true},
 		{name: "Emya video HEAD", method: http.MethodHead, path: "/emya/video", want: true},
+		{name: "Emya subtitle GET", method: http.MethodGet, path: "/emby/emya/subtitle?server=emos&media_id=evn6y0q52p53&subtitle_id=11575", want: true},
+		{name: "Emya subtitle HEAD", method: http.MethodHead, path: "/emya/subtitle", want: true},
 		{name: "exact PlaybackInfo", method: http.MethodGet, path: "/Items/42/PlaybackInfo?UserId=7", want: true},
 		{name: "exact emby PlaybackInfo", method: http.MethodHead, path: "/emby/Items/42/PlaybackInfo", want: true},
 		{name: "HLS manifest", method: http.MethodGet, path: "/custom/live.m3u8", want: true},

--- a/main_test.go
+++ b/main_test.go
@@ -6470,6 +6470,14 @@ func TestPathIngressNormalizationAndPrefixHelpers(t *testing.T) {
 	if u.Path != "/Videos/1" {
 		t.Fatalf("stripped path=%q", u.Path)
 	}
+	uRepeated, err := url.Parse("https://panel.example/emos/emos/_meridian/d/token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stripIngressPathPrefix(uRepeated, "/emos")
+	if uRepeated.Path != "/_meridian/d/token" {
+		t.Fatalf("repeated stripped path=%q, want /_meridian/d/token", uRepeated.Path)
+	}
 	if got := addIngressPathPrefix("/Videos/1", "/emby"); got != "/emby/Videos/1" {
 		t.Fatalf("prefixed path=%q", got)
 	}

--- a/playback_info_rewrite.go
+++ b/playback_info_rewrite.go
@@ -808,6 +808,7 @@ func rewritePlaybackInfoResponse(payload []byte, session *dynamicRewriteSession)
 						// Some Emby-compatible servers mark relative subtitle DeliveryUrl
 						// values as external. Resolve them against the real upstream
 						// PlaybackInfo URL so the optional subtitle cannot reject the video.
+						session.rememberRelativePlaybackPath(deliveryText)
 						rewritten, err := session.rewriteAgainstSourceKindWithRequiredHeaders(deliveryText, session.base, capabilitySource, kind, requiredHeaders)
 						if err != nil {
 							return nil, err

--- a/proxy_start.go
+++ b/proxy_start.go
@@ -323,6 +323,9 @@ func (pm *ProxyManager) StartSite(site Site) error {
 		}
 		defer inst.endHTTPRequest(requestController)
 		normalizeEmbeddedDynamicCapabilityRequestPath(r.URL)
+		if site.PathPrefix != "" && !isReservedDynamicRoute(r.URL.Path) {
+			stripIngressPathPrefix(r.URL, site.PathPrefix)
+		}
 		requestStartedAt := time.Now()
 		clientRequestContext := r.Context()
 		requestLogWriter := &requestLogResponseWriter{ResponseWriter: w}

--- a/request_logs.go
+++ b/request_logs.go
@@ -505,7 +505,7 @@ func classifyRequestLogResource(r *http.Request) string {
 		return requestLogCategoryManifest
 	case requestLogPathHasSuffix(path, ".ts", ".m4s"):
 		return requestLogCategorySegment
-	case strings.Contains(path, "/subtitles/"), strings.HasSuffix(path, "/subtitles"), strings.Contains(path, "/captions/"), requestLogPathHasSuffix(path, ".srt", ".ass", ".ssa", ".vtt", ".sub", ".idx", ".sup"):
+	case strings.Contains(path, "/subtitles/"), strings.HasSuffix(path, "/subtitles"), strings.Contains(path, "/captions/"), strings.Contains(path, "/emya/subtitle"), requestLogPathHasSuffix(path, ".srt", ".ass", ".ssa", ".vtt", ".sub", ".idx", ".sup"):
 		return requestLogCategorySubtitle
 	case strings.Contains(path, "/images/"), strings.HasSuffix(path, "/images"), strings.Contains(path, "/image/"), strings.Contains(path, "/icons/"), strings.Contains(path, "/branding/"), strings.Contains(path, "/covers/"), requestLogPathHasSuffix(path, ".jpg", ".jpeg", ".gif", ".png", ".svg", ".ico", ".webp", ".avif"):
 		return requestLogCategoryImage

--- a/request_logs_test.go
+++ b/request_logs_test.go
@@ -223,6 +223,7 @@ func TestRequestLogClassificationAndSanitization(t *testing.T) {
 		{path: "/Items?Recursive=true", want: requestLogCategoryMetadata},
 		{path: "/Shows/NextUp", want: requestLogCategoryMetadata},
 		{path: "/Videos/abc/Subtitles/0/Stream.vtt", want: requestLogCategorySubtitle},
+		{path: "/emby/emya/subtitle", want: requestLogCategorySubtitle},
 		{path: "/web/app.js", want: requestLogCategoryAsset},
 		{path: "/socket", want: requestLogCategoryWebSocket, upgrade: true},
 		{path: "/Users/AuthenticateByName", want: requestLogCategoryAuth},

--- a/site_routing.go
+++ b/site_routing.go
@@ -298,21 +298,26 @@ func isKnownMediaApplicationRoute(pathValue string) bool {
 }
 
 func stripIngressPathPrefix(requestURL *url.URL, prefix string) {
-	if requestURL == nil || !ingressPathMatches(requestURL.Path, prefix) {
+	if requestURL == nil || prefix == "" || !ingressPathMatches(requestURL.Path, prefix) {
 		return
 	}
-	path := strings.TrimPrefix(requestURL.Path, prefix)
-	if path == "" {
-		path = "/"
-	}
-	requestURL.Path = path
-	if requestURL.RawPath != "" {
-		rawPrefix := (&url.URL{Path: prefix}).EscapedPath()
-		rawPath := strings.TrimPrefix(requestURL.RawPath, rawPrefix)
-		if rawPath == "" {
-			rawPath = "/"
+	rawPrefix := (&url.URL{Path: prefix}).EscapedPath()
+	for ingressPathMatches(requestURL.Path, prefix) {
+		path := strings.TrimPrefix(requestURL.Path, prefix)
+		if path == "" {
+			path = "/"
 		}
-		requestURL.RawPath = rawPath
+		requestURL.Path = path
+		if requestURL.RawPath != "" {
+			rawPath := strings.TrimPrefix(requestURL.RawPath, rawPrefix)
+			if rawPath == "" {
+				rawPath = "/"
+			}
+			requestURL.RawPath = rawPath
+		}
+		if path == "/" {
+			break
+		}
 	}
 }
 
@@ -712,7 +717,8 @@ func isPlaybackRequest(path string) bool {
 
 func isPlaybackRedirectEndpoint(pathValue string) bool {
 	pathValue = strings.ToLower(pathValue)
-	return pathValue == "/emya/video" || pathValue == "/emby/emya/video"
+	return pathValue == "/emya/video" || pathValue == "/emby/emya/video" ||
+		pathValue == "/emya/subtitle" || pathValue == "/emby/emya/subtitle"
 }
 
 func isPlaybackInfoRequest(path string) bool {


### PR DESCRIPTION
## 改动内容

1. **支持 emos(Emya) 外挂字幕重定向识别**：
   - 在 `site_routing.go` 的 `isPlaybackRedirectEndpoint` 中补充 `/emya/subtitle` 和 `/emby/emya/subtitle`；
   - 在 `playback_info_rewrite.go` 处理相对外挂字幕时，调用 `session.rememberRelativePlaybackPath` 动态记忆字幕回源路径；
   - 在 `request_logs.go` 中将 `/emya/subtitle` 正确归类为 `requestLogCategorySubtitle`。
   - **修复问题**：解决反代 Emya 节点时，外挂字幕无法内部跟随 308 重定向，导致 Web 端跨域 CORS 拦截或部分客户端因 308 兼容性无法加载外挂字幕的问题。

2. **客户端重复前缀容错**：
   - 优化 `stripIngressPathPrefix` 和 `proxy_start.go`，自动消除部分 Emby 移动端客户端（如 Yamby 等）在拼接 Base URL 时产生的重复前缀（如 `/prefix/prefix/...`），避免动态能力路由被错判为 404。

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 重构 / 代码清理
- [ ] 其他：

## 验证方式

- [x] `go test ./...` 全部通过（包含新增的 Emya 字幕与重复前缀单元测试）
- [x] `go build -o meridian .` 编译通过
- [x] 实机部署测试验证：
  - 在 Linux VPS 环境下使用真实的 Emya 节点和 Android/Yamby 客户端进行测试；
  - 外挂 `.ass` 字幕成功跟随 308 重定向并完整下载展示，控制台分类显示为「字幕」。

## 影响范围

- [x] 反代引擎
- [ ] 站点管理 API
- [ ] 诊断功能
- [ ] 认证 / 登录
- [ ] 流量计量
- [ ] 前端 UI
- [ ] CI / Docker

## 注意事项

- 保持了原有代码逻辑与错误处理的一致性，未引入额外第三方依赖。