### PR TITLE
fix: isolate agent sessions and bound scheduler work

### DIFF
--- a/agent_live.go
+++ b/agent_live.go
@@ -32,6 +32,9 @@ func validateNodeLiveReport(report NodeLiveReport, now time.Time) error {
 	if report.ReportSessionID == "" || len(report.ReportSessionID) > 128 || len(report.CounterEpoch) > 128 {
 		return errors.New("invalid live report session")
 	}
+	if report.AgentLeaseID != "" && (report.SessionEpoch <= 0 || len(report.AgentLeaseID) > 128) {
+		return errors.New("invalid live report lease")
+	}
 	if report.Sequence <= 0 || report.TelemetrySequence < 0 || report.SampledAtMS <= 0 || len(report.SiteStats) > maxNodeLiveSitesPerReport {
 		return errors.New("invalid live report metadata")
 	}
@@ -75,6 +78,19 @@ func (d *DB) recordNodeLiveReport(nodeID int64, report NodeLiveReport, now time.
 	allowed, err := authorizedNodeSitesTx(tx, nodeID, now.UnixMilli())
 	if err != nil {
 		return nil, nil, err
+	}
+	var activeSession, lease string
+	var activeEpoch int64
+	if err := tx.QueryRow("SELECT active_agent_session_id,agent_session_epoch,agent_lease_id FROM control_nodes WHERE id=?", nodeID).Scan(&activeSession, &activeEpoch, &lease); err != nil {
+		return nil, nil, err
+	}
+	if strings.TrimSpace(activeSession) != "" && report.AgentLeaseID == "" && report.SessionEpoch == 0 {
+		return nil, nil, errStaleAgentSession
+	}
+	if report.AgentLeaseID != "" || report.SessionEpoch > 0 {
+		if report.AgentLeaseID == "" || report.SessionEpoch <= 0 || strings.TrimSpace(report.ReportSessionID) != strings.TrimSpace(activeSession) || report.SessionEpoch != activeEpoch || strings.TrimSpace(report.AgentLeaseID) != strings.TrimSpace(lease) {
+			return nil, nil, errStaleAgentSession
+		}
 	}
 
 	accepted = make([]int64, 0, len(report.SiteStats))

--- a/app_core.go
+++ b/app_core.go
@@ -40,6 +40,7 @@ type App struct {
 	agentLiveLimiter   *nodeReportAdmission
 	agentPreAuthMu     sync.Mutex
 	agentPreAuth       *agentPreAuthAdmission
+	nodeSchedulerMu    sync.Mutex
 }
 
 func (a *App) tmdbService() *tmdbService {

--- a/app_nodes.go
+++ b/app_nodes.go
@@ -57,7 +57,28 @@ func configuredAgentBinaryPath() string {
 const (
 	agentPlatformHeader = "X-Meridian-Agent-Platform"
 	agentVersionHeader  = "X-Meridian-Agent-Version"
+	agentSessionHeader  = "X-Meridian-Agent-Session"
+	agentEpochHeader    = "X-Meridian-Agent-Session-Epoch"
 )
+
+func requestedAgentSession(r *http.Request) (agentSessionRequest, error) {
+	if r == nil {
+		return agentSessionRequest{}, nil
+	}
+	id := strings.TrimSpace(r.Header.Get(agentSessionHeader))
+	epochText := strings.TrimSpace(r.Header.Get(agentEpochHeader))
+	if id == "" && epochText == "" {
+		return agentSessionRequest{}, nil
+	}
+	if id == "" || len(id) > 128 {
+		return agentSessionRequest{}, errors.New("invalid agent session")
+	}
+	epoch, err := strconv.ParseInt(epochText, 10, 64)
+	if err != nil || epoch <= 0 {
+		return agentSessionRequest{}, errors.New("invalid agent session epoch")
+	}
+	return agentSessionRequest{ID: id, Epoch: epoch}, nil
+}
 
 func normalizeAgentPlatform(value string) string {
 	switch strings.ToLower(strings.TrimSpace(value)) {
@@ -693,6 +714,11 @@ func (a *App) handleAgentReport(w http.ResponseWriter, r *http.Request) {
 		writeAgentAuthFailure(a, w, r)
 		return
 	}
+	if errors.Is(err, errStaleAgentSession) {
+		w.Header().Set("X-Meridian-Agent-State", "stale")
+		a.jsonErr(w, http.StatusConflict, "stale agent session; retry configuration fetch")
+		return
+	}
 	if err != nil {
 		a.jsonErr(w, http.StatusBadRequest, err.Error())
 		return
@@ -752,6 +778,11 @@ func (a *App) handleAgentLive(w http.ResponseWriter, r *http.Request) {
 	accepted, discarded, err := a.db.recordNodeLiveReport(identity.Node.ID, report, now)
 	if errors.Is(err, errInvalidAgentToken) {
 		writeAgentAuthFailure(a, w, r)
+		return
+	}
+	if errors.Is(err, errStaleAgentSession) {
+		w.Header().Set("X-Meridian-Agent-State", "stale")
+		a.jsonErr(w, http.StatusConflict, "stale agent session; retry configuration fetch")
 		return
 	}
 	if err != nil {
@@ -848,6 +879,10 @@ func (a *App) handleAgentWebSocket(ws *websocket.Conn) {
 		result, err := a.db.RecordNodeReportResult(token, report, time.Now())
 		release()
 		if err != nil {
+			if errors.Is(err, errStaleAgentSession) {
+				_ = ws.SetWriteDeadline(time.Now().Add(2 * time.Second))
+				_ = websocket.JSON.Send(ws, map[string]interface{}{"accepted": false, "agent_state": "stale", "error": "stale agent session; retry configuration fetch"})
+			}
 			return
 		}
 		ack := map[string]interface{}{

--- a/app_traffic.go
+++ b/app_traffic.go
@@ -204,9 +204,17 @@ func (a *App) handleSSE(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) sendSSEEvent(w http.ResponseWriter, flusher http.Flusher) error {
-	snap, err := a.pm.TrafficSnapshot()
-	if err != nil {
-		return err
+	// The process-wide sampler owns the SQLite-backed aggregation. Reuse its
+	// immutable snapshot for every SSE client so opening more dashboards does
+	// not multiply database work. Keep a fallback for startup and lightweight
+	// embedders whose sampler has not started yet.
+	snap := a.pm.latestDashboardSnapshot()
+	if snap == nil {
+		var err error
+		snap, err = a.pm.TrafficSnapshot()
+		if err != nil {
+			return err
+		}
 	}
 	snap.PanelDomain = a.panelHost
 	snap.PanelAccessURL = a.panelAccessURL()

--- a/dashboard_realtime.go
+++ b/dashboard_realtime.go
@@ -58,8 +58,8 @@ func (pm *ProxyManager) captureDashboardRealtimeSample() {
 	}
 
 	pm.dashboardRealtimeMu.Lock()
-	defer pm.dashboardRealtimeMu.Unlock()
 	if sampledAtMS <= pm.dashboardRealtimeLastMS {
+		pm.dashboardRealtimeMu.Unlock()
 		return
 	}
 	if pm.dashboardRealtimePrev == nil {
@@ -76,6 +76,39 @@ func (pm *ProxyManager) captureDashboardRealtimeSample() {
 	pm.dashboardRealtimePrev = next
 	pm.dashboardRealtimeLastMS = sampledAtMS
 	pm.dashboardRealtimePoints = appendDashboardRealtimePoint(pm.dashboardRealtimePoints, point)
+	latest := cloneDashboardTrendPoint(point)
+	pm.dashboardRealtimeMu.Unlock()
+
+	// Publish one immutable snapshot after the trend point has been appended so
+	// SSE, dashboard and trend consumers observe the same sample sequence.
+	snapshot.RealtimeTrend = &latest
+	pm.dashboardSnapshotMu.Lock()
+	pm.dashboardSnapshot = cloneTrafficSnapshot(snapshot)
+	pm.dashboardSnapshotMu.Unlock()
+}
+
+func cloneTrafficSnapshot(snapshot *TrafficSnapshot) *TrafficSnapshot {
+	if snapshot == nil {
+		return nil
+	}
+	cloned := *snapshot
+	if snapshot.LiveSites != nil {
+		cloned.LiveSites = append([]SiteTraffic(nil), snapshot.LiveSites...)
+	}
+	if snapshot.RealtimeTrend != nil {
+		trend := cloneDashboardTrendPoint(*snapshot.RealtimeTrend)
+		cloned.RealtimeTrend = &trend
+	}
+	return &cloned
+}
+
+func (pm *ProxyManager) latestDashboardSnapshot() *TrafficSnapshot {
+	if pm == nil {
+		return nil
+	}
+	pm.dashboardSnapshotMu.RLock()
+	defer pm.dashboardSnapshotMu.RUnlock()
+	return cloneTrafficSnapshot(pm.dashboardSnapshot)
 }
 
 func dashboardRealtimePointFromSnapshot(snapshot *TrafficSnapshot, previous map[int64]dashboardRealtimeCounter, sampledAtMS int64) (dashboardTrendPoint, map[int64]dashboardRealtimeCounter) {

--- a/dashboard_trends.go
+++ b/dashboard_trends.go
@@ -202,11 +202,11 @@ func (pm *ProxyManager) pendingDashboardTraffic(siteID *int64) map[int64]dashboa
 	return result
 }
 
-// lockLocalDashboardTrendSnapshot pins every selected local proxy while the
-// caller takes the SQLite history snapshot. Holding trafficMu across that
-// read makes the in-memory cumulative/pending split and traffic_logs observe
-// one consistent point in time; the returned unlock function must be called
-// on every path.
+// lockLocalDashboardTrendSnapshot copies the selected local counters under
+// trafficMu and releases every mutex before returning. The returned unlock
+// function is retained for source compatibility with older callers, but is a
+// no-op. In particular, callers must be able to perform SQLite history reads
+// without holding all local traffic locks.
 func (pm *ProxyManager) lockLocalDashboardTrendSnapshot(siteID *int64, sampledAt time.Time) (map[int64]dashboardPendingTraffic, map[int64]dashboardTrendBaseline, func()) {
 	pendingResult := make(map[int64]dashboardPendingTraffic)
 	baselineResult := make(map[int64]dashboardTrendBaseline)
@@ -249,13 +249,10 @@ func (pm *ProxyManager) lockLocalDashboardTrendSnapshot(siteID *int64, sampledAt
 			BytesIn: baselineIn, BytesOut: baselineOut, Requests: baselineRequests,
 			SampledAtMS: sampledAt.UnixMilli(),
 		}
+		inst.trafficMu.Unlock()
 	}
-	return pendingResult, baselineResult, func() {
-		for index := len(ids) - 1; index >= 0; index-- {
-			instances[ids[index]].trafficMu.Unlock()
-		}
-		pm.mu.RUnlock()
-	}
+	pm.mu.RUnlock()
+	return pendingResult, baselineResult, func() {}
 }
 
 // localDashboardTrendBaselines returns the controller-local cumulative

--- a/database_migrations.go
+++ b/database_migrations.go
@@ -20,7 +20,7 @@ const (
 	// databaseSchemaVersion is independent from the application and backup
 	// format versions. It is persisted in SQLite so restores can reject a
 	// database whose columns/state are newer than this binary understands.
-	databaseSchemaVersion = 46
+	databaseSchemaVersion = 47
 )
 
 func (d *DB) migrate() error {
@@ -377,6 +377,9 @@ func (d *DB) migrateOnce() error {
 		last_raw_tx_bytes BIGINT NOT NULL DEFAULT 0,
 		last_boot_id TEXT NOT NULL DEFAULT '',
 		last_report_session_id TEXT NOT NULL DEFAULT '',
+		active_agent_session_id TEXT NOT NULL DEFAULT '',
+		agent_session_epoch BIGINT NOT NULL DEFAULT 0,
+		agent_lease_id TEXT NOT NULL DEFAULT '',
 		last_sequence BIGINT NOT NULL DEFAULT 0,
 		interface_name TEXT NOT NULL DEFAULT '',
 		agent_version TEXT NOT NULL DEFAULT '',
@@ -775,6 +778,9 @@ func (d *DB) migrateOnce() error {
 	for _, migration := range []struct{ table, column, sql string }{
 		{"control_nodes", "traffic_manual_offset_bytes", "ALTER TABLE control_nodes ADD COLUMN traffic_manual_offset_bytes BIGINT NOT NULL DEFAULT 0"},
 		{"control_nodes", "last_report_session_id", "ALTER TABLE control_nodes ADD COLUMN last_report_session_id TEXT NOT NULL DEFAULT ''"},
+		{"control_nodes", "active_agent_session_id", "ALTER TABLE control_nodes ADD COLUMN active_agent_session_id TEXT NOT NULL DEFAULT ''"},
+		{"control_nodes", "agent_session_epoch", "ALTER TABLE control_nodes ADD COLUMN agent_session_epoch BIGINT NOT NULL DEFAULT 0"},
+		{"control_nodes", "agent_lease_id", "ALTER TABLE control_nodes ADD COLUMN agent_lease_id TEXT NOT NULL DEFAULT ''"},
 		{"control_nodes", "event_spool_error", "ALTER TABLE control_nodes ADD COLUMN event_spool_error TEXT NOT NULL DEFAULT ''"},
 		{"control_nodes", "event_queue_depth", "ALTER TABLE control_nodes ADD COLUMN event_queue_depth INTEGER NOT NULL DEFAULT 0"},
 		{"control_nodes", "event_dropped", "ALTER TABLE control_nodes ADD COLUMN event_dropped BIGINT NOT NULL DEFAULT 0"},

--- a/edge_agent.go
+++ b/edge_agent.go
@@ -49,6 +49,7 @@ var errEdgeAgentUpdated = errors.New("Agent binary updated; restarting")
 type edgeAgentState struct {
 	NodeGUID string `json:"node_guid"`
 	Token    string `json:"agent_token"`
+	LeaseID  string `json:"agent_lease_id,omitempty"`
 }
 
 type edgeSiteIdentity struct {
@@ -508,6 +509,8 @@ type edgeAgentRuntime struct {
 	mu                   sync.RWMutex
 	stateDir             string
 	nodeGUID             string
+	sessionEpoch         int64
+	leaseID              string
 	port                 int
 	handler              http.Handler
 	certificate          *tls.Certificate
@@ -1893,6 +1896,24 @@ func (runtime *edgeAgentRuntime) status() (string, int64, string, string, int64,
 	return runtime.appliedHash, runtime.appliedRevision, runtime.listenerError, runtime.applyError, runtime.applyErrorAtMS, runtime.applyFailures
 }
 
+func (runtime *edgeAgentRuntime) reportIdentity() (string, int64) {
+	if runtime == nil {
+		return "", 0
+	}
+	runtime.mu.RLock()
+	defer runtime.mu.RUnlock()
+	return strings.TrimSpace(runtime.leaseID), runtime.sessionEpoch
+}
+
+func (runtime *edgeAgentRuntime) setLeaseID(leaseID string) {
+	if runtime == nil {
+		return
+	}
+	runtime.mu.Lock()
+	runtime.leaseID = strings.TrimSpace(leaseID)
+	runtime.mu.Unlock()
+}
+
 // nextTelemetrySequence is shared by the full and lightweight report loops.
 // Their channel-local sequences intentionally remain independent, while this
 // monotonic value provides the Controller with one ordering boundary.
@@ -1998,6 +2019,11 @@ func isEdgeAgentRevoked(err error) bool {
 	return errors.As(err, &apiErr) && strings.EqualFold(strings.TrimSpace(apiErr.AgentState), "revoked")
 }
 
+func isEdgeAgentStale(err error) bool {
+	var apiErr *edgeAPIError
+	return errors.As(err, &apiErr) && strings.EqualFold(strings.TrimSpace(apiErr.AgentState), "stale")
+}
+
 // edgeQuiesceRevoked closes the data plane before recording the durable
 // marker. If the disk is unavailable, returning would let systemd restart the
 // same revoked credential forever; stay inert until an operator stops or
@@ -2092,6 +2118,9 @@ func edgeAPIRequestWithHeaders(ctx context.Context, client *http.Client, method,
 }
 
 type edgeReportAck struct {
+	Accepted                    bool     `json:"accepted"`
+	AgentState                  string   `json:"agent_state,omitempty"`
+	Error                       string   `json:"error,omitempty"`
 	AcceptedSiteIDs             []int64  `json:"accepted_site_ids"`
 	DiscardedSiteIDs            []int64  `json:"discarded_site_ids"`
 	AcceptedMediaSiteIDs        []int64  `json:"accepted_media_site_ids"`
@@ -2200,6 +2229,10 @@ func (c *edgeWSReportClient) report(ctx context.Context, payload NodeReport) (ed
 		c.nextTry = time.Now().Add(30 * time.Second)
 		return edgeReportAck{}, err
 	}
+	if !ack.Accepted && strings.EqualFold(strings.TrimSpace(ack.AgentState), "stale") {
+		c.closeLocked()
+		return edgeReportAck{}, &edgeAPIError{StatusCode: http.StatusConflict, AgentState: "stale", Message: ack.Error}
+	}
 	return ack, nil
 }
 
@@ -2304,7 +2337,7 @@ func edgeCollect(sessionID string, sequence int64) (NodeReport, error) {
 	return NodeReport{BootID: sessionID, ReportSessionID: sessionID, CounterEpoch: edgeCounterEpoch(interfaceName), Sequence: sequence, InterfaceName: interfaceName, RXBytes: rx, TXBytes: tx, AgentVersion: appVersion}, nil
 }
 
-func edgeLiveReportLoop(ctx context.Context, client *http.Client, controller, token, sessionID string, runtime *edgeAgentRuntime) error {
+func edgeLiveReportLoop(ctx context.Context, client *http.Client, controller, token, sessionID string, sessionEpoch int64, runtime *edgeAgentRuntime) error {
 	if runtime == nil {
 		return nil
 	}
@@ -2317,12 +2350,14 @@ func edgeLiveReportLoop(ctx context.Context, client *http.Client, controller, to
 		})
 		report := NodeLiveReport{
 			ReportSessionID:   sessionID,
+			SessionEpoch:      sessionEpoch,
 			CounterEpoch:      edgeCounterEpoch(edgeDefaultInterface()),
 			Sequence:          sequence,
 			TelemetrySequence: telemetrySequence,
 			SampledAtMS:       sampledAtMS,
 			SiteStats:         stats,
 		}
+		report.AgentLeaseID, _ = runtime.reportIdentity()
 		var ack struct{}
 		return edgeAPIRequest(ctx, client, http.MethodPost, controller+"/api/agent/live", token, report, &ack)
 	}
@@ -2570,7 +2605,11 @@ func runEdgeAgent() error {
 			return err
 		}
 	}
-	runtime := &edgeAgentRuntime{stateDir: filepath.Dir(*statePath), nodeGUID: state.NodeGUID}
+	sessionEpoch := time.Now().UnixNano()
+	if sessionEpoch <= 0 {
+		sessionEpoch = 1
+	}
+	runtime := &edgeAgentRuntime{stateDir: filepath.Dir(*statePath), nodeGUID: state.NodeGUID, sessionEpoch: sessionEpoch, leaseID: state.LeaseID}
 	spoolDir := filepath.Join(runtime.stateDir, "events")
 	spoolKey, spoolKeyErr := loadOrCreateSpoolKey(filepath.Join(runtime.stateDir, "spool.key"))
 	if spoolKeyErr != nil {
@@ -2608,7 +2647,7 @@ func runEdgeAgent() error {
 		liveDone = make(chan struct{})
 		go func() {
 			defer close(liveDone)
-			if err := edgeLiveReportLoop(liveCtx, client, controller, state.Token, bootID, runtime); err != nil {
+			if err := edgeLiveReportLoop(liveCtx, client, controller, state.Token, bootID, sessionEpoch, runtime); err != nil {
 				select {
 				case liveErrCh <- err:
 				default:
@@ -2648,14 +2687,24 @@ func runEdgeAgent() error {
 			if err := edgeAPIRequestWithHeaders(ctx, client, http.MethodGet, controller+"/api/agent/config", state.Token, nil, &config, http.Header{
 				agentPlatformHeader: []string{goruntime.GOOS + "/" + goruntime.GOARCH},
 				agentVersionHeader:  []string{appVersion},
+				agentSessionHeader:  []string{bootID},
+				agentEpochHeader:    []string{strconv.FormatInt(sessionEpoch, 10)},
 			}); err != nil {
 				if isEdgeAgentRevoked(err) {
 					return edgeQuiesceRevoked(ctx, runtime, revokedMarker)
+				}
+				if isEdgeAgentStale(err) {
+					lastConfigAt = time.Time{}
 				}
 				fmt.Fprintf(os.Stderr, "Meridian Agent config fetch failed: %v\n", err)
 			} else if configErr := validateAgentConfigEnvelope(config); configErr != nil {
 				fmt.Fprintf(os.Stderr, "Meridian Agent rejected config: %v\n", configErr)
 			} else {
+				runtime.setLeaseID(config.AgentLeaseID)
+				state.LeaseID = config.AgentLeaseID
+				if saveErr := edgeSaveState(*statePath, state); saveErr != nil {
+					fmt.Fprintf(os.Stderr, "Meridian Agent state save failed: %v\n", saveErr)
+				}
 				// A new identity must be applied atomically. Updating the old
 				// bundle before apply would leak a failed candidate's quota into
 				// the still-serving configuration. Hash-stable refreshes are the
@@ -2720,6 +2769,7 @@ func runEdgeAgent() error {
 			fmt.Fprintf(os.Stderr, "Meridian Agent traffic collection failed: %v\n", collectErr)
 		} else {
 			report.AppliedConfigHash, report.AppliedConfigRevision, report.ListenerError, report.ApplyError, report.ApplyErrorAtMS, report.ApplyFailures = runtime.status()
+			report.AgentLeaseID, report.SessionEpoch = runtime.reportIdentity()
 			runtime.mu.RLock()
 			report.CacheClearGeneration = runtime.cacheClearGeneration
 			report.SiteCounterEpoch = strconv.FormatUint(runtime.siteCounterEpoch, 10)
@@ -2734,6 +2784,10 @@ func runEdgeAgent() error {
 			if wsErr != nil {
 				if isEdgeAgentRevoked(wsErr) {
 					return edgeQuiesceRevoked(ctx, runtime, revokedMarker)
+				}
+				if isEdgeAgentStale(wsErr) {
+					lastConfigAt = time.Time{}
+					refreshImmediately = true
 				}
 				fmt.Fprintf(os.Stderr, "Meridian Agent report failed: %v\n", wsErr)
 			} else {

--- a/node_repository.go
+++ b/node_repository.go
@@ -27,6 +27,7 @@ var (
 	errNodeNameConflict      = errors.New("node name already exists")
 	errInvalidNodeToken      = errors.New("invalid or expired node token")
 	errInvalidAgentToken     = errors.New("invalid agent token")
+	errStaleAgentSession     = errors.New("stale agent session; fetch a fresh agent configuration")
 	errManualNodeUnavailable = errors.New("manual node is unavailable")
 	errPersistentJWTRequired = errors.New("Agent nodes require a persistent JWT_SECRET")
 )
@@ -80,6 +81,9 @@ type ControlNode struct {
 	lastRawTXBytes        int64
 	lastBootID            string // counter epoch (kernel boot + interface)
 	lastReportSessionID   string
+	activeAgentSessionID  string
+	agentSessionEpoch     int64
+	agentLeaseID          string
 	lastSequence          int64
 	enrollmentTokenHash   string
 	agentTokenHash        string
@@ -127,6 +131,8 @@ type NodeCreateInput struct {
 type NodeReport struct {
 	BootID           string `json:"boot_id"`
 	ReportSessionID  string `json:"report_session_id,omitempty"`
+	SessionEpoch     int64  `json:"session_epoch,omitempty"`
+	AgentLeaseID     string `json:"agent_lease_id,omitempty"`
 	CounterEpoch     string `json:"counter_epoch,omitempty"`
 	SiteCounterEpoch string `json:"site_counter_epoch,omitempty"`
 	Sequence         int64  `json:"sequence"`
@@ -159,6 +165,8 @@ type NodeReport struct {
 // responsible for site state, media, observations, events, and persistence.
 type NodeLiveReport struct {
 	ReportSessionID   string                `json:"report_session_id"`
+	SessionEpoch      int64                 `json:"session_epoch,omitempty"`
+	AgentLeaseID      string                `json:"agent_lease_id,omitempty"`
 	CounterEpoch      string                `json:"counter_epoch,omitempty"`
 	Sequence          int64                 `json:"sequence"`
 	TelemetrySequence int64                 `json:"telemetry_sequence,omitempty"`
@@ -459,7 +467,7 @@ type rowScanner interface{ Scan(...interface{}) error }
 
 const controlNodeSelect = `SELECT id,guid,name,address,https_port,enabled,priority,traffic_quota,billing_mode,reset_day,
 	cycle_started_at_ms,period_rx_bytes,period_tx_bytes,lifetime_rx_bytes,lifetime_tx_bytes,traffic_manual_offset_bytes,
-	last_raw_rx_bytes,last_raw_tx_bytes,last_boot_id,last_report_session_id,last_sequence,interface_name,agent_version,desired_config_hash,config_dirty,applied_config_hash,agent_apply_error,agent_apply_error_at_ms,agent_apply_failures,agent_listener_error,event_spool_error,event_queue_depth,event_dropped,
+	last_raw_rx_bytes,last_raw_tx_bytes,last_boot_id,last_report_session_id,active_agent_session_id,agent_session_epoch,agent_lease_id,last_sequence,interface_name,agent_version,desired_config_hash,config_dirty,applied_config_hash,agent_apply_error,agent_apply_error_at_ms,agent_apply_failures,agent_listener_error,event_spool_error,event_queue_depth,event_dropped,
 	config_revision,desired_config_revision,applied_config_revision,
 	enrollment_token_hash,enrollment_expires_at_ms,probe_secret_ciphertext,agent_token_hash,cache_clear_generation,cache_clear_applied_generation,enrolled_at_ms,last_seen_at_ms,created_at_ms,updated_at_ms
 	FROM control_nodes`
@@ -469,7 +477,7 @@ func scanControlNode(scanner rowScanner, now time.Time) (ControlNode, error) {
 	var enabled, configDirty int
 	err := scanner.Scan(&node.ID, &node.GUID, &node.Name, &node.Address, &node.Port, &enabled, &node.Priority, &node.TrafficQuota,
 		&node.BillingMode, &node.ResetDay, &node.CycleStartedAtMS, &node.PeriodRXBytes, &node.PeriodTXBytes,
-		&node.LifetimeRXBytes, &node.LifetimeTXBytes, &node.TrafficManualOffset, &node.lastRawRXBytes, &node.lastRawTXBytes, &node.lastBootID, &node.lastReportSessionID,
+		&node.LifetimeRXBytes, &node.LifetimeTXBytes, &node.TrafficManualOffset, &node.lastRawRXBytes, &node.lastRawTXBytes, &node.lastBootID, &node.lastReportSessionID, &node.activeAgentSessionID, &node.agentSessionEpoch, &node.agentLeaseID,
 		&node.lastSequence, &node.InterfaceName, &node.AgentVersion, &node.DesiredConfigHash, &configDirty, &node.AppliedConfigHash, &node.AgentApplyError, &node.AgentApplyErrorAtMS, &node.AgentApplyFailures, &node.AgentListenerError, &node.EventSpoolError, &node.EventQueueDepth, &node.EventDropped,
 		&node.ConfigRevision, &node.DesiredConfigRevision, &node.AppliedConfigRevision,
 		&node.enrollmentTokenHash, &node.enrollmentExpiresMS, &node.probeSecretCiphertext,
@@ -1029,7 +1037,7 @@ func validateNodeReport(report NodeReport) error {
 	report.ReportSessionID = strings.TrimSpace(report.ReportSessionID)
 	report.CounterEpoch = strings.TrimSpace(report.CounterEpoch)
 	report.InterfaceName = strings.TrimSpace(report.InterfaceName)
-	if report.BootID == "" || len(report.BootID) > 128 || len(report.ReportSessionID) > 128 || len(report.CounterEpoch) > 128 || len(report.SiteCounterEpoch) > 128 {
+	if report.BootID == "" || len(report.BootID) > 128 || len(report.ReportSessionID) > 128 || len(report.AgentLeaseID) > 128 || report.SessionEpoch < 0 || len(report.CounterEpoch) > 128 || len(report.SiteCounterEpoch) > 128 {
 		return errors.New("invalid boot_id")
 	}
 	if report.Sequence <= 0 || report.TelemetrySequence < 0 || report.RXBytes < 0 || report.TXBytes < 0 || report.CacheClearGeneration < 0 {
@@ -1533,6 +1541,41 @@ func appendNodeEventIdentity(ids *[]int64, uids *[]string, event NodeRequestEven
 	}
 }
 
+// claimAgentLeaseTx binds a process session to the node before the first
+// report is accepted. A newer session epoch rotates the lease; an older
+// session can no longer overwrite state after a restart or failover.
+func claimAgentLeaseTx(tx *sql.Tx, nodeID int64, sessionID string, sessionEpoch int64) (string, error) {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" || sessionEpoch <= 0 {
+		var lease string
+		if err := tx.QueryRow("SELECT agent_lease_id FROM control_nodes WHERE id=?", nodeID).Scan(&lease); err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(lease), nil
+	}
+	var activeSession, lease string
+	var activeEpoch int64
+	if err := tx.QueryRow("SELECT active_agent_session_id,agent_session_epoch,agent_lease_id FROM control_nodes WHERE id=?", nodeID).Scan(&activeSession, &activeEpoch, &lease); err != nil {
+		return "", err
+	}
+	activeSession = strings.TrimSpace(activeSession)
+	lease = strings.TrimSpace(lease)
+	if activeSession == sessionID && activeEpoch == sessionEpoch && lease != "" {
+		return lease, nil
+	}
+	if activeSession != "" && sessionEpoch <= activeEpoch {
+		return "", errStaleAgentSession
+	}
+	newLease, err := newNodeToken()
+	if err != nil {
+		return "", err
+	}
+	if _, err := tx.Exec("UPDATE control_nodes SET active_agent_session_id=?,agent_session_epoch=?,agent_lease_id=?,updated_at_ms=? WHERE id=?", sessionID, sessionEpoch, newLease, time.Now().UnixMilli(), nodeID); err != nil {
+		return "", err
+	}
+	return newLease, nil
+}
+
 func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now time.Time) (nodeReportCommitResult, error) {
 	result := nodeReportCommitResult{}
 	validEvents := make([]NodeRequestEvent, 0, len(report.Events))
@@ -1559,15 +1602,24 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 	var id, lastSequence, lastRX, lastTX int64
 	var previousApplyFailures int64
 	var cacheClearGeneration int64
-	var lastBootID, lastSessionID, desiredConfigHash, previousApplyError, previousAgentVersion string
+	var lastBootID, lastSessionID, activeSessionID, desiredConfigHash, previousApplyError, previousAgentVersion, agentLeaseID string
+	var activeSessionEpoch int64
 	var configDirty, configRevision, desiredConfigRevision, appliedConfigRevision int64
-	err = tx.QueryRow(`SELECT id,last_sequence,last_raw_rx_bytes,last_raw_tx_bytes,last_boot_id,last_report_session_id,cache_clear_generation,desired_config_hash,config_dirty,agent_apply_error,agent_apply_failures,config_revision,desired_config_revision,applied_config_revision,agent_version FROM control_nodes WHERE agent_token_hash=?`, hashNodeToken(agentToken)).Scan(
-		&id, &lastSequence, &lastRX, &lastTX, &lastBootID, &lastSessionID, &cacheClearGeneration, &desiredConfigHash, &configDirty, &previousApplyError, &previousApplyFailures, &configRevision, &desiredConfigRevision, &appliedConfigRevision, &previousAgentVersion)
+	err = tx.QueryRow(`SELECT id,last_sequence,last_raw_rx_bytes,last_raw_tx_bytes,last_boot_id,last_report_session_id,active_agent_session_id,agent_session_epoch,agent_lease_id,cache_clear_generation,desired_config_hash,config_dirty,agent_apply_error,agent_apply_failures,config_revision,desired_config_revision,applied_config_revision,agent_version FROM control_nodes WHERE agent_token_hash=?`, hashNodeToken(agentToken)).Scan(
+		&id, &lastSequence, &lastRX, &lastTX, &lastBootID, &lastSessionID, &activeSessionID, &activeSessionEpoch, &agentLeaseID, &cacheClearGeneration, &desiredConfigHash, &configDirty, &previousApplyError, &previousApplyFailures, &configRevision, &desiredConfigRevision, &appliedConfigRevision, &previousAgentVersion)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nodeReportCommitResult{}, errInvalidAgentToken
 	}
 	if err != nil {
 		return nodeReportCommitResult{}, err
+	}
+	if activeSessionID != "" && strings.TrimSpace(report.AgentLeaseID) == "" && report.SessionEpoch == 0 {
+		return nodeReportCommitResult{}, errStaleAgentSession
+	}
+	if strings.TrimSpace(report.AgentLeaseID) != "" || report.SessionEpoch > 0 {
+		if strings.TrimSpace(report.AgentLeaseID) == "" || report.SessionEpoch <= 0 || strings.TrimSpace(report.ReportSessionID) != strings.TrimSpace(activeSessionID) || report.SessionEpoch != activeSessionEpoch || strings.TrimSpace(report.AgentLeaseID) != strings.TrimSpace(agentLeaseID) {
+			return nodeReportCommitResult{}, errStaleAgentSession
+		}
 	}
 
 	// Authorization and every report mutation use one transaction. A scheduler

--- a/node_repository_test.go
+++ b/node_repository_test.go
@@ -1814,3 +1814,50 @@ func TestNormalizeControllerURLRejectsBasePaths(t *testing.T) {
 		}
 	}
 }
+
+func TestAgentSessionLeaseRejectsStaleReports(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now().UTC()
+	node, enrollment, err := app.db.CreateControlNode(NodeCreateInput{Name: "lease-node", Address: "203.0.113.210"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, token, err := app.db.EnrollControlNode(enrollment, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := app.buildAgentConfigForRequest(context.Background(), token, now, "", "", agentSessionRequest{ID: "session-a", Epoch: 100})
+	if err != nil {
+		t.Fatalf("claim first session: %v", err)
+	}
+	if first.AgentLeaseID == "" {
+		t.Fatal("first config did not issue an Agent lease")
+	}
+	if _, err := app.db.RecordNodeReport(token, NodeReport{BootID: "session-a", ReportSessionID: "session-a", SessionEpoch: 100, AgentLeaseID: first.AgentLeaseID, CounterEpoch: "kernel-a", Sequence: 1, InterfaceName: "eth0", RXBytes: 100, TXBytes: 200, AgentVersion: "test"}, now.Add(time.Second)); err != nil {
+		t.Fatalf("first session report: %v", err)
+	}
+	second, err := app.buildAgentConfigForRequest(context.Background(), token, now.Add(2*time.Second), "", "", agentSessionRequest{ID: "session-b", Epoch: 200})
+	if err != nil {
+		t.Fatalf("claim second session: %v", err)
+	}
+	if second.AgentLeaseID == first.AgentLeaseID {
+		t.Fatal("new session reused the previous Agent lease")
+	}
+	before, err := app.db.controlNodeByID(node.ID, now.Add(2*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.RecordNodeReport(token, NodeReport{BootID: "session-a", ReportSessionID: "session-a", SessionEpoch: 100, AgentLeaseID: first.AgentLeaseID, CounterEpoch: "kernel-a", Sequence: 2, InterfaceName: "eth0", RXBytes: 999999, TXBytes: 999999, AgentVersion: "stale"}, now.Add(3*time.Second)); !errors.Is(err, errStaleAgentSession) {
+		t.Fatalf("stale report error=%v, want errStaleAgentSession", err)
+	}
+	after, err := app.db.controlNodeByID(node.ID, now.Add(3*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.LastSeenAtMS != before.LastSeenAtMS || after.lastRawRXBytes != before.lastRawRXBytes || after.lastRawTXBytes != before.lastRawTXBytes {
+		t.Fatalf("stale report changed node state: before=%#v after=%#v", before, after)
+	}
+	if _, err := app.db.RecordNodeReport(token, NodeReport{BootID: "session-b", ReportSessionID: "session-b", SessionEpoch: 200, AgentLeaseID: second.AgentLeaseID, CounterEpoch: "kernel-b", Sequence: 1, InterfaceName: "eth0", RXBytes: 300, TXBytes: 400, AgentVersion: "current"}, now.Add(4*time.Second)); err != nil {
+		t.Fatalf("current session report: %v", err)
+	}
+}

--- a/proxy_manager.go
+++ b/proxy_manager.go
@@ -156,6 +156,11 @@ type ProxyManager struct {
 	dashboardRealtimeLastMS      int64
 	dashboardRealtimeBillingMode string
 	dashboardRealtimeStarted     atomic.Bool
+	// dashboardSnapshot is the last process-wide traffic snapshot captured by
+	// the realtime sampler. SSE clients read this immutable copy instead of
+	// rerunning the full SQLite-backed aggregation for every connection.
+	dashboardSnapshotMu sync.RWMutex
+	dashboardSnapshot   *TrafficSnapshot
 }
 
 // ProxyRuntimeStat is a non-persistent edge snapshot. Node scheduling quotas

--- a/review_regression_test.go
+++ b/review_regression_test.go
@@ -106,6 +106,21 @@ func TestReviewCacheMultiValueHeaders(t *testing.T) {
 	}
 }
 
+func TestOwnedAddressRecordAdoptionRequiresUniqueMeridianMarker(t *testing.T) {
+	records := []cloudflareAddressRecord{{ID: "r1", Type: "A", Name: "site.example", Content: "203.0.113.7", Comment: "Meridian site=7"}}
+	owned, ok, ambiguous := ownedAddressRecord(records, "A", "site.example", "203.0.113.7", "Meridian site=7")
+	if !ok || ambiguous || owned.ID != "r1" {
+		t.Fatalf("owned record match = %#v, ok=%v ambiguous=%v", owned, ok, ambiguous)
+	}
+	records = append(records, records[0])
+	if _, ok, ambiguous = ownedAddressRecord(records, "A", "site.example", "203.0.113.7", "Meridian site=7"); ok || !ambiguous {
+		t.Fatalf("duplicate marker was not treated as ambiguous: ok=%v ambiguous=%v", ok, ambiguous)
+	}
+	if _, ok, _ = ownedAddressRecord([]cloudflareAddressRecord{{ID: "operator", Type: "A", Name: "site.example", Content: "203.0.113.7", Comment: ""}}, "A", "site.example", "203.0.113.7", "Meridian site=7"); ok {
+		t.Fatal("unmarked operator record was adopted")
+	}
+}
+
 func TestReviewCacheSiteIdentityAcrossRebuild(t *testing.T) {
 	calls := 0
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/site_node_scheduler.go
+++ b/site_node_scheduler.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -37,6 +38,7 @@ const (
 	// unknown) version while a revocation is pending, the whole Agent
 	// credential is revoked so the old data-plane listener cannot drain forever.
 	legacyForceStopGrace = 10 * time.Minute
+	nodeSchedulerWorkers = 4
 )
 
 type SiteNodeSchedule struct {
@@ -102,6 +104,7 @@ type AgentRuntimeConfig struct {
 	PrivateKeyPEM        string           `json:"private_key_pem,omitempty"`
 	DynamicKey           string           `json:"dynamic_key,omitempty"`
 	ProbeSecret          string           `json:"probe_secret,omitempty"`
+	AgentLeaseID         string           `json:"agent_lease_id,omitempty"`
 	AgentVersion         string           `json:"agent_version,omitempty"`
 	AgentSHA256          string           `json:"agent_sha256,omitempty"`
 	AgentDownloadURL     string           `json:"agent_download_url,omitempty"`
@@ -839,7 +842,12 @@ func (a *App) buildAgentConfigForPlatform(token string, now time.Time, platform 
 	return a.buildAgentConfigForRequest(context.Background(), token, now, platform, "")
 }
 
-func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now time.Time, platform, clientVersion string) (AgentRuntimeConfig, error) {
+type agentSessionRequest struct {
+	ID    string
+	Epoch int64
+}
+
+func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now time.Time, platform, clientVersion string, requestedSession ...agentSessionRequest) (AgentRuntimeConfig, error) {
 	var node ControlNode
 	var err error
 	if identity, ok := agentCredentialFromContext(ctx); ok && identity.HasNode && identity.Token == token {
@@ -884,6 +892,14 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 	}
 	defer tx.Rollback()
 	node, err = scanControlNode(tx.QueryRow(controlNodeSelect+" WHERE id=?", node.ID), now)
+	if err != nil {
+		return AgentRuntimeConfig{}, err
+	}
+	var session agentSessionRequest
+	if len(requestedSession) > 0 {
+		session = requestedSession[0]
+	}
+	leaseID, err := claimAgentLeaseTx(tx, node.ID, session.ID, session.Epoch)
 	if err != nil {
 		return AgentRuntimeConfig{}, err
 	}
@@ -976,7 +992,7 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 	// Keep the legacy field names in the Agent wire contract during rolling
 	// upgrades. Their values now describe one HTTPS-only listener.
 	config := AgentRuntimeConfig{SchemaVersion: agentConfigSchemaVersion, ConfigRevision: node.ConfigRevision, NodeGUID: node.GUID, EntryMode: "direct",
-		HTTPPort: 0, HTTPSPort: node.Port, DynamicKey: encodeRuntimeKey(dynamicKey), ProbeSecret: probeSecretText,
+		HTTPPort: 0, HTTPSPort: node.Port, DynamicKey: encodeRuntimeKey(dynamicKey), ProbeSecret: probeSecretText, AgentLeaseID: leaseID,
 		CacheClearGeneration: node.CacheClearGeneration, Routes: routes}
 	forceRows, forceErr := tx.Query("SELECT site_id FROM agent_route_revocations WHERE node_id=? ORDER BY site_id", node.ID)
 	if forceErr != nil {
@@ -1055,9 +1071,19 @@ func (a *App) handleAgentConfig(w http.ResponseWriter, r *http.Request) {
 		a.jsonErr(w, http.StatusBadRequest, platformErr.Error())
 		return
 	}
-	config, err := a.buildAgentConfigForRequest(r.Context(), requestBearerToken(r), time.Now(), platform, r.Header.Get(agentVersionHeader))
+	session, sessionErr := requestedAgentSession(r)
+	if sessionErr != nil {
+		a.jsonErr(w, http.StatusBadRequest, sessionErr.Error())
+		return
+	}
+	config, err := a.buildAgentConfigForRequest(r.Context(), requestBearerToken(r), time.Now(), platform, r.Header.Get(agentVersionHeader), session)
 	if errors.Is(err, errInvalidAgentToken) {
 		writeAgentAuthFailure(a, w, r)
+		return
+	}
+	if errors.Is(err, errStaleAgentSession) {
+		w.Header().Set("X-Meridian-Agent-State", "stale")
+		a.jsonErr(w, http.StatusConflict, "stale agent session; retry configuration fetch")
 		return
 	}
 	if err != nil {
@@ -1181,7 +1207,7 @@ func (a *App) cloudflareForScheduling() (*cloudflareClient, error) {
 	return &cloudflareClient{token: token, httpClient: &http.Client{Timeout: 15 * time.Second}, apiBase: "https://api.cloudflare.com/client/v4"}, nil
 }
 
-type cloudflareAddressRecord struct{ ID, Type, Name, Content string }
+type cloudflareAddressRecord struct{ ID, Type, Name, Content, Comment string }
 
 func (c *cloudflareClient) exactAddressRecords(ctx context.Context, zoneID, name string) ([]cloudflareAddressRecord, error) {
 	result, err := c.request(ctx, http.MethodGet, "/zones/"+url.PathEscape(zoneID)+"/dns_records?name="+url.QueryEscape(name)+"&per_page=100", nil)
@@ -1193,6 +1219,7 @@ func (c *cloudflareClient) exactAddressRecords(ctx context.Context, zoneID, name
 		Type    string `json:"type"`
 		Name    string `json:"name"`
 		Content string `json:"content"`
+		Comment string `json:"comment"`
 	}
 	if err := json.Unmarshal(result, &raw); err != nil {
 		return nil, errors.New("Cloudflare DNS returned invalid records")
@@ -1200,14 +1227,18 @@ func (c *cloudflareClient) exactAddressRecords(ctx context.Context, zoneID, name
 	values := make([]cloudflareAddressRecord, 0, len(raw))
 	for _, item := range raw {
 		if (item.Type == "A" || item.Type == "AAAA") && strings.EqualFold(item.Name, name) {
-			values = append(values, cloudflareAddressRecord{ID: item.ID, Type: item.Type, Name: item.Name, Content: item.Content})
+			values = append(values, cloudflareAddressRecord{ID: item.ID, Type: item.Type, Name: item.Name, Content: item.Content, Comment: item.Comment})
 		}
 	}
 	return values, nil
 }
 
-func (c *cloudflareClient) writeAddressRecord(ctx context.Context, zoneID, recordID, recordType, name, address string) (string, error) {
-	body, _ := json.Marshal(map[string]any{"type": recordType, "name": name, "content": address, "ttl": 60, "proxied": false})
+func (c *cloudflareClient) writeAddressRecord(ctx context.Context, zoneID, recordID, recordType, name, address string, comments ...string) (string, error) {
+	payload := map[string]any{"type": recordType, "name": name, "content": address, "ttl": 60, "proxied": false}
+	if len(comments) > 0 && strings.TrimSpace(comments[0]) != "" {
+		payload["comment"] = strings.TrimSpace(comments[0])
+	}
+	body, _ := json.Marshal(payload)
 	method, path := http.MethodPost, "/zones/"+url.PathEscape(zoneID)+"/dns_records"
 	if recordID != "" {
 		method, path = http.MethodPut, path+"/"+url.PathEscape(recordID)
@@ -1223,6 +1254,18 @@ func (c *cloudflareClient) writeAddressRecord(ctx context.Context, zoneID, recor
 		return "", errors.New("Cloudflare DNS did not return a record ID")
 	}
 	return record.ID, nil
+}
+
+func ownedAddressRecord(records []cloudflareAddressRecord, recordType, name, address, marker string) (cloudflareAddressRecord, bool, bool) {
+	var match cloudflareAddressRecord
+	count := 0
+	for _, record := range records {
+		if record.Type == recordType && strings.EqualFold(record.Name, name) && record.Content == address && strings.TrimSpace(record.Comment) == marker {
+			match = record
+			count++
+		}
+	}
+	return match, count == 1, count > 1
 }
 
 func (a *App) deleteTrackedSiteDNS(ctx context.Context, schedule SiteNodeSchedule) error {
@@ -1481,10 +1524,34 @@ func (a *App) reconcileOneSiteSchedule(ctx context.Context, schedule SiteNodeSch
 			return err
 		}
 		if len(records) > 0 {
-			return errors.New("an untracked exact A/AAAA record already exists; Meridian will not overwrite it")
+			marker := fmt.Sprintf("Meridian site=%d", schedule.SiteID)
+			if owned, ok, ambiguous := ownedAddressRecord(records, recordType, schedule.PublicHost, ip.String(), marker); ambiguous {
+				return errors.New("multiple Meridian DNS records match this site; manual cleanup required")
+			} else if ok {
+				// A previous POST may have succeeded while its response or local
+				// transaction was lost. Adopt the uniquely marked record instead of
+				// creating another record or reporting a permanent untracked error.
+				schedule.cfZoneID, schedule.cfRecordID = zoneID, owned.ID
+			}
+			if schedule.cfRecordID == "" {
+				return errors.New("an untracked exact A/AAAA record already exists; Meridian will not overwrite it")
+			}
 		}
 	}
-	recordID, err := cf.writeAddressRecord(ctx, zoneID, schedule.cfRecordID, recordType, schedule.PublicHost, ip.String())
+	marker := fmt.Sprintf("Meridian site=%d", schedule.SiteID)
+	recordID, err := cf.writeAddressRecord(ctx, zoneID, schedule.cfRecordID, recordType, schedule.PublicHost, ip.String(), marker)
+	if err != nil && schedule.cfRecordID == "" {
+		// POST is not safely retryable: the remote side may have created the
+		// record even when the response was lost. Re-read exact records and
+		// adopt only a uniquely matching Meridian marker.
+		if records, getErr := cf.exactAddressRecords(ctx, zoneID, schedule.PublicHost); getErr == nil {
+			if owned, ok, ambiguous := ownedAddressRecord(records, recordType, schedule.PublicHost, ip.String(), marker); ambiguous {
+				return errors.New("multiple Meridian DNS records match this site; manual cleanup required")
+			} else if ok {
+				recordID, err = owned.ID, nil
+			}
+		}
+	}
 	if err != nil && schedule.cfRecordID != "" && isCloudflareRecordNotFoundError(err) {
 		// A tracked record may have been removed outside Meridian. Re-resolve
 		// the zone and recreate only when the exact name is still unoccupied;
@@ -1498,7 +1565,7 @@ func (a *App) reconcileOneSiteSchedule(ctx context.Context, schedule SiteNodeSch
 			}
 		}
 		if err == nil {
-			recordID, err = cf.writeAddressRecord(ctx, zoneID, "", recordType, schedule.PublicHost, ip.String())
+			recordID, err = cf.writeAddressRecord(ctx, zoneID, "", recordType, schedule.PublicHost, ip.String(), marker)
 		}
 	}
 	if err != nil {
@@ -1570,6 +1637,14 @@ func upsertSiteNodeDrainTx(tx *sql.Tx, siteID, nodeID int64, publicHost string, 
 }
 
 func (a *App) reconcileSiteNodeScheduling(ctx context.Context) {
+	if a == nil {
+		return
+	}
+	// A scheduler round is single-flight. This keeps the bounded worker pool
+	// from ever reconciling the same site in two overlapping rounds when an
+	// embedder invokes the scheduler manually while the ticker is active.
+	a.nodeSchedulerMu.Lock()
+	defer a.nodeSchedulerMu.Unlock()
 	now := time.Now()
 	if _, err := a.db.db.Exec("DELETE FROM site_node_drains WHERE acked_at_ms>0 AND finalization_expires_at_ms>0 AND finalization_expires_at_ms<=?", now.UnixMilli()); err != nil {
 		log.Printf("[node-scheduler] expire node drains: %v", err)
@@ -1599,43 +1674,95 @@ func (a *App) reconcileSiteNodeScheduling(ctx context.Context) {
 		log.Printf("[node-scheduler] list site schedules failed: %v", err)
 		return
 	}
+	type job struct {
+		value   SiteNodeSchedule
+		cleanup bool
+	}
+	type outcome struct {
+		job job
+		err error
+	}
+	jobs := make([]job, 0, len(values))
 	for _, value := range values {
 		if !value.Enabled && siteNodeScheduleNeedsCleanup(value) {
-			cleanupCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
-			cleanupErr := a.deleteTrackedSiteDNS(cleanupCtx, value)
-			cancel()
-			if cleanupErr != nil {
-				log.Printf("[node-scheduler] cleanup disabled site %d: %v", value.SiteID, cleanupErr)
-				_, _ = a.db.db.Exec("UPDATE site_node_schedules SET dns_status='waiting',last_error=?,updated_at_ms=? WHERE site_id=?", cleanupErr.Error(), now.UnixMilli(), value.SiteID)
+			jobs = append(jobs, job{value: value, cleanup: true})
+		} else if value.Enabled {
+			jobs = append(jobs, job{value: value})
+		}
+	}
+	if len(jobs) == 0 {
+		return
+	}
+	workerCount := nodeSchedulerWorkers
+	if workerCount < 1 {
+		workerCount = 1
+	}
+	if workerCount > len(jobs) {
+		workerCount = len(jobs)
+	}
+	jobCh := make(chan job)
+	outCh := make(chan outcome, len(jobs))
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+	for i := 0; i < workerCount; i++ {
+		go func() {
+			defer workers.Done()
+			for current := range jobCh {
+				workCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+				var workErr error
+				if current.cleanup {
+					workErr = a.deleteTrackedSiteDNS(workCtx, current.value)
+				} else {
+					workErr = a.reconcileOneSiteSchedule(workCtx, current.value, now)
+				}
+				cancel()
+				outCh <- outcome{job: current, err: workErr}
+			}
+		}()
+	}
+	go func() {
+		defer close(jobCh)
+		for _, current := range jobs {
+			select {
+			case jobCh <- current:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	workers.Wait()
+	close(outCh)
+	for result := range outCh {
+		value := result.job.value
+		err := result.err
+		if result.job.cleanup {
+			if err != nil {
+				log.Printf("[node-scheduler] cleanup disabled site %d: %v", value.SiteID, err)
+				_, _ = a.db.db.Exec("UPDATE site_node_schedules SET dns_status='waiting',last_error=?,updated_at_ms=? WHERE site_id=?", err.Error(), now.UnixMilli(), value.SiteID)
 			}
 			continue
 		}
-		if !value.Enabled {
+		if err == nil {
 			continue
 		}
-		probeCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
-		err := a.reconcileOneSiteSchedule(probeCtx, value, now)
-		cancel()
-		if err != nil {
-			log.Printf("[node-scheduler] site %d waiting: %v", value.SiteID, err)
-			var readiness *nodeReadinessError
-			if value.Mode == "global" && value.DesiredNodeID > 0 && errors.As(err, &readiness) {
-				var schedulerMode string
-				if modeErr := a.db.db.QueryRow("SELECT mode FROM node_scheduler_settings WHERE id=1").Scan(&schedulerMode); modeErr == nil && schedulerMode == "auto" {
-					shouldCooldown := readiness.Kind == readinessCertificate || readiness.Kind == readinessListener || readiness.Kind == readinessProbe
-					if readiness.Kind == readinessConfig && value.ConfigPendingSinceMS > 0 {
-						shouldCooldown = now.Sub(time.UnixMilli(value.ConfigPendingSinceMS)) >= 90*time.Second
-					}
-					if shouldCooldown {
-						if cooldownErr := a.db.recordSiteNodeProbeFailure(value.SiteID, value.DesiredNodeID, err, now); cooldownErr != nil {
-							log.Printf("[node-scheduler] record site %d node %d cooldown failed: %v", value.SiteID, value.DesiredNodeID, cooldownErr)
-						}
+		log.Printf("[node-scheduler] site %d waiting: %v", value.SiteID, err)
+		var readiness *nodeReadinessError
+		if value.Mode == "global" && value.DesiredNodeID > 0 && errors.As(err, &readiness) {
+			var schedulerMode string
+			if modeErr := a.db.db.QueryRow("SELECT mode FROM node_scheduler_settings WHERE id=1").Scan(&schedulerMode); modeErr == nil && schedulerMode == "auto" {
+				shouldCooldown := readiness.Kind == readinessCertificate || readiness.Kind == readinessListener || readiness.Kind == readinessProbe
+				if readiness.Kind == readinessConfig && value.ConfigPendingSinceMS > 0 {
+					shouldCooldown = now.Sub(time.UnixMilli(value.ConfigPendingSinceMS)) >= 90*time.Second
+				}
+				if shouldCooldown {
+					if cooldownErr := a.db.recordSiteNodeProbeFailure(value.SiteID, value.DesiredNodeID, err, now); cooldownErr != nil {
+						log.Printf("[node-scheduler] record site %d node %d cooldown failed: %v", value.SiteID, value.DesiredNodeID, cooldownErr)
 					}
 				}
 			}
-			if value.DNSStatus != "waiting" || value.LastError != err.Error() {
-				_, _ = a.db.db.Exec("UPDATE site_node_schedules SET dns_status='waiting',last_error=?,updated_at_ms=? WHERE site_id=?", err.Error(), now.UnixMilli(), value.SiteID)
-			}
+		}
+		if value.DNSStatus != "waiting" || value.LastError != err.Error() {
+			_, _ = a.db.db.Exec("UPDATE site_node_schedules SET dns_status='waiting',last_error=?,updated_at_ms=? WHERE site_id=?", err.Error(), now.UnixMilli(), value.SiteID)
 		}
 	}
 }


### PR DESCRIPTION
## Changes

- Bind Agent config/report/live traffic to a rotating process lease.
- Recover Cloudflare DNS records after ambiguous POST responses using an owned marker.
- Reuse the process-wide dashboard sample for SSE clients.
- Release local traffic locks before SQLite trend reads.
- Reconcile site schedules with a bounded worker pool.

## Validation

- go test ./...
- go test -race ./...
- go vet ./...
- govulncheck ./...
