### PR TITLE
fix: harden scheduler DNS mutations and agent lease takeover (v1.9.84)

### DIFF
--- a/app_sites.go
+++ b/app_sites.go
@@ -487,6 +487,12 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 	case action == "toggle" && r.Method == "POST":
 		a.siteLifecycleMu.Lock()
 		defer a.siteLifecycleMu.Unlock()
+		// Site lifecycle mutations bump schedule_revision and race the
+		// scheduler's Cloudflare side effects; serialize them with the same
+		// per-site lock the scheduler workers use (lock order:
+		// siteLifecycleMu -> siteScheduleLock).
+		unlockSchedule := a.lockSiteSchedule(id)
+		defer unlockSchedule()
 		site, err := a.db.GetSite(id)
 		if err != nil {
 			a.jsonErr(w, 500, err.Error())
@@ -562,6 +568,11 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 	case action == "" && r.Method == "PUT":
 		a.siteLifecycleMu.Lock()
 		defer a.siteLifecycleMu.Unlock()
+		// Serialize with scheduler workers: the update bumps schedule_revision
+		// and may replace the public host the scheduler manages DNS for
+		// (lock order: siteLifecycleMu -> siteScheduleLock).
+		unlockSchedule := a.lockSiteSchedule(id)
+		defer unlockSchedule()
 		oldSite, err := a.db.GetSite(id)
 		if err != nil {
 			a.jsonErr(w, 404, "site not found")
@@ -1036,6 +1047,11 @@ func (a *App) handleSiteByID(w http.ResponseWriter, r *http.Request) {
 	case action == "" && r.Method == "DELETE":
 		a.siteLifecycleMu.Lock()
 		defer a.siteLifecycleMu.Unlock()
+		// removeSiteNodeSchedule serializes the schedule/remote-DNS cleanup
+		// with scheduler workers through its own per-site lock; DeleteSite and
+		// the disable fallback bump schedule_revision so any queued worker job
+		// fails its CAS. Do not take lockSiteSchedule here: the mutex is not
+		// re-entrant and removeSiteNodeSchedule would deadlock.
 		// Only delete after a clean stop. If ingress already closed but drain or
 		// final persistence failed, retain a disabled row as the retry handle.
 		if stopErr := a.pm.StopSite(id); stopErr != nil {

--- a/database_migrations.go
+++ b/database_migrations.go
@@ -20,7 +20,7 @@ const (
 	// databaseSchemaVersion is independent from the application and backup
 	// format versions. It is persisted in SQLite so restores can reject a
 	// database whose columns/state are newer than this binary understands.
-	databaseSchemaVersion = 48
+	databaseSchemaVersion = 49
 )
 
 func (d *DB) migrate() error {
@@ -537,6 +537,7 @@ func (d *DB) migrateOnce() error {
 		{"agent_apply_error_at_ms", "ALTER TABLE control_nodes ADD COLUMN agent_apply_error_at_ms INTEGER NOT NULL DEFAULT 0"},
 		{"agent_apply_failures", "ALTER TABLE control_nodes ADD COLUMN agent_apply_failures BIGINT NOT NULL DEFAULT 0"},
 		{"agent_listener_error", "ALTER TABLE control_nodes ADD COLUMN agent_listener_error TEXT NOT NULL DEFAULT ''"},
+		{"agent_lease_expires_at_ms", "ALTER TABLE control_nodes ADD COLUMN agent_lease_expires_at_ms INTEGER NOT NULL DEFAULT 0"},
 	} {
 		var found int
 		if err := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM pragma_table_info('control_nodes') WHERE name=?", migration.column).Scan(&found); err != nil {

--- a/edge_agent.go
+++ b/edge_agent.go
@@ -2312,41 +2312,8 @@ func edgeEnroll(ctx context.Context, client *http.Client, controller, tokenFile,
 	return state, nil
 }
 
-func edgeDefaultInterface() string {
-	file, err := os.Open("/proc/net/route")
-	if err == nil {
-		defer file.Close()
-		scanner := bufio.NewScanner(file)
-		_ = scanner.Scan()
-		for scanner.Scan() {
-			fields := strings.Fields(scanner.Text())
-			if len(fields) >= 4 && fields[1] == "00000000" {
-				flags, parseErr := strconv.ParseUint(fields[3], 16, 32)
-				if parseErr == nil && flags&2 != 0 {
-					return fields[0]
-				}
-			}
-		}
-	}
-	interfaces, _ := net.Interfaces()
-	for _, candidate := range interfaces {
-		if candidate.Flags&net.FlagUp != 0 && candidate.Flags&net.FlagLoopback == 0 {
-			return candidate.Name
-		}
-	}
-	return ""
-}
-
-func edgeCounter(interfaceName, name string) (int64, error) {
-	if name != "rx_bytes" && name != "tx_bytes" {
-		return 0, errors.New("invalid counter")
-	}
-	data, err := os.ReadFile(filepath.Join("/sys/class/net", interfaceName, "statistics", name)) // #nosec G304 -- interface is discovered from the kernel route table.
-	if err != nil {
-		return 0, err
-	}
-	return strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
-}
+// edgeDefaultInterface, edgeCounter and edgeCounterEpoch are platform-specific
+// and live in edge_agent_counters_unix.go / edge_agent_counters_windows.go.
 
 func edgeBootID() string {
 	random := make([]byte, 8)
@@ -2356,14 +2323,6 @@ func edgeBootID() string {
 		prefix = strings.TrimSpace(string(data)) + ":"
 	}
 	return prefix + hex.EncodeToString(random)
-}
-
-func edgeCounterEpoch(interfaceName string) string {
-	kernelBootID := "unknown"
-	if data, err := os.ReadFile("/proc/sys/kernel/random/boot_id"); err == nil {
-		kernelBootID = strings.TrimSpace(string(data))
-	}
-	return kernelBootID + ":" + interfaceName
 }
 
 func edgeCollect(sessionID string, sequence int64) (NodeReport, error) {
@@ -2749,6 +2708,9 @@ func runEdgeAgent() error {
 	const agentApplyRetryMax = 60 * time.Second
 	const agentStaleRecoveryBase = 30 * time.Second
 	const agentStaleRecoveryMax = 5 * time.Minute
+	// agentQuiescedPollInterval bounds the supervisor loop's sleep while the
+	// runtime is quiesced, keeping the CPU idle between retry attempts.
+	const agentQuiescedPollInterval = 2 * time.Second
 	lastConfigAt := time.Time{}
 	lastUpdateAttempt := time.Time{}
 	nextApplyAttempt := time.Time{}
@@ -2882,6 +2844,21 @@ func runEdgeAgent() error {
 			}
 		}
 		if runtime.isQuiesced() {
+			if *once {
+				return nil
+			}
+			// A quiesced runtime has nothing to report or apply. Sleep instead
+			// of spinning: the next fetch/apply attempt is gated by
+			// lastConfigAt/nextApplyAttempt and stale recovery waits on
+			// staleRecoveryAt, so a failing controller or a failing apply must
+			// not burn a CPU core while those timers run out.
+			timer := time.NewTimer(agentQuiescedPollInterval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil
+			case <-timer.C:
+			}
 			continue
 		}
 		refreshImmediately := false

--- a/edge_agent_counters_unix.go
+++ b/edge_agent_counters_unix.go
@@ -1,0 +1,62 @@
+//go:build !windows
+
+package main
+
+import (
+	"bufio"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// edgeDefaultInterface discovers the interface carrying the default route via
+// the kernel route table and falls back to the first up non-loopback adapter.
+func edgeDefaultInterface() string {
+	file, err := os.Open("/proc/net/route")
+	if err == nil {
+		defer file.Close()
+		scanner := bufio.NewScanner(file)
+		_ = scanner.Scan()
+		for scanner.Scan() {
+			fields := strings.Fields(scanner.Text())
+			if len(fields) >= 4 && fields[1] == "00000000" {
+				flags, parseErr := strconv.ParseUint(fields[3], 16, 32)
+				if parseErr == nil && flags&2 != 0 {
+					return fields[0]
+				}
+			}
+		}
+	}
+	interfaces, _ := net.Interfaces()
+	for _, candidate := range interfaces {
+		if candidate.Flags&net.FlagUp != 0 && candidate.Flags&net.FlagLoopback == 0 {
+			return candidate.Name
+		}
+	}
+	return ""
+}
+
+// edgeCounter reads a sysfs statistics counter for the discovered interface.
+func edgeCounter(interfaceName, name string) (int64, error) {
+	if name != "rx_bytes" && name != "tx_bytes" {
+		return 0, errors.New("invalid counter")
+	}
+	data, err := os.ReadFile(filepath.Join("/sys/class/net", interfaceName, "statistics", name)) // #nosec G304 -- interface is discovered from the kernel route table.
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+}
+
+// edgeCounterEpoch binds the cumulative counters to the kernel boot so the
+// Controller can detect a counter reset after a reboot.
+func edgeCounterEpoch(interfaceName string) string {
+	kernelBootID := "unknown"
+	if data, err := os.ReadFile("/proc/sys/kernel/random/boot_id"); err == nil {
+		kernelBootID = strings.TrimSpace(string(data))
+	}
+	return kernelBootID + ":" + interfaceName
+}

--- a/edge_agent_counters_windows.go
+++ b/edge_agent_counters_windows.go
@@ -1,0 +1,90 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"math"
+	"strconv"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// windowsIfTypeLoopback is IF_TYPE_SOFTWARE_LOOPBACK from the IANA ifType
+// registry; x/sys does not export the named constant.
+const windowsIfTypeLoopback = 24
+
+var kernel32 = syscall.NewLazyDLL("kernel32.dll")
+var procGetTickCount64 = kernel32.NewProc("GetTickCount64")
+
+// bootTickMilliseconds returns milliseconds since boot via GetTickCount64,
+// which x/sys does not wrap. The value resets at boot, giving the Controller
+// the same counter reset signal the Linux boot_id provides.
+func bootTickMilliseconds() uint64 {
+	tick, _, _ := procGetTickCount64.Call()
+	return uint64(tick)
+}
+
+// edgeWindowsInterfaceName identifies the aggregate of every non-loopback
+// interface. Windows exposes per-adapter byte counters only through the IP
+// Helper API and adapters are renamed freely, so the Agent reports one summed
+// counter instead of chasing the default-route adapter.
+const edgeWindowsInterfaceName = "windows-aggregate"
+
+// edgeDefaultInterface returns the synthetic aggregate identity; see
+// edgeWindowsInterfaceName.
+func edgeDefaultInterface() string {
+	return edgeWindowsInterfaceName
+}
+
+// edgeCounter returns the summed rx/tx octets of every up non-loopback
+// interface via the IP Helper API, replacing the Linux-only sysfs source.
+func edgeCounter(interfaceName, name string) (int64, error) {
+	if interfaceName != edgeWindowsInterfaceName {
+		return 0, errors.New("unknown interface")
+	}
+	switch name {
+	case "rx_bytes", "tx_bytes":
+	default:
+		return 0, errors.New("invalid counter")
+	}
+	var table *windows.MibIfTable2
+	if err := windows.GetIfTable2Ex(windows.MibIfTableNormal, &table); err != nil {
+		return 0, err
+	}
+	defer windows.FreeMibTable(unsafe.Pointer(table)) // #nosec G103 -- table is allocated by GetIfTable2Ex with this exact element type.
+	rows := unsafe.Slice(&table.Table[0], table.NumEntries)
+	var rx, tx int64
+	for i := range rows {
+		row := &rows[i]
+		if row.Type == windowsIfTypeLoopback || row.OperStatus != uint32(windows.IfOperStatusUp) {
+			continue
+		}
+		rx += trafficOctetsToBytes(row.InOctets)
+		tx += trafficOctetsToBytes(row.OutOctets)
+	}
+	if name == "rx_bytes" {
+		return rx, nil
+	}
+	return tx, nil
+}
+
+// trafficOctetsToBytes converts an unsigned interface octet counter into the
+// signed byte accounting used by reports, clamping at the int64 maximum. A
+// 64-bit NIC counter only reaches that bound after 8 exabytes, far past any
+// reset window, but the conversion must not be allowed to wrap negative.
+func trafficOctetsToBytes(value uint64) int64 {
+	if value > uint64(math.MaxInt64) {
+		return math.MaxInt64
+	}
+	return int64(value)
+}
+
+// edgeCounterEpoch binds the cumulative counters to the Windows boot session,
+// giving the Controller the same counter reset signal the Linux boot_id
+// provides.
+func edgeCounterEpoch(interfaceName string) string {
+	return strconv.FormatUint(bootTickMilliseconds(), 10) + ":" + interfaceName
+}

--- a/edge_agent_counters_windows_test.go
+++ b/edge_agent_counters_windows_test.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package main
+
+import (
+	"testing"
+)
+
+// TestEdgeCounterWindowsAggregate exercises the real IP Helper API path so a
+// struct layout or API regression fails on a Windows host instead of silently
+// disabling Agent traffic reporting.
+func TestEdgeCounterWindowsAggregate(t *testing.T) {
+	if edgeDefaultInterface() != edgeWindowsInterfaceName {
+		t.Fatalf("edgeDefaultInterface() = %q, want %q", edgeDefaultInterface(), edgeWindowsInterfaceName)
+	}
+	rx, err := edgeCounter(edgeWindowsInterfaceName, "rx_bytes")
+	if err != nil {
+		t.Fatalf("edgeCounter(rx_bytes) failed: %v", err)
+	}
+	tx, err := edgeCounter(edgeWindowsInterfaceName, "tx_bytes")
+	if err != nil {
+		t.Fatalf("edgeCounter(tx_bytes) failed: %v", err)
+	}
+	if rx < 0 || tx < 0 {
+		t.Fatalf("negative counters: rx=%d tx=%d", rx, tx)
+	}
+	if _, err := edgeCounter("eth0", "rx_bytes"); err == nil {
+		t.Fatalf("edgeCounter with a non-aggregate interface must fail")
+	}
+	if _, err := edgeCounter(edgeWindowsInterfaceName, "packets"); err == nil {
+		t.Fatalf("edgeCounter with an invalid counter name must fail")
+	}
+	epoch := edgeCounterEpoch(edgeWindowsInterfaceName)
+	if epoch == "" || epoch == "unknown:"+edgeWindowsInterfaceName {
+		t.Fatalf("edgeCounterEpoch = %q, want a boot-tick based epoch", epoch)
+	}
+}

--- a/hardening_regression_test.go
+++ b/hardening_regression_test.go
@@ -1,7 +1,14 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -127,5 +134,197 @@ func TestStaleDisabledCleanupCannotPublishRevocation(t *testing.T) {
 	}
 	if revocations != 0 || enabled != 1 {
 		t.Fatalf("stale cleanup changed replacement generation: revocations=%d enabled=%d", revocations, enabled)
+	}
+}
+
+func TestClaimAgentLeaseTTLTakeover(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now()
+	node, _, err := app.db.CreateControlNode(NodeCreateInput{Name: "lease-node", Address: "203.0.113.91", Port: 9090}, now)
+	if err != nil {
+		t.Fatalf("create node: %v", err)
+	}
+	claim := func(sessionID string, epoch int64, at time.Time) (string, error) {
+		tx, err := app.db.db.Begin()
+		if err != nil {
+			t.Fatalf("begin: %v", err)
+		}
+		defer tx.Rollback()
+		lease, err := claimAgentLeaseTx(tx, node.ID, sessionID, epoch, at)
+		if err != nil {
+			return "", err
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatalf("commit: %v", err)
+		}
+		return lease, nil
+	}
+	leaseA, err := claim("session-a", 100, now)
+	if err != nil || leaseA == "" {
+		t.Fatalf("first claim: lease=%q err=%v", leaseA, err)
+	}
+	leaseB, err := claim("session-b", 101, now.Add(5*time.Second))
+	if err != nil || leaseB == "" || leaseB == leaseA {
+		t.Fatalf("newer epoch must rotate the lease: lease=%q err=%v", leaseB, err)
+	}
+	if _, err := claim("session-a", 100, now.Add(6*time.Second)); !errors.Is(err, errStaleAgentSession) {
+		t.Fatalf("older epoch against a fresh lease must stay stale, err=%v", err)
+	}
+	renewed, err := claim("session-b", 101, now.Add(7*time.Second))
+	if err != nil || renewed != leaseB {
+		t.Fatalf("same session must renew without rotating: lease=%q err=%v", renewed, err)
+	}
+	// Expire the active lease: the previously superseded session must now be
+	// able to take the node over instead of waiting for a process restart.
+	if _, err := app.db.db.Exec("UPDATE control_nodes SET agent_lease_expires_at_ms=? WHERE id=?", now.Add(10*time.Second).UnixMilli(), node.ID); err != nil {
+		t.Fatalf("expire lease: %v", err)
+	}
+	takeoverAt := now.Add(20 * time.Second)
+	leaseA2, err := claim("session-a", 100, takeoverAt)
+	if err != nil || leaseA2 == "" || leaseA2 == leaseA {
+		t.Fatalf("expired lease must allow takeover: lease=%q err=%v", leaseA2, err)
+	}
+	var activeSession string
+	var activeEpoch, expiryMS int64
+	if err := app.db.db.QueryRow("SELECT active_agent_session_id,agent_session_epoch,agent_lease_expires_at_ms FROM control_nodes WHERE id=?", node.ID).Scan(&activeSession, &activeEpoch, &expiryMS); err != nil {
+		t.Fatal(err)
+	}
+	if activeSession != "session-a" || activeEpoch != 100 {
+		t.Fatalf("takeover identity session=%q epoch=%d, want session-a/100", activeSession, activeEpoch)
+	}
+	if expiryMS != takeoverAt.Add(agentLeaseTTL).UnixMilli() {
+		t.Fatalf("takeover expiry=%d, want %d", expiryMS, takeoverAt.Add(agentLeaseTTL).UnixMilli())
+	}
+	// A lower-epoch session (another stale clone) stays fenced by the fresh
+	// lease; a higher epoch may still take over by the newer-session rule.
+	if _, err := claim("session-c", 99, takeoverAt.Add(time.Second)); !errors.Is(err, errStaleAgentSession) {
+		t.Fatalf("lower-epoch clone must stay fenced after takeover, err=%v", err)
+	}
+}
+
+func TestNodeSchedulerWorkerSkipsSupersededJobs(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now()
+	site, err := app.db.CreateSiteRecord(Site{Name: "stale-job-site", PublicHost: "stale-job.example.test", IngressMode: ingressModeHost, TargetURL: "http://127.0.0.1:8096"})
+	if err != nil {
+		t.Fatalf("create site: %v", err)
+	}
+	if _, err := app.db.SaveSiteNodeSchedule(site.ID, false, "global", 0, now); err != nil {
+		t.Fatalf("create disabled schedule: %v", err)
+	}
+	if _, err := app.db.db.Exec(`UPDATE site_node_schedules SET cf_zone_id='zone-1',cf_record_id='rec-1',cf_record_type='A',applied_address='203.0.113.9' WHERE site_id=?`, site.ID); err != nil {
+		t.Fatalf("track DNS handle: %v", err)
+	}
+	current, err := app.db.siteNodeSchedule(site.ID)
+	if err != nil {
+		t.Fatalf("load schedule: %v", err)
+	}
+	queue := &nodeSchedulerQueue{jobs: make(chan nodeSchedulerJob, 4), inFlight: map[int64]struct{}{}}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// A job captured before the latest generation must not touch the site at
+	// all: no Cloudflare client attempt, no outcome write, no revision bump.
+	stale := current
+	stale.ScheduleRevision--
+	app.runNodeSchedulerJob(ctx, queue, nodeSchedulerJob{value: stale, cleanup: true, now: now})
+	afterStale, err := app.db.siteNodeSchedule(site.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterStale.ScheduleRevision != current.ScheduleRevision || afterStale.LastError != "" || afterStale.cfRecordID != "rec-1" {
+		t.Fatalf("stale job mutated the schedule: revision=%d error=%q record=%q", afterStale.ScheduleRevision, afterStale.LastError, afterStale.cfRecordID)
+	}
+
+	// A current job must proceed past re-validation into the Cloudflare path,
+	// which fails in a bare test app before any remote side effect.
+	app.runNodeSchedulerJob(ctx, queue, nodeSchedulerJob{value: current, cleanup: true, now: now})
+	afterFresh, err := app.db.siteNodeSchedule(site.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterFresh.LastError == "" {
+		t.Fatal("current cleanup job did not reach the Cloudflare path")
+	}
+}
+
+func TestDeleteTrackedSiteDNSRemoteVerifiesOwnership(t *testing.T) {
+	recordJSON := func(id, recordType, name, content, comment string) string {
+		return `{"success":true,"result":{"id":"` + id + `","type":"` + recordType + `","name":"` + name + `","content":"` + content + `","comment":"` + comment + `"}}`
+	}
+	schedule := SiteNodeSchedule{SiteID: 7, PublicHost: "site.example", cfZoneID: "zone-1", cfRecordID: "rec-1"}
+	cases := []struct {
+		name       string
+		body       string
+		status     int
+		wantErr    string
+		wantDelete bool
+	}{
+		{name: "owned record is deleted", body: recordJSON("rec-1", "A", "site.example", "203.0.113.5", "Meridian site=7"), status: http.StatusOK, wantDelete: true},
+		{name: "operator-edited comment refuses delete", body: recordJSON("rec-1", "A", "site.example", "203.0.113.5", ""), status: http.StatusOK, wantErr: "refusing to delete"},
+		{name: "renamed record refuses delete", body: recordJSON("rec-1", "A", "other.example", "203.0.113.5", "Meridian site=7"), status: http.StatusOK, wantErr: "refusing to delete"},
+		{name: "wrong family refuses delete", body: recordJSON("rec-1", "CNAME", "site.example", "target.example", "Meridian site=7"), status: http.StatusOK, wantErr: "refusing to delete"},
+		{name: "missing record stays idempotent", body: `{"success":false,"errors":[{"code":81044,"message":"record does not exist"}]}`, status: http.StatusNotFound, wantDelete: true},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var sawDelete bool
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodDelete {
+					sawDelete = true
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(testCase.status)
+				_, _ = w.Write([]byte(testCase.body))
+			}))
+			defer server.Close()
+			cf := &cloudflareClient{token: "test", httpClient: server.Client(), apiBase: server.URL}
+			err := deleteTrackedSiteDNSRemote(context.Background(), cf, schedule)
+			if testCase.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), testCase.wantErr) {
+					t.Fatalf("err=%v, want containing %q", err, testCase.wantErr)
+				}
+				if sawDelete {
+					t.Fatal("delete must not run for a record that lost ownership")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("deleteTrackedSiteDNSRemote: %v", err)
+			}
+			if sawDelete != testCase.wantDelete {
+				t.Fatalf("delete ran=%v, want %v", sawDelete, testCase.wantDelete)
+			}
+		})
+	}
+}
+
+func TestRecreateReplacedDNSRecordRestoresPreimage(t *testing.T) {
+	var payload struct {
+		Type    string `json:"type"`
+		Name    string `json:"name"`
+		Content string `json:"content"`
+		Comment string `json:"comment"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/dns_records") {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Errorf("decode create payload: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"result":{"id":"restored"}}`))
+	}))
+	defer server.Close()
+	cf := &cloudflareClient{token: "test", httpClient: server.Client(), apiBase: server.URL}
+	previous := cloudflareAddressRecord{ID: "old", Type: "A", Name: "site.example", Content: "203.0.113.5", Comment: "Meridian site=7"}
+	if err := recreateReplacedDNSRecordBestEffort(context.Background(), cf, "zone-1", previous); err != nil {
+		t.Fatalf("recreate: %v", err)
+	}
+	if payload.Type != "A" || payload.Name != "site.example" || payload.Content != "203.0.113.5" || payload.Comment != "Meridian site=7" {
+		t.Fatalf("restore payload=%+v, want the deleted record preimage", payload)
 	}
 }

--- a/node_repository.go
+++ b/node_repository.go
@@ -1542,10 +1542,20 @@ func appendNodeEventIdentity(ids *[]int64, uids *[]string, event NodeRequestEven
 	}
 }
 
+// agentLeaseTTL is how long a claimed Agent lease stays valid without a
+// renewal. Agents report every five seconds and renew on every accepted report
+// and config fetch, so a healthy lease never lapses; a lapsed lease means the
+// owning Agent stopped reporting and may be taken over by another session.
+const agentLeaseTTL = 90 * time.Second
+
 // claimAgentLeaseTx binds a process session to the node before the first
 // report is accepted. A newer session epoch rotates the lease; an older
-// session can no longer overwrite state after a restart or failover.
-func claimAgentLeaseTx(tx *sql.Tx, nodeID int64, sessionID string, sessionEpoch int64) (string, error) {
+// session can no longer overwrite state after a restart or failover. A lease
+// whose TTL lapsed proves the owning Agent stopped reporting, so another
+// enrolled session may take the node over: the takeover rotates the lease and
+// stamps a fresh expiry, and the superseded session can only reclaim after the
+// new lease itself expires.
+func claimAgentLeaseTx(tx *sql.Tx, nodeID int64, sessionID string, sessionEpoch int64, now time.Time) (string, error) {
 	sessionID = strings.TrimSpace(sessionID)
 	if sessionID == "" || sessionEpoch <= 0 {
 		var lease string
@@ -1555,23 +1565,34 @@ func claimAgentLeaseTx(tx *sql.Tx, nodeID int64, sessionID string, sessionEpoch 
 		return strings.TrimSpace(lease), nil
 	}
 	var activeSession, lease string
-	var activeEpoch int64
-	if err := tx.QueryRow("SELECT active_agent_session_id,agent_session_epoch,agent_lease_id FROM control_nodes WHERE id=?", nodeID).Scan(&activeSession, &activeEpoch, &lease); err != nil {
+	var activeEpoch, activeExpiryMS int64
+	if err := tx.QueryRow("SELECT active_agent_session_id,agent_session_epoch,agent_lease_id,agent_lease_expires_at_ms FROM control_nodes WHERE id=?", nodeID).Scan(&activeSession, &activeEpoch, &lease, &activeExpiryMS); err != nil {
 		return "", err
 	}
 	activeSession = strings.TrimSpace(activeSession)
 	lease = strings.TrimSpace(lease)
+	nowMS := now.UnixMilli()
+	expiresMS := now.Add(agentLeaseTTL).UnixMilli()
 	if activeSession == sessionID && activeEpoch == sessionEpoch && lease != "" {
+		// Same session reclaiming through the config path: renew the window.
+		if _, err := tx.Exec("UPDATE control_nodes SET agent_lease_expires_at_ms=?,updated_at_ms=? WHERE id=?", expiresMS, nowMS, nodeID); err != nil {
+			return "", err
+		}
 		return lease, nil
 	}
-	if activeSession != "" && sessionEpoch <= activeEpoch {
+	leaseExpired := activeSession != "" && activeExpiryMS > 0 && nowMS > activeExpiryMS
+	if activeSession != "" && !leaseExpired && sessionEpoch <= activeEpoch {
 		return "", errStaleAgentSession
 	}
 	newLease, err := newNodeToken()
 	if err != nil {
 		return "", err
 	}
-	if _, err := tx.Exec("UPDATE control_nodes SET active_agent_session_id=?,agent_session_epoch=?,agent_lease_id=?,updated_at_ms=? WHERE id=?", sessionID, sessionEpoch, newLease, time.Now().UnixMilli(), nodeID); err != nil {
+	// The claiming session keeps its own epoch so its subsequent reports keep
+	// matching the stored (session, epoch, lease) triple. Fencing against the
+	// superseded owner is preserved by the rotated lease ID: the old lease can
+	// never validate again, and reclaiming it requires the new lease to expire.
+	if _, err := tx.Exec("UPDATE control_nodes SET active_agent_session_id=?,agent_session_epoch=?,agent_lease_id=?,agent_lease_expires_at_ms=?,updated_at_ms=? WHERE id=?", sessionID, sessionEpoch, newLease, expiresMS, nowMS, nodeID); err != nil {
 		return "", err
 	}
 	return newLease, nil
@@ -1725,12 +1746,12 @@ func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now ti
 	}
 	if _, err = tx.Exec(`UPDATE control_nodes SET period_rx_bytes=period_rx_bytes+?,period_tx_bytes=period_tx_bytes+?,
 			lifetime_rx_bytes=lifetime_rx_bytes+?,lifetime_tx_bytes=lifetime_tx_bytes+?,last_raw_rx_bytes=?,last_raw_tx_bytes=?,
-			last_boot_id=?,last_report_session_id=?,last_sequence=?,interface_name=?,agent_version=?,applied_config_hash=?,applied_config_revision=?,agent_apply_error=?,agent_apply_error_at_ms=?,agent_apply_failures=?,agent_listener_error=?,event_spool_error=?,event_queue_depth=?,event_dropped=?,config_dirty=CASE WHEN ? THEN 0 ELSE config_dirty END,cache_clear_applied_generation=CASE WHEN ? > cache_clear_applied_generation AND ? <= ? THEN ? ELSE cache_clear_applied_generation END,last_seen_at_ms=?,updated_at_ms=? WHERE id=?`,
+			last_boot_id=?,last_report_session_id=?,last_sequence=?,interface_name=?,agent_version=?,applied_config_hash=?,applied_config_revision=?,agent_apply_error=?,agent_apply_error_at_ms=?,agent_apply_failures=?,agent_listener_error=?,event_spool_error=?,event_queue_depth=?,event_dropped=?,config_dirty=CASE WHEN ? THEN 0 ELSE config_dirty END,cache_clear_applied_generation=CASE WHEN ? > cache_clear_applied_generation AND ? <= ? THEN ? ELSE cache_clear_applied_generation END,agent_lease_expires_at_ms=?,last_seen_at_ms=?,updated_at_ms=? WHERE id=?`,
 		deltaRX, deltaTX, deltaRX, deltaTX, report.RXBytes, report.TXBytes, counterEpoch, sessionID, report.Sequence,
 		strings.TrimSpace(report.InterfaceName), strings.TrimSpace(report.AgentVersion), appliedHash, report.AppliedConfigRevision, applyError, applyErrorAtMS, applyFailures, strings.TrimSpace(report.ListenerError), strings.TrimSpace(report.EventSpoolError), report.EventQueueDepth, report.EventDropped,
 		clearAppliedConfig,
 		report.CacheClearGeneration, report.CacheClearGeneration, cacheClearGeneration, report.CacheClearGeneration,
-		now.UnixMilli(), now.UnixMilli(), id); err != nil {
+		now.Add(agentLeaseTTL).UnixMilli(), now.UnixMilli(), now.UnixMilli(), id); err != nil {
 		return nodeReportCommitResult{}, err
 	}
 	// A cold-started Agent may report before it has successfully applied the

--- a/proxy_manager.go
+++ b/proxy_manager.go
@@ -49,6 +49,10 @@ type ProxyInstance struct {
 	reqCount                  atomic.Int64
 	pendingRequests           atomic.Int64
 	persistedTraffic          atomic.Int64
+	// trafficGeneration backs the flush-generation fallback for controller
+	// local instances (no Agent runtime counter). The dashboard trend snapshot
+	// uses it to detect a flush that raced its SQLite history read.
+	trafficGeneration         atomic.Uint64
 	trafficCycleStart         time.Time
 	trafficCycleMode          string
 	trafficCycleUsage         int64
@@ -130,10 +134,16 @@ func (inst *ProxyInstance) trafficPendingRequests() *atomic.Int64 {
 }
 
 func (inst *ProxyInstance) trafficFlushGeneration() *atomic.Uint64 {
-	if inst != nil && inst.trafficCounter != nil {
+	if inst == nil {
+		return nil
+	}
+	if inst.trafficCounter != nil {
 		return &inst.trafficCounter.flushGeneration
 	}
-	return nil
+	// Controller-local instances track the flush generation inline so the
+	// trend snapshot's retry logic also covers sites without an Agent
+	// runtime counter.
+	return &inst.trafficGeneration
 }
 
 type ProxyManager struct {

--- a/site_node_scheduler.go
+++ b/site_node_scheduler.go
@@ -86,20 +86,55 @@ func (a *App) runNodeSchedulerWorker(ctx context.Context, queue *nodeSchedulerQu
 		case <-ctx.Done():
 			return
 		case job := <-queue.jobs:
-			workCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
-			var err error
-			if job.cleanup {
-				err = a.deleteTrackedSiteDNS(workCtx, job.value)
-			} else {
-				err = a.reconcileOneSiteSchedule(workCtx, job.value, job.now)
-			}
-			cancel()
-			a.processNodeSchedulerOutcome(job, err)
-			queue.mu.Lock()
-			delete(queue.inFlight, job.value.SiteID)
-			queue.mu.Unlock()
+			a.runNodeSchedulerJob(ctx, queue, job)
 		}
 	}
+}
+
+// runNodeSchedulerJob executes one dequeued job. The schedule is re-read under
+// the site lock so a queued job can never act on a superseded generation: any
+// Cloudflare side effect must be validated against the current revision before
+// it happens. A panic in one job is contained to that job and reported as a
+// failure outcome instead of taking down the whole controller.
+func (a *App) runNodeSchedulerJob(ctx context.Context, queue *nodeSchedulerQueue, job nodeSchedulerJob) {
+	workCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	err := func() (jobErr error) {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				jobErr = fmt.Errorf("scheduler job panicked: %v", recovered)
+			}
+		}()
+		unlockSite := a.lockSiteSchedule(job.value.SiteID)
+		defer unlockSite()
+		current, loadErr := a.db.siteNodeSchedule(job.value.SiteID)
+		if errors.Is(loadErr, errNodeNotFound) {
+			// The site is gone; there is nothing left to reconcile or clean up.
+			return nil
+		}
+		if loadErr != nil {
+			return loadErr
+		}
+		if current.ScheduleRevision != job.value.ScheduleRevision {
+			// A newer generation replaced this queued job; the next tick
+			// schedules work for the current revision.
+			return nil
+		}
+		if job.cleanup {
+			if current.Enabled || !siteNodeScheduleNeedsCleanup(current) {
+				return nil
+			}
+			return a.deleteTrackedSiteDNSLocked(workCtx, current)
+		}
+		if !current.Enabled {
+			return nil
+		}
+		return a.reconcileOneSiteScheduleLocked(workCtx, current, time.Now())
+	}()
+	cancel()
+	a.processNodeSchedulerOutcome(job, err)
+	queue.mu.Lock()
+	delete(queue.inFlight, job.value.SiteID)
+	queue.mu.Unlock()
 }
 
 func (a *App) enqueueNodeSchedulerJob(queue *nodeSchedulerQueue, job nodeSchedulerJob) bool {
@@ -1011,7 +1046,7 @@ func (a *App) buildAgentConfigForRequest(ctx context.Context, token string, now 
 	if len(requestedSession) > 0 {
 		session = requestedSession[0]
 	}
-	leaseID, err := claimAgentLeaseTx(tx, node.ID, session.ID, session.Epoch)
+	leaseID, err := claimAgentLeaseTx(tx, node.ID, session.ID, session.Epoch, now)
 	if err != nil {
 		return AgentRuntimeConfig{}, err
 	}
@@ -1333,6 +1368,24 @@ func (a *App) cloudflareForScheduling() (*cloudflareClient, error) {
 
 type cloudflareAddressRecord struct{ ID, Type, Name, Content, Comment string }
 
+func (c *cloudflareClient) dnsRecordByID(ctx context.Context, zoneID, recordID string) (cloudflareAddressRecord, error) {
+	result, err := c.request(ctx, http.MethodGet, "/zones/"+url.PathEscape(zoneID)+"/dns_records/"+url.PathEscape(recordID), nil)
+	if err != nil {
+		return cloudflareAddressRecord{}, err
+	}
+	var raw struct {
+		ID      string `json:"id"`
+		Type    string `json:"type"`
+		Name    string `json:"name"`
+		Content string `json:"content"`
+		Comment string `json:"comment"`
+	}
+	if err := json.Unmarshal(result, &raw); err != nil {
+		return cloudflareAddressRecord{}, errors.New("Cloudflare DNS returned an invalid record")
+	}
+	return cloudflareAddressRecord{ID: raw.ID, Type: raw.Type, Name: raw.Name, Content: raw.Content, Comment: raw.Comment}, nil
+}
+
 func (c *cloudflareClient) exactAddressRecords(ctx context.Context, zoneID, name string) ([]cloudflareAddressRecord, error) {
 	result, err := c.request(ctx, http.MethodGet, "/zones/"+url.PathEscape(zoneID)+"/dns_records?name="+url.QueryEscape(name)+"&per_page=100", nil)
 	if err != nil {
@@ -1397,6 +1450,13 @@ func ownedAddressRecord(records []cloudflareAddressRecord, recordType, name, add
 // content may legitimately differ after a node move and is reconciled by the
 // caller. Any unowned exact record is a hard conflict because Cloudflare would
 // otherwise round-robin traffic between an operator record and Meridian's.
+// siteDNSOwnershipMarker is the Cloudflare comment that marks an address
+// record as owned by this Meridian instance for one site. Create, adopt,
+// update and delete paths must all verify against this exact value.
+func siteDNSOwnershipMarker(siteID int64) string {
+	return fmt.Sprintf("Meridian site=%d", siteID)
+}
+
 func classifyOwnedAddressRecords(records []cloudflareAddressRecord, name, marker string) (cloudflareAddressRecord, bool, int, bool) {
 	var owned cloudflareAddressRecord
 	ownedCount := 0
@@ -1565,8 +1625,33 @@ func deleteTrackedSiteDNSRemote(ctx context.Context, cf *cloudflareClient, sched
 	if schedule.cfZoneID == "" {
 		return errors.New("tracked DNS zone is missing")
 	}
+	if err := verifyTrackedSiteDNSOwnership(ctx, cf, schedule); err != nil {
+		return err
+	}
 	if err := cf.deleteRecord(ctx, schedule.cfZoneID, schedule.cfRecordID); err != nil && !isCloudflareRecordNotFoundError(err) {
 		return err
+	}
+	return nil
+}
+
+// verifyTrackedSiteDNSOwnership re-reads the tracked record before the
+// destructive delete. Only a record that still carries the exact Meridian
+// ownership marker for this site may be removed; an operator edit (cleared
+// comment, changed type or renamed host) is treated as a conflict and left in
+// place for the operator to resolve. A record that no longer exists remains an
+// idempotent success so the local cleanup can complete.
+func verifyTrackedSiteDNSOwnership(ctx context.Context, cf *cloudflareClient, schedule SiteNodeSchedule) error {
+	record, err := cf.dnsRecordByID(ctx, schedule.cfZoneID, schedule.cfRecordID)
+	if err != nil {
+		if isCloudflareRecordNotFoundError(err) {
+			return nil
+		}
+		return err
+	}
+	if (record.Type != "A" && record.Type != "AAAA") ||
+		!strings.EqualFold(strings.TrimSpace(record.Name), strings.TrimSpace(schedule.PublicHost)) ||
+		strings.TrimSpace(record.Comment) != siteDNSOwnershipMarker(schedule.SiteID) {
+		return errors.New("tracked DNS record no longer carries the Meridian ownership marker; refusing to delete")
 	}
 	return nil
 }
@@ -1609,6 +1694,17 @@ func restoreDNSRecordBestEffort(ctx context.Context, cf *cloudflareClient, zoneI
 		return err
 	}
 	return nil
+}
+
+// recreateReplacedDNSRecordBestEffort recreates a record that a family switch
+// (A↔AAAA) deleted after its replacement create failed. Best effort: if the
+// restore also fails, the next reconcile retries the complete switch.
+func recreateReplacedDNSRecordBestEffort(ctx context.Context, cf *cloudflareClient, zoneID string, previous cloudflareAddressRecord) error {
+	if cf == nil || strings.TrimSpace(previous.ID) == "" {
+		return nil
+	}
+	_, err := cf.writeAddressRecord(ctx, zoneID, "", previous.Type, previous.Name, previous.Content, previous.Comment)
+	return err
 }
 
 func compensateDNSRecordBestEffort(ctx context.Context, cf *cloudflareClient, zoneID, name, expectedContent, marker, recordID string, created bool, previous *cloudflareAddressRecord) error {
@@ -1762,21 +1858,27 @@ func (a *App) reconcileOneSiteScheduleLocked(ctx context.Context, schedule SiteN
 			return err
 		}
 	}
-	marker := fmt.Sprintf("Meridian site=%d", schedule.SiteID)
+	marker := siteDNSOwnershipMarker(schedule.SiteID)
 	trackedRecordID := strings.TrimSpace(schedule.cfRecordID)
 	recordID := trackedRecordID
 	dnsRecordCreated := false
 	var previousRecord *cloudflareAddressRecord
+	var replacedRecord *cloudflareAddressRecord
 	if recordID != "" {
 		// Keep a preimage for a possible PUT compensation if the schedule
 		// generation changes before the local transaction commits.
-		if records, getErr := cf.exactAddressRecords(ctx, zoneID, schedule.PublicHost); getErr == nil {
-			for i := range records {
-				if records[i].ID == recordID {
-					copy := records[i]
-					previousRecord = &copy
-					break
-				}
+		records, getErr := cf.exactAddressRecords(ctx, zoneID, schedule.PublicHost)
+		if getErr != nil {
+			// Without the preimage a compensating PUT could not restore the
+			// previous address if the schedule changes mid-update. Refuse the
+			// blind write; the next tick retries with a fresh snapshot.
+			return fmt.Errorf("read current DNS record before update: %w", getErr)
+		}
+		for i := range records {
+			if records[i].ID == recordID {
+				copy := records[i]
+				previousRecord = &copy
+				break
 			}
 		}
 	}
@@ -1801,6 +1903,8 @@ func (a *App) reconcileOneSiteScheduleLocked(ctx context.Context, schedule SiteN
 					if err := cf.deleteRecord(ctx, zoneID, owned.ID); err != nil && !isCloudflareRecordNotFoundError(err) {
 						return err
 					}
+					replaced := owned
+					replacedRecord = &replaced
 				} else {
 					recordID = owned.ID
 				}
@@ -1826,6 +1930,10 @@ func (a *App) reconcileOneSiteScheduleLocked(ctx context.Context, schedule SiteN
 				return errors.New("an untracked exact A/AAAA record already exists; Meridian will not overwrite it")
 			} else if ok && owned.Type == recordType {
 				recordID, err = owned.ID, nil
+				// The adopted record was created by this attempt's lost POST, so
+				// compensation must delete it if the schedule generation no
+				// longer matches; otherwise it would leak an untracked record.
+				dnsRecordCreated = creatingRecord
 			}
 		}
 	}
@@ -1847,9 +1955,16 @@ func (a *App) reconcileOneSiteScheduleLocked(ctx context.Context, schedule SiteN
 					err = errors.New("an untracked exact A/AAAA record already exists; Meridian will not overwrite it")
 				case ok && owned.Type == recordType:
 					recordID, err, recoveredRecord = owned.ID, nil, true
+					// The adopted marker record is untracked in this schedule
+					// generation, so compensation must remove it if the local
+					// transaction still fails; otherwise it would leak.
+					dnsRecordCreated = true
 				case ok:
 					if deleteErr := cf.deleteRecord(ctx, zoneID, owned.ID); deleteErr != nil && !isCloudflareRecordNotFoundError(deleteErr) {
 						err = deleteErr
+					} else {
+						replaced := owned
+						replacedRecord = &replaced
 					}
 				default:
 					err = errors.New("tracked Meridian DNS record is missing")
@@ -1864,6 +1979,14 @@ func (a *App) reconcileOneSiteScheduleLocked(ctx context.Context, schedule SiteN
 		}
 	}
 	if err != nil {
+		if replacedRecord != nil {
+			// A family switch (A↔AAAA) deleted the previous record before its
+			// replacement create failed. Restore the old record so a transient
+			// Cloudflare error cannot leave the hostname without any address.
+			if restoreErr := recreateReplacedDNSRecordBestEffort(ctx, cf, zoneID, *replacedRecord); restoreErr != nil {
+				return errors.Join(err, restoreErr)
+			}
+		}
 		return err
 	}
 	// DNS is an external side effect and is complete at this point. Publish the
@@ -1975,7 +2098,7 @@ func (a *App) processNodeSchedulerOutcome(job nodeSchedulerJob, err error) {
 				shouldCooldown = now.Sub(time.UnixMilli(value.ConfigPendingSinceMS)) >= 90*time.Second
 			}
 			if shouldCooldown {
-				if cooldownErr := a.db.recordSiteNodeProbeFailure(value.SiteID, value.DesiredNodeID, err, now); cooldownErr != nil {
+				if cooldownErr := a.recordSiteNodeProbeFailureForJob(value, err, now); cooldownErr != nil {
 					log.Printf("[node-scheduler] record site %d node %d cooldown failed: %v", value.SiteID, value.DesiredNodeID, cooldownErr)
 				}
 			}
@@ -1984,6 +2107,20 @@ func (a *App) processNodeSchedulerOutcome(job nodeSchedulerJob, err error) {
 	if value.DNSStatus != "waiting" || value.LastError != err.Error() {
 		_, _ = a.db.db.Exec("UPDATE site_node_schedules SET dns_status='waiting',last_error=?,updated_at_ms=? WHERE site_id=? AND enabled=1 AND desired_node_id=? AND schedule_revision=?", err.Error(), now.UnixMilli(), value.SiteID, value.DesiredNodeID, value.ScheduleRevision)
 	}
+}
+
+// recordSiteNodeProbeFailureForJob records the health-check cooldown only when
+// the schedule generation that produced the failure is still current. The
+// outcome runs after the job released the site lock, so a superseded job's
+// failure must not penalize the node for the replacement generation.
+func (a *App) recordSiteNodeProbeFailureForJob(value SiteNodeSchedule, jobErr error, now time.Time) error {
+	unlockSite := a.lockSiteSchedule(value.SiteID)
+	defer unlockSite()
+	current, err := a.db.siteNodeSchedule(value.SiteID)
+	if err != nil || current.ScheduleRevision != value.ScheduleRevision || current.DesiredNodeID != value.DesiredNodeID {
+		return nil
+	}
+	return a.db.recordSiteNodeProbeFailure(value.SiteID, value.DesiredNodeID, jobErr, now)
 }
 
 func (a *App) reconcileSiteNodeScheduling(ctx context.Context) {


### PR DESCRIPTION
## 改动内容

修复本轮审查确认的 4 个 P1 + 3 个 P2 问题，以及上轮审查确认的 2 个 P2 问题（Agent 忙等、Controller 趋势防双计数死代码）。共 10 项，全部附带回归测试。

### 调度器 / Cloudflare DNS
- **P1-1** worker 执行任何排队 job 前在 site lock 下重读 schedule 并校验 revision；过期 job 直接丢弃，杜绝"已重新启用的站点 DNS 被旧 cleanup 删除"。
- **P1-2** A↔AAAA 类型切换先删后建：替换创建失败时用 preimage 恢复原记录，Cloudflare 瞬时故障不再导致域名无地址记录。
- **P1-3a** preimage GET 失败时拒绝执行 PUT（补偿将无法恢复）；下一 tick 重试。
- **P1-3b** lost-POST adopt 与 404 恢复 adopt 补 `dnsRecordCreated=true`，本地事务失败时补偿会删除该记录，不再泄漏孤儿 marker 记录。
- **P1-4** 删除 tracked 记录前重新 GET 并校验 ownership marker/主机名/记录类型；被管理员改写过的记录按冲突拒绝删除，404 保持幂等成功。
- **P2-3** probe-failure cooldown 写入前重读 schedule 校验 revision + desired node，旧 generation 的失败不再处罚新 generation。
- worker 增加 panic recovery：单个 job panic 转为失败 outcome，不再拖垮整个 controller。

### Agent
- **P2-2** Controller 侧 lease TTL（90s）：租约过期（Agent 停止上报）后允许其他会话通过 config 路径接管节点；接受的报告续租。winner 永久宕机后 loser 可自动恢复，无需重启进程；被接管方旧 lease 永久失效（fencing）。
- **P2（忙等）** quiesced 状态 supervisor 循环改为睡眠等待，修复 Controller 不可达/apply 失败时 100% CPU 空转；`--once` 模式 quiesced 时正常退出。
- **P2（Windows）** 用 IP Helper API（GetIfTable2Ex）实现 Windows 流量计数，替换 Linux-only 的 sysfs 读取——此前 Windows Agent 每个周期采集失败、完整报告被整体跳过；counter epoch 用开机 tick 提供重启信号。

### 流量
- **P2（趋势）** Controller 本地实例内联 flush-generation，使趋势快照的 flush 竞态重试机制对无 Agent runtime counter 的站点同样生效，消除当前时段流量双重计数。

## 改动类型

- [x] Bug 修复

## 验证方式

- [x] `go test ./...` 通过
- [x] `go test -race ./...` 通过
- [x] `go vet ./...` 通过（含 GOOS=windows / darwin 交叉 vet）
- [x] `govulncheck`：0 漏洞
- [x] `gosec -quiet -severity medium -confidence medium`：0 问题
- [x] `node --check` 全部前端 JS；`node --test tests/*.test.js` 176/176
- [x] `bash -n` 三个 shell 脚本
- [x] Windows 本机运行时验证 Windows 流量计数（GetIfTable2Ex 冒烟测试）
- 新增回归测试：lease TTL 接管与 fencing、过期 job 跳过、ownership 校验拒绝/幂等、family-switch 回滚 preimage

## 影响范围

- [x] 反代引擎（Windows 计数、flush-generation）
- [ ] 站点管理 API
- [ ] 诊断功能
- [ ] 认证 / 登录
- [x] 流量计量（趋势一致性、lease 续租）
- [ ] 前端 UI
- [x] CI / Docker（schema version 49：control_nodes.agent_lease_expires_at_ms）

## 注意事项

- schema 升级 48→49 为纯增量列，旧库自动迁移；备份恢复校验使用新版本号。
- lease 接管语义：新 epoch 会话仍可立即轮换租约（原有规则不变）；只有"当前租约过期"才允许低 epoch 会话接管，接管后旧 lease 永久失效。
- 站点 DELETE 分支未加 siteScheduleLock：removeSiteNodeSchedule 内部自带该锁（Mutex 不可重入，已加注释说明）。