### PR TITLE
fix: isolate live reports and retry Cloudflare DNS

### DIFF
--- a/agent_report_guard.go
+++ b/agent_report_guard.go
@@ -298,6 +298,22 @@ func (a *App) agentReports() *nodeReportAdmission {
 	return a.agentReportLimiter
 }
 
+// agentLiveReports has a separate per-node admission budget from the full
+// report path. Live samples are lightweight and in-memory, while full reports
+// may hold the SQLite-backed admission slot for longer. Keeping their slots
+// independent prevents a slow full report from dropping live trend samples.
+func (a *App) agentLiveReports() *nodeReportAdmission {
+	if a == nil {
+		return newNodeReportAdmission()
+	}
+	a.agentLiveReportMu.Lock()
+	defer a.agentLiveReportMu.Unlock()
+	if a.agentLiveLimiter == nil {
+		a.agentLiveLimiter = newNodeReportAdmission()
+	}
+	return a.agentLiveLimiter
+}
+
 func (a *App) agentPreAuthAdmission() *agentPreAuthAdmission {
 	if a == nil {
 		return newAgentPreAuthAdmission()

--- a/agent_report_guard_test.go
+++ b/agent_report_guard_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -174,6 +175,51 @@ func TestNodeReportAdmissionReclaimsIdleEntries(t *testing.T) {
 	admission.mu.Unlock()
 	if exists {
 		t.Fatal("idle node report limiter entry was not reclaimed")
+	}
+}
+
+func TestAgentLiveReportAdmissionIsIndependentFromFullReports(t *testing.T) {
+	app := &App{}
+	now := time.Now()
+	fullRelease, _, ok := app.agentReports().admit(42, now)
+	if !ok {
+		t.Fatal("full report was rejected")
+	}
+	defer fullRelease()
+
+	liveRelease, _, ok := app.agentLiveReports().admit(42, now)
+	if !ok {
+		t.Fatal("live report was blocked by an in-flight full report")
+	}
+	liveRelease()
+	if app.agentReports() == app.agentLiveReports() {
+		t.Fatal("live and full reports unexpectedly share an admission limiter")
+	}
+}
+
+func TestAgentLiveHandlerIsNotBlockedByFullReport(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now()
+	node, enrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "live-admission", Address: "203.0.113.42"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, token, err := app.db.EnrollControlNode(enrollment, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fullRelease, _, ok := app.agentReports().admit(node.ID, now)
+	if !ok {
+		t.Fatal("full report was rejected")
+	}
+	defer fullRelease()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/agent/live", strings.NewReader(`{"report_session_id":"live-test","counter_epoch":"kernel:eth0","sequence":1,"telemetry_sequence":1,"sampled_at_ms":1}`))
+	req.Header.Set("Authorization", "Bearer "+token)
+	response := httptest.NewRecorder()
+	app.handleAgentLive(response, req)
+	if response.Code != http.StatusOK {
+		t.Fatalf("live report status=%d body=%s, want 200", response.Code, response.Body.String())
 	}
 }
 

--- a/app_core.go
+++ b/app_core.go
@@ -36,6 +36,8 @@ type App struct {
 	tmdbOnce           sync.Once
 	agentReportMu      sync.Mutex
 	agentReportLimiter *nodeReportAdmission
+	agentLiveReportMu  sync.Mutex
+	agentLiveLimiter   *nodeReportAdmission
 	agentPreAuthMu     sync.Mutex
 	agentPreAuth       *agentPreAuthAdmission
 }

--- a/app_nodes.go
+++ b/app_nodes.go
@@ -712,8 +712,8 @@ func (a *App) handleAgentReport(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleAgentLive accepts the small, high-frequency traffic sample used by
-// the dashboard. It shares the per-node report admission gate with the full
-// HTTP/WebSocket report paths, but performs no SQLite writes.
+// the dashboard. It has an independent per-node admission gate from the full
+// HTTP/WebSocket report paths, and performs no SQLite writes.
 func (a *App) handleAgentLive(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
@@ -725,7 +725,7 @@ func (a *App) handleAgentLive(w http.ResponseWriter, r *http.Request) {
 		writeAgentAuthenticationError(a, w, r, authErr)
 		return
 	}
-	release, retryAfter, admitted := a.agentReports().admit(identity.Node.ID, time.Now())
+	release, retryAfter, admitted := a.agentLiveReports().admit(identity.Node.ID, time.Now())
 	if !admitted {
 		seconds := int(retryAfter.Seconds())
 		if retryAfter-time.Duration(seconds)*time.Second > 0 {

--- a/panel_acme.go
+++ b/panel_acme.go
@@ -428,6 +428,12 @@ type cloudflareResponse struct {
 	Result json.RawMessage `json:"result"`
 }
 
+const (
+	cloudflareRequestMaxAttempts = 3
+	cloudflareRequestRetryBase   = 250 * time.Millisecond
+	cloudflareRequestBodyLimit   = 1 << 20
+)
+
 // cleanConfiguredTLSPath normalizes valid administrator paths for consistent
 // comparisons. Validation is performed by validateTLSPathConfiguration before
 // the server starts; retaining the cleaned raw value here keeps legacy callers
@@ -1721,34 +1727,118 @@ func waitForTXTRecord(ctx context.Context, name, value string) error {
 	}
 }
 
+func cloudflareRequestRetryableMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodPut, http.MethodDelete:
+		return true
+	default:
+		// Retrying POST could create duplicate DNS records when the first
+		// request succeeded but its response was lost.
+		return false
+	}
+}
+
+func cloudflareRequestRetryableStatus(status int) bool {
+	return status == http.StatusTooManyRequests || (status >= 500 && status <= 599)
+}
+
+func waitCloudflareRequestRetry(ctx context.Context, attempt int) error {
+	if attempt < 1 {
+		attempt = 1
+	}
+	delay := cloudflareRequestRetryBase * time.Duration(1<<(attempt-1))
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// request retries only idempotent DNS operations. This covers transient
+// Cloudflare/API gateway failures without risking duplicate records from a
+// retried POST. The caller's context remains the overall retry budget.
 func (c *cloudflareClient) request(ctx context.Context, method, requestPath string, body io.Reader) (json.RawMessage, error) {
-	request, err := http.NewRequestWithContext(ctx, method, strings.TrimRight(c.apiBase, "/")+requestPath, body)
-	if err != nil {
-		return nil, err
+	if c == nil {
+		return nil, errors.New("Cloudflare DNS client is unavailable")
 	}
-	request.Header.Set("Authorization", "Bearer "+c.token)
-	request.Header.Set("Content-Type", "application/json")
-	response, err := c.httpClient.Do(request)
-	if err != nil {
-		return nil, fmt.Errorf("cloudflare DNS request failed: %w", err)
-	}
-	defer response.Body.Close()
-	data, err := io.ReadAll(io.LimitReader(response.Body, 1<<20))
-	if err != nil {
-		return nil, fmt.Errorf("read Cloudflare DNS response: %w", err)
-	}
-	var envelope cloudflareResponse
-	if err := json.Unmarshal(data, &envelope); err != nil {
-		return nil, errors.New("cloudflare DNS returned an invalid response")
-	}
-	if response.StatusCode < 200 || response.StatusCode >= 300 || !envelope.Success {
-		message := "cloudflare DNS request was rejected"
-		if len(envelope.Errors) > 0 && strings.TrimSpace(envelope.Errors[0].Message) != "" {
-			message += ": " + strings.TrimSpace(envelope.Errors[0].Message)
+	var bodyBytes []byte
+	if body != nil {
+		data, err := io.ReadAll(io.LimitReader(body, cloudflareRequestBodyLimit+1))
+		if err != nil {
+			return nil, fmt.Errorf("read Cloudflare DNS request: %w", err)
 		}
-		return nil, errors.New(message)
+		if len(data) > cloudflareRequestBodyLimit {
+			return nil, errors.New("Cloudflare DNS request body is too large")
+		}
+		bodyBytes = data
 	}
-	return envelope.Result, nil
+	client := c.httpClient
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+	maxAttempts := 1
+	if cloudflareRequestRetryableMethod(method) {
+		maxAttempts = cloudflareRequestMaxAttempts
+	}
+	endpoint := strings.TrimRight(c.apiBase, "/") + requestPath
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		var requestBody io.Reader
+		if bodyBytes != nil {
+			requestBody = bytes.NewReader(bodyBytes)
+		}
+		request, err := http.NewRequestWithContext(ctx, method, endpoint, requestBody)
+		if err != nil {
+			return nil, err
+		}
+		request.Header.Set("Authorization", "Bearer "+c.token)
+		request.Header.Set("Content-Type", "application/json")
+		response, err := client.Do(request)
+		if err != nil {
+			if attempt < maxAttempts && ctx.Err() == nil {
+				if retryErr := waitCloudflareRequestRetry(ctx, attempt); retryErr == nil {
+					continue
+				}
+			}
+			return nil, fmt.Errorf("cloudflare DNS request failed: %w", err)
+		}
+		data, readErr := io.ReadAll(io.LimitReader(response.Body, cloudflareRequestBodyLimit))
+		closeErr := response.Body.Close()
+		if readErr != nil {
+			if attempt < maxAttempts && ctx.Err() == nil {
+				if retryErr := waitCloudflareRequestRetry(ctx, attempt); retryErr == nil {
+					continue
+				}
+			}
+			return nil, fmt.Errorf("read Cloudflare DNS response: %w", readErr)
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("close Cloudflare DNS response: %w", closeErr)
+		}
+		// Gate retries on the HTTP status before decoding the body. Gateways
+		// often return HTML or an empty body for 429/5xx responses, and those
+		// responses are still safely retryable for idempotent operations.
+		if attempt < maxAttempts && cloudflareRequestRetryableStatus(response.StatusCode) && ctx.Err() == nil {
+			if retryErr := waitCloudflareRequestRetry(ctx, attempt); retryErr == nil {
+				continue
+			}
+		}
+		var envelope cloudflareResponse
+		if err := json.Unmarshal(data, &envelope); err != nil {
+			return nil, errors.New("cloudflare DNS returned an invalid response")
+		}
+		if response.StatusCode < 200 || response.StatusCode >= 300 || !envelope.Success {
+			message := "cloudflare DNS request was rejected"
+			if len(envelope.Errors) > 0 && strings.TrimSpace(envelope.Errors[0].Message) != "" {
+				message += ": " + strings.TrimSpace(envelope.Errors[0].Message)
+			}
+			return nil, errors.New(message)
+		}
+		return envelope.Result, nil
+	}
+	return nil, errors.New("cloudflare DNS request failed after retries")
 }
 
 func (c *cloudflareClient) findZone(ctx context.Context, zoneName string) (string, error) {

--- a/panel_acme_test.go
+++ b/panel_acme_test.go
@@ -443,6 +443,52 @@ func TestCloudflareDeleteRecordIsIdempotentWhenRecordIsMissing(t *testing.T) {
 	}
 }
 
+func TestCloudflareRequestRetriesTransientIdempotentOperation(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if r.Method != http.MethodPut {
+			t.Fatalf("method = %s, want PUT", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if attempts == 1 {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte(`{"success":false,"errors":[{"message":"temporary gateway failure"}]}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"success":true,"result":{"id":"record"}}`))
+	}))
+	defer server.Close()
+
+	client := &cloudflareClient{token: "test", httpClient: server.Client(), apiBase: server.URL}
+	result, err := client.request(context.Background(), http.MethodPut, "/zones/zone/dns_records/record", strings.NewReader(`{"content":"203.0.113.10"}`))
+	if err != nil {
+		t.Fatalf("transient PUT failed: %v", err)
+	}
+	if string(result) != `{"id":"record"}` || attempts != 2 {
+		t.Fatalf("result=%s attempts=%d, want record and two attempts", result, attempts)
+	}
+}
+
+func TestCloudflareRequestDoesNotRetryCreatePOST(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"success":false,"errors":[{"message":"temporary gateway failure"}]}`))
+	}))
+	defer server.Close()
+
+	client := &cloudflareClient{token: "test", httpClient: server.Client(), apiBase: server.URL}
+	if _, err := client.request(context.Background(), http.MethodPost, "/zones/zone/dns_records", strings.NewReader(`{"type":"TXT"}`)); err == nil {
+		t.Fatal("create POST unexpectedly succeeded")
+	}
+	if attempts != 1 {
+		t.Fatalf("create POST attempts=%d, want one attempt", attempts)
+	}
+}
+
 func TestDNSPropagationResolversIncludeUDPAndTCP(t *testing.T) {
 	t.Setenv("DNS_PROPAGATION_RESOLVERS", "1.1.1.1")
 	resolvers := dnsPropagationResolvers()


### PR DESCRIPTION
Fix two production reliability issues observed on AWS.

- Give /api/agent/live its own per-node admission limiter so full SQLite-backed reports cannot drop live trend samples.
- Retry idempotent Cloudflare GET/PUT/DELETE requests up to three attempts with bounded exponential backoff; leave record-creating POST requests single-attempt to avoid duplicates.
- Add regression tests for admission isolation and Cloudflare retry behavior.

Validation: go test ./..., go test -race ./..., go vet ./... (including Windows/macOS targets), govulncheck, gosec, and 176 frontend Node tests pass locally. CI will run shell and Docker checks.
