### PR TITLE
fix: harden proxy lifecycle, restore pipeline, and panel boundaries (v1.9.85)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,17 @@ meridian.exe
 *.exe
 .idea
 .vscode
+.tmp
+.ai-memory
+.planning
+.planning/*
+output
+output/*
+findings.md
+progress.md
+task_plan.md
+AGENTS.md
+docs/images
+tests
+*.log
+*.mrbak

--- a/account_repository.go
+++ b/account_repository.go
@@ -248,3 +248,13 @@ func (d *DB) ResetAdminPassword(password string) error {
 	}
 	return tx.Commit()
 }
+
+// RevokeUserSessions rotates the account's session version so every issued
+// token — including the one logging out — stops validating immediately.
+func (d *DB) RevokeUserSessions(userID int64) error {
+	if d == nil || d.db == nil || userID <= 0 {
+		return nil
+	}
+	_, err := d.db.Exec("UPDATE users SET session_version=session_version+1 WHERE id=?", userID)
+	return err
+}

--- a/agent_instance_lock_windows.go
+++ b/agent_instance_lock_windows.go
@@ -24,7 +24,11 @@ func acquireAgentInstanceLock(path string) (func(), error) {
 	flags := uint32(windows.LOCKFILE_EXCLUSIVE_LOCK | windows.LOCKFILE_FAIL_IMMEDIATELY)
 	if err := windows.LockFileEx(windows.Handle(file.Fd()), flags, 0, 1, 0, &overlapped); err != nil {
 		_ = file.Close()
-		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) || errors.Is(err, windows.ERROR_IO_PENDING) {
+		// Only a lock violation means another agent holds the file. With
+		// LOCKFILE_FAIL_IMMEDIATELY an asynchronous completion (IO_PENDING)
+		// is not expected; reporting it as "already running" would mask the
+		// real failure.
+		if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
 			return nil, errAgentAlreadyRunning
 		}
 		return nil, err

--- a/app_http.go
+++ b/app_http.go
@@ -291,10 +291,34 @@ func panelBodyReadDeadline(next http.Handler) http.Handler {
 			// Clearing it when the handler returns lets a slow client keep dripping an
 			// unread body indefinitely. The server installs the next request/idle
 			// deadline before reusing a healthy keep-alive connection.
-			_ = controller.SetReadDeadline(time.Now().Add(30 * time.Second))
+			_ = controller.SetReadDeadline(time.Now().Add(panelBodyReadTimeout(r)))
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// panelBodyReadTimeout scales the absolute body-read deadline with the request
+// size. A flat 30s deadline caps uploads at ~8.5 MB/s, which made 256 MiB
+// backup restores fail permanently on links slower than ~70 Mbps; the restore
+// upload is an authenticated, size-capped operation, so it gets a generous
+// window while small JSON bodies keep the anti-slow-loris deadline.
+func panelBodyReadTimeout(r *http.Request) time.Duration {
+	const base = 30 * time.Second
+	if r.URL.Path != "/api/backup/restore" {
+		return base
+	}
+	const perMiB = 2 * time.Second
+	deadline := base
+	if r.ContentLength > 0 {
+		deadline += time.Duration(r.ContentLength>>20) * perMiB
+	} else {
+		// Unknown length (chunked upload): allow the full maximum payload.
+		deadline += 256 * 2 * time.Second
+	}
+	if deadline > 20*time.Minute {
+		return 20 * time.Minute
+	}
+	return deadline
 }
 
 func staticHandler(staticFS fs.FS) http.Handler {
@@ -548,6 +572,14 @@ func (a *App) handleLogout(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Cache-Control", "no-store")
+	// Revoking the server-side session makes logout effective for a stolen or
+	// shared-cookie copy too, instead of only clearing this browser's cookie
+	// while the token stays valid until its 72-hour expiry.
+	if userID, _, err := a.authenticatedSessionIdentity(r); err == nil {
+		if revokeErr := a.db.RevokeUserSessions(userID); revokeErr != nil {
+			log.Printf("[auth] logout session revocation failed: %v", revokeErr)
+		}
+	}
 	a.clearSessionCookie(w, r)
 	a.jsonOK(w, map[string]bool{"logged_out": true})
 }

--- a/backup_restore.go
+++ b/backup_restore.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -1654,6 +1655,31 @@ func backupHasJWTProtectedTokenFile(path string) (bool, error) {
 			return true, nil
 		}
 	}
+	// Probe secrets and watch-history tokens are also encrypted under keys
+	// derived from the JWT secret. A restore carrying any of them under an
+	// ephemeral JWT secret would be unrecoverable after the next restart
+	// rotates that secret, so they must trip the same guard.
+	for _, protected := range []struct{ table, column string }{
+		{table: "control_nodes", column: "probe_secret_ciphertext"},
+		{table: "watch_sessions", column: "token_ciphertext"},
+		{table: "watch_history_inbox", column: "payload_json"},
+	} {
+		exists, err := backupSQLiteColumnExists(db, protected.table, protected.column)
+		if err != nil {
+			return false, err
+		}
+		if !exists {
+			continue
+		}
+		// #nosec G202 -- table and column are fixed literals from the list above.
+		var nonEmpty int
+		if err := db.QueryRow("SELECT COUNT(*) FROM " + protected.table + " WHERE " + protected.column + "<>''").Scan(&nonEmpty); err != nil {
+			return false, err
+		}
+		if nonEmpty > 0 {
+			return true, nil
+		}
+	}
 	hasTMDBColumn, err := backupSQLiteColumnExists(db, "tmdb_settings", "token_ciphertext")
 	if err != nil {
 		return false, err
@@ -2462,7 +2488,14 @@ func applyPendingRestore(dbPath string) (*restoreAppliedState, error) {
 	committed := false
 	defer func() {
 		if rollbackReady && !committed {
-			_ = rollbackRestoreFiles(dbPath, rollback)
+			if rollbackErr := rollbackRestoreFiles(dbPath, rollback); rollbackErr != nil {
+				// The rollback itself failed: the rollback directory and the
+				// applied marker are now the only copy of the pre-restore
+				// state. Keep both so the next startup retry can finish the
+				// rollback instead of destroying the last recovery path.
+				log.Printf("恢复回滚失败，保留回滚目录与标记等待下次启动重试: %v", rollbackErr)
+				return
+			}
 			_ = os.Remove(dbPath + backupAppliedSuffix) // #nosec G703 G304 -- fixed restore marker suffix.
 			_ = os.RemoveAll(rollback)                  // #nosec G703 G304 -- fixed rollback suffix path.
 			_ = os.RemoveAll(pending)                   // #nosec G703 G304 -- fixed pending suffix path.

--- a/database.go
+++ b/database.go
@@ -41,6 +41,7 @@ type DB struct {
 	agentSecurityLastRejectedMS atomic.Int64
 	agentSecurityMu             sync.Mutex
 	agentSecurityLastLog        map[string]time.Time
+	lastTrafficPruneMS          atomic.Int64
 	systemSettings              atomic.Pointer[SystemSettings]
 	nodeTLSMutationMu           sync.Mutex
 	watchHistoryMetadataMu      sync.Mutex

--- a/dynamic_authority.go
+++ b/dynamic_authority.go
@@ -85,6 +85,48 @@ func (l *dynamicAuthorityLease) rollback() {
 	l.finish(false)
 }
 
+// dynamicAuthorityIdleTTL bounds how long a committed, fully idle authority
+// entry stays in the per-site and global tables. Without eviction the tables
+// only ever grow, and once they reach the configured capacity every NEW
+// authority is permanently denied with capacity_limit while previously seen
+// ones keep working.
+const dynamicAuthorityIdleTTL = 15 * time.Minute
+
+// evictIdleAuthoritiesLocked drops committed entries with no in-flight
+// requests that have not been used within dynamicAuthorityIdleTTL. The caller
+// must hold runtime.mu and s.mu.
+func (s *dynamicSiteState) evictIdleAuthoritiesLocked(runtime *dynamicRuntime, now time.Time) {
+	for authority, entry := range s.authorities {
+		if !entry.committed || entry.inFlight != 0 || entry.resolution != nil {
+			continue
+		}
+		if now.Sub(time.Unix(0, entry.lastUsed)) < dynamicAuthorityIdleTTL {
+			continue
+		}
+		delete(s.authorities, authority)
+		if runtime.authorities[authority] <= 1 {
+			delete(runtime.authorities, authority)
+		} else {
+			runtime.authorities[authority]--
+		}
+	}
+}
+
+// evictIdleAuthoritiesGloballyLocked sweeps every site state for stale
+// authority entries. The caller must hold runtime.mu and the calling state's
+// mu, which must be passed as skip: state mu is not re-entrant, so the sweep
+// must never try to lock the caller's own state again.
+func (runtime *dynamicRuntime) evictIdleAuthoritiesGloballyLocked(now time.Time, skip *dynamicSiteState) {
+	for state := range runtime.states {
+		if state == nil || state == skip {
+			continue
+		}
+		state.mu.Lock()
+		state.evictIdleAuthoritiesLocked(runtime, now)
+		state.mu.Unlock()
+	}
+}
+
 func (s *dynamicSiteState) reserveAuthority(authority string, now time.Time) (*dynamicAuthorityReservation, string) {
 	if s == nil || s.runtime == nil || authority == "" {
 		return nil, dynamicObservationReasonRuntimeUnavailable
@@ -96,6 +138,7 @@ func (s *dynamicSiteState) reserveAuthority(authority string, now time.Time) (*d
 	defer s.mu.Unlock()
 	if entry := s.authorities[authority]; entry != nil {
 		entry.inFlight++
+		entry.lastUsed = now.UnixNano()
 		if entry.resolution == nil {
 			entry.resolution = newDynamicAuthorityResolution()
 		}
@@ -107,16 +150,25 @@ func (s *dynamicSiteState) reserveAuthority(authority string, now time.Time) (*d
 		}, ""
 	}
 
+	// Bound the tables before admitting a new authority so stale entries
+	// cannot permanently exhaust the capacity for new ones.
+	s.evictIdleAuthoritiesLocked(runtime, now)
+	if len(s.authorities) >= s.limits.MaxAuthorities || runtime.authorities[authority] == 0 && len(runtime.authorities) >= globalDynamicMaxAuthorities {
+		// A full global table may be caused by stale entries on other sites;
+		// sweep them once before refusing. The calling state is skipped: its
+		// mu is already held here and is not re-entrant.
+		runtime.evictIdleAuthoritiesGloballyLocked(now, s)
+		if len(s.authorities) >= s.limits.MaxAuthorities || runtime.authorities[authority] == 0 && len(runtime.authorities) >= globalDynamicMaxAuthorities {
+			return nil, dynamicObservationReasonCapacityLimit
+		}
+	}
 	s.newAuthorities = pruneDynamicRateWindow(s.newAuthorities, now)
 	runtime.newAuthorities = pruneDynamicRateWindow(runtime.newAuthorities, now)
-	if len(s.authorities) >= s.limits.MaxAuthorities || runtime.authorities[authority] == 0 && len(runtime.authorities) >= globalDynamicMaxAuthorities {
-		return nil, dynamicObservationReasonCapacityLimit
-	}
 	if len(s.newAuthorities) >= s.limits.MaxNewAuthoritiesPerMinute || runtime.authorities[authority] == 0 && len(runtime.newAuthorities) >= globalDynamicMaxNewAuthoritiesMinute {
 		return nil, dynamicObservationReasonRateLimit
 	}
 	resolution := newDynamicAuthorityResolution()
-	entry := &dynamicAuthorityEntry{inFlight: 1, resolution: resolution}
+	entry := &dynamicAuthorityEntry{inFlight: 1, resolution: resolution, lastUsed: now.UnixNano()}
 	s.authorities[authority] = entry
 	s.newAuthorities = append(s.newAuthorities, now)
 	if runtime.authorities[authority] == 0 {

--- a/dynamic_redirect_runtime_test.go
+++ b/dynamic_redirect_runtime_test.go
@@ -2019,7 +2019,9 @@ func TestDynamicRedirectRuntimeProfileOperationalBoundaries(t *testing.T) {
 			state := newDynamicSiteState(runtime, limits)
 			for index := range limits.MaxAuthorities - 1 {
 				authority := fmt.Sprintf("https://seed-%d.example.com:443", index)
-				state.authorities[authority] = &dynamicAuthorityEntry{committed: true}
+				// Seed through the same fields reserveAuthority populates so
+				// the idle-eviction sweep treats these as freshly used.
+				state.authorities[authority] = &dynamicAuthorityEntry{committed: true, lastUsed: now.UnixNano()}
 				runtime.authorities[authority] = 1
 			}
 			if len(state.authorities) != limits.MaxAuthorities-1 {

--- a/dynamic_runtime_state.go
+++ b/dynamic_runtime_state.go
@@ -195,6 +195,9 @@ type dynamicAuthorityEntry struct {
 	inFlight   int
 	committed  bool
 	resolution *dynamicAuthorityResolution
+	// lastUsed is a unix-nano stamp refreshed on every reservation; guarded
+	// by the owning dynamicSiteState.mu.
+	lastUsed int64
 }
 
 type dynamicCapabilityEntry struct {

--- a/edge_agent.go
+++ b/edge_agent.go
@@ -2502,7 +2502,15 @@ func edgeMaybeUpdate(ctx context.Context, client *http.Client, controller, token
 	defer os.Remove(temporaryName)
 	digest := sha256.New()
 	written, copyErr := io.Copy(io.MultiWriter(temporary, digest), io.LimitReader(response.Body, 128<<20))
-	if copyErr != nil || written <= 0 || !strings.EqualFold(hex.EncodeToString(digest.Sum(nil)), config.AgentSHA256) {
+	if copyErr != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("Agent update download failed: %w", copyErr)
+	}
+	if written <= 0 {
+		_ = temporary.Close()
+		return errors.New("Agent update download was empty")
+	}
+	if !strings.EqualFold(hex.EncodeToString(digest.Sum(nil)), config.AgentSHA256) {
 		_ = temporary.Close()
 		return errors.New("Agent update checksum mismatch")
 	}

--- a/hardening_regression_test.go
+++ b/hardening_regression_test.go
@@ -328,3 +328,237 @@ func TestRecreateReplacedDNSRecordRestoresPreimage(t *testing.T) {
 		t.Fatalf("restore payload=%+v, want the deleted record preimage", payload)
 	}
 }
+
+func TestPathRouteSelectionIsDeterministic(t *testing.T) {
+	pm := &ProxyManager{
+		pathPrefixes: map[string]int64{"/emby": 2, "/foo": 1},
+		proxies: map[int64]*ProxyInstance{
+			1: {Site: Site{ID: 1}, handler: http.NotFoundHandler()},
+			2: {Site: Site{ID: 2}, handler: http.NotFoundHandler()},
+		},
+	}
+	// /emby/foo/x matches the direct /emby prefix and the embedded /emby/foo
+	// form; the longer effective match must win on every iteration instead of
+	// following Go's randomized map order.
+	for i := 0; i < 50; i++ {
+		_, prefix, ok := pm.PathRoute("/emby/foo/x")
+		if !ok || prefix != "/foo" {
+			t.Fatalf("iteration %d: prefix=%q ok=%v, want the deterministic /foo match", i, prefix, ok)
+		}
+	}
+	// An exact /emby request only matches the /emby site directly.
+	for i := 0; i < 50; i++ {
+		_, prefix, ok := pm.PathRoute("/emby")
+		if !ok || prefix != "/emby" {
+			t.Fatalf("iteration %d: prefix=%q ok=%v, want the deterministic /emby match", i, prefix, ok)
+		}
+	}
+	// Nested prefixes: the more specific /foo/bar wins over /foo.
+	pm.pathPrefixes["/foo/bar"] = 1
+	_, prefix, ok := pm.PathRoute("/foo/bar/baz")
+	if !ok || prefix != "/foo/bar" {
+		t.Fatalf("nested prefix=%q ok=%v, want /foo/bar", prefix, ok)
+	}
+}
+
+func TestCleanUpstreamDotSegments(t *testing.T) {
+	cases := map[string]string{
+		"/emby/../admin":    "/admin",
+		"/emby/./Items":     "/emby/Items",
+		"/emby/Items":       "/emby/Items",
+		"/emby/Items/":      "/emby/Items/",
+		"/emby/../..":       "/",
+		"/.well-known/acme": "/.well-known/acme",
+		"/a/b/../c/./d":     "/a/c/d",
+	}
+	for input, want := range cases {
+		if got := cleanUpstreamDotSegments(input); got != want {
+			t.Fatalf("cleanUpstreamDotSegments(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestPruneTrafficLogsBoundsHistoryAndDeletesOnSiteDelete(t *testing.T) {
+	app := newTestApp(t)
+	site, err := app.db.CreateSiteRecord(Site{Name: "traffic-prune", ListenPort: 19851, TargetURL: "http://127.0.0.1:8096", PlaybackMode: "direct", StreamHosts: "[]", UAMode: "passthrough"})
+	if err != nil {
+		t.Fatalf("create site: %v", err)
+	}
+	now := time.Now()
+	if err := app.db.addTrafficWithRequests(site.ID, 1, 2, 3); err != nil {
+		t.Fatalf("insert current traffic: %v", err)
+	}
+	old := now.Add(-401 * 24 * time.Hour)
+	if _, err := app.db.db.Exec("INSERT INTO traffic_logs (site_id, bytes_in, bytes_out, requests, recorded_at, recorded_at_ms) VALUES (?,?,?,?,?,?)",
+		site.ID, 5, 5, 5, old, old.UnixMilli()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := app.db.db.Exec("INSERT INTO node_site_traffic_logs (node_id, site_id, bytes_in, bytes_out, requests, recorded_at_ms) VALUES (1,?,?,?,?,?)",
+		site.ID, 5, 5, 5, old.UnixMilli()); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.db.pruneTrafficLogs(now); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	var oldRows, newRows, nodeRows int
+	if err := app.db.db.QueryRow("SELECT COUNT(*) FROM traffic_logs WHERE recorded_at_ms<?", now.Add(-300*24*time.Hour).UnixMilli()).Scan(&oldRows); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.db.db.QueryRow("SELECT COUNT(*) FROM traffic_logs WHERE recorded_at_ms>=?", now.Add(-300*24*time.Hour).UnixMilli()).Scan(&newRows); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.db.db.QueryRow("SELECT COUNT(*) FROM node_site_traffic_logs").Scan(&nodeRows); err != nil {
+		t.Fatal(err)
+	}
+	if oldRows != 0 || newRows == 0 || nodeRows != 0 {
+		t.Fatalf("prune left oldRows=%d newRows=%d nodeRows=%d, want 0/>0/0", oldRows, newRows, nodeRows)
+	}
+	// The daily guard must skip an immediate second sweep.
+	if err := app.db.pruneTrafficLogs(now.Add(time.Minute)); err != nil {
+		t.Fatalf("guarded prune: %v", err)
+	}
+	// Deleting the site must also clear the node traffic ledger.
+	if _, err := app.db.db.Exec("INSERT INTO node_site_traffic_logs (node_id, site_id, bytes_in, bytes_out, requests, recorded_at_ms) VALUES (1,?,1,1,1,?)", site.ID, now.UnixMilli()); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.db.DeleteSite(site.ID); err != nil {
+		t.Fatalf("delete site: %v", err)
+	}
+	if err := app.db.db.QueryRow("SELECT COUNT(*) FROM node_site_traffic_logs WHERE site_id=?", site.ID).Scan(&nodeRows); err != nil {
+		t.Fatal(err)
+	}
+	if nodeRows != 0 {
+		t.Fatalf("node traffic rows survived site deletion: %d", nodeRows)
+	}
+}
+
+func TestExactAddressRecordsFollowsPagination(t *testing.T) {
+	var pages int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pages++
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.RawQuery, "page=2") {
+			_, _ = w.Write([]byte(`{"success":true,"result_info":{"page":2,"total_pages":2},"result":[{"id":"r2","type":"A","name":"site.example","content":"203.0.113.2","comment":""}]}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"success":true,"result_info":{"page":1,"total_pages":2},"result":[{"id":"r1","type":"A","name":"site.example","content":"203.0.113.1","comment":""}]}`))
+	}))
+	defer server.Close()
+	cf := &cloudflareClient{token: "test", httpClient: server.Client(), apiBase: server.URL}
+	records, err := cf.exactAddressRecords(context.Background(), "zone-1", "site.example")
+	if err != nil {
+		t.Fatalf("exactAddressRecords: %v", err)
+	}
+	if pages != 2 || len(records) != 2 || records[0].ID != "r1" || records[1].ID != "r2" {
+		t.Fatalf("pages=%d records=%d, want both pages merged", pages, len(records))
+	}
+}
+
+func TestSaveManagedPanelSettingsRejectsSitePortConflict(t *testing.T) {
+	app := newTestApp(t)
+	site, err := app.db.CreateSiteRecord(Site{Name: "port-site", ListenPort: 19555, IngressMode: ingressModePort, TargetURL: "http://127.0.0.1:8096", PlaybackMode: "direct", StreamHosts: "[]", UAMode: "passthrough"})
+	if err != nil {
+		t.Fatalf("create site: %v", err)
+	}
+	if _, _, err := app.db.SaveManagedPanelSettings("panel.admin.example.test", "example.test", site.ListenPort, false); err == nil {
+		t.Fatal("panel port collision with a dedicated-port site must be rejected")
+	}
+}
+
+func TestDynamicAuthorityIdleEvictionReleasesCapacity(t *testing.T) {
+	limits := DynamicProfileLimits{MaxAuthorities: 2, MaxNewAuthoritiesPerMinute: 100}
+	runtime := newDynamicRuntime()
+	state := newDynamicSiteState(runtime, limits)
+	commit := func(authority string, at time.Time) {
+		reservation, reason := state.reserveAuthority(authority, at)
+		if reason != "" {
+			t.Fatalf("reserve %s: %s", authority, reason)
+		}
+		reservation.commit()
+	}
+	now := time.Now()
+	commit("one.example", now)
+	commit("two.example", now)
+	// At capacity with stale entries, a new authority must be admitted after
+	// eviction instead of being permanently rejected.
+	late := now.Add(dynamicAuthorityIdleTTL + time.Minute)
+	commit("three.example", late)
+	// Freshly used committed entries are never evicted: three.example is
+	// within the TTL and must still reserve without recreating.
+	if entry, reason := state.reserveAuthority("three.example", late.Add(time.Second)); reason != "" || entry == nil {
+		t.Fatalf("fresh committed authority rejected after eviction sweep: %s", reason)
+	}
+}
+
+func TestDynamicAuthorityGlobalSweepDoesNotDeadlockOrLeak(t *testing.T) {
+	limits := DynamicProfileLimits{MaxAuthorities: 1, MaxNewAuthoritiesPerMinute: 1000}
+	runtime := newDynamicRuntime()
+	state := newDynamicSiteState(runtime, limits)
+	other := newDynamicSiteState(runtime, limits)
+	now := time.Now()
+	// Keep the busy site at capacity with a fresh committed entry.
+	reservation, reason := state.reserveAuthority("busy.example", now)
+	if reason != "" {
+		t.Fatalf("reserve busy: %s", reason)
+	}
+	reservation.commit()
+	// Plant a stale committed entry on another site for the global sweep.
+	staleAt := now.Add(-dynamicAuthorityIdleTTL - time.Minute)
+	staleReservation, reason := other.reserveAuthority("stale.example", staleAt)
+	if reason != "" {
+		t.Fatalf("reserve stale: %s", reason)
+	}
+	staleReservation.commit()
+	// Reserving a new authority on the busy site runs the global sweep while
+	// holding this state's mu: the sweep must skip the caller (no self
+	// deadlock), evict the other site's stale entry, and still deny with
+	// capacity_limit because the caller's own table stays full.
+	done := make(chan string, 1)
+	go func() {
+		_, sweepReason := state.reserveAuthority("new.example", now.Add(time.Second))
+		done <- sweepReason
+	}()
+	select {
+	case sweepReason := <-done:
+		if sweepReason != dynamicObservationReasonCapacityLimit {
+			t.Fatalf("reason=%q, want capacity_limit", sweepReason)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("reserveAuthority deadlocked during the global eviction sweep")
+	}
+	runtime.mu.Lock()
+	other.mu.Lock()
+	remaining := len(other.authorities)
+	other.mu.Unlock()
+	runtime.mu.Unlock()
+	if remaining != 0 {
+		t.Fatalf("global sweep left %d stale entries on the other site", remaining)
+	}
+}
+
+func TestNodeRequestEventPendingLedgerIsCapped(t *testing.T) {
+	app := newTestApp(t)
+	now := time.Now()
+	total := nodeRequestEventPendingLimit + 5
+	for i := 0; i < total; i++ {
+		if _, err := app.db.db.Exec("INSERT INTO node_request_events (node_id, agent_boot_id, event_id, received_at_ms) VALUES (7, 'boot', ?, ?)",
+			int64(i), now.Add(-time.Duration(total-i)*time.Minute).UnixMilli()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	tx, err := app.db.db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	if err := pruneRequestLogsTx(tx, now, 24*time.Hour); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	var pending int
+	if err := tx.QueryRow("SELECT COUNT(*) FROM node_request_events WHERE processed_at_ms=0").Scan(&pending); err != nil {
+		t.Fatal(err)
+	}
+	if pending > nodeRequestEventPendingLimit {
+		t.Fatalf("pending ledger rows=%d, want <= %d", pending, nodeRequestEventPendingLimit)
+	}
+}

--- a/install.sh
+++ b/install.sh
@@ -18,11 +18,25 @@ AGENT_BIN_NAME="meridian-agent"
 SERVICE_USER="meridian"
 SERVICE_GROUP="meridian"
 SYSTEMD_RESTRICT_ADDRESS_FAMILIES="AF_UNIX AF_INET AF_INET6 AF_NETLINK"
+# A data directory under /home cannot coexist with ProtectHome=true: systemd
+# would hide it from the sandboxed service and the install would fail its
+# health check with a misleading error. Allow read-only protection instead.
+case "$MERIDIAN_DATA_DIR" in
+    /home/*) SYSTEMD_PROTECT_HOME="read-only" ;;
+    *) SYSTEMD_PROTECT_HOME="true" ;;
+esac
 ROOT_GROUP="${MERIDIAN_ROOT_GROUP:-$(id -gn 0 2>/dev/null || printf 'root')}"
 NGINX_MARKER="# Managed by Meridian installer - panel only"
 NGINX_REDACTION_MARKER="# Meridian redacted URI access log"
 
 while [ "$INSTALL_DIR" != "/" ] && [[ "$INSTALL_DIR" == */ ]]; do INSTALL_DIR="${INSTALL_DIR%/}"; done
+case "$INSTALL_DIR" in
+    ""|/|/bin|/boot|/dev|/etc|/home|/lib|/lib64|/media|/mnt|/opt|/proc|/root|/run|/sbin|/srv|/sys|/tmp|/usr|/usr/bin|/usr/local|/usr/local/share|/usr/share|/var|/var/lib)
+        fail "拒绝使用不安全的安装目录: ${INSTALL_DIR:-<empty>}" ;;
+    *//*|*/../*|*/..|*/./*|*/.|*$'
+'*)
+        fail "安装目录包含不安全的路径片段: $INSTALL_DIR" ;;
+esac
 while [ "$DATA_DIR" != "/" ] && [[ "$DATA_DIR" == */ ]]; do DATA_DIR="${DATA_DIR%/}"; done
 while [ "$BACKUP_DIR" != "/" ] && [[ "$BACKUP_DIR" == */ ]]; do BACKUP_DIR="${BACKUP_DIR%/}"; done
 
@@ -862,7 +876,7 @@ NoNewPrivileges=true
 PrivateTmp=true
 PrivateDevices=true
 ProtectSystem=strict
-ProtectHome=true
+ProtectHome=${SYSTEMD_PROTECT_HOME}
 ProtectHostname=true
 ProtectKernelTunables=true
 ProtectKernelModules=true
@@ -2211,6 +2225,13 @@ do_uninstall() {
         as_root rm -rf -- "$DATA_DIR"
         if id "$SERVICE_USER" >/dev/null 2>&1 && command -v userdel >/dev/null 2>&1; then
             as_root userdel "$SERVICE_USER" 2>/dev/null || true
+        fi
+        if getent group "$SERVICE_GROUP" >/dev/null 2>&1 && command -v groupdel >/dev/null 2>&1; then
+            # Only remove the group the installer created when no other user
+            # still references it.
+            if [ -z "$(awk -F: -v g="$SERVICE_GROUP" '$4==gid {print}' /etc/passwd 2>/dev/null)" ]; then
+                as_root groupdel "$SERVICE_GROUP" 2>/dev/null || true
+            fi
         fi
         ok "数据目录已删除；备份目录仍保留: $BACKUP_DIR"
     else

--- a/panel_acme.go
+++ b/panel_acme.go
@@ -425,7 +425,15 @@ type cloudflareResponse struct {
 		Code    int    `json:"code"`
 		Message string `json:"message"`
 	} `json:"errors"`
-	Result json.RawMessage `json:"result"`
+	Result     json.RawMessage      `json:"result"`
+	ResultInfo cloudflareResultInfo `json:"result_info"`
+}
+
+// cloudflareResultInfo carries Cloudflare list pagination metadata so list
+// helpers can follow every page instead of silently truncating at per_page.
+type cloudflareResultInfo struct {
+	Page       int `json:"page"`
+	TotalPages int `json:"total_pages"`
 }
 
 const (
@@ -927,10 +935,15 @@ func (m *panelCertificateManager) status(settings PanelSettings, activePanelDoma
 	if m == nil {
 		return status
 	}
+	// Only the in-memory issuing flag and the pair paths need the manager
+	// mutex. File reads, parsing and chain verification run outside it: they
+	// touch disk and the system trust store, and GetCertificate for every TLS
+	// handshake shares this mutex, so holding it across that I/O would stall
+	// panel handshakes whenever a status poll hit a slow disk.
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	status.Issuing = m.issuing
 	certFile, _ := m.panelPairPaths()
+	m.mu.Unlock()
 	data, err := os.ReadFile(certFile) // #nosec G304 G703 -- certFile is an administrator-configured TLS path captured when the certificate manager is created, never an HTTP request value.
 	if err != nil {
 		return status
@@ -1227,6 +1240,59 @@ func (m *panelCertificateManager) issueCloudflare(ctx context.Context, email, to
 	return m.issueCloudflareForIdentifiers(ctx, email, token, settings.RouteDomain, identifiers, staging)
 }
 
+// reusableCertificateForIdentifiers returns the currently installed panel
+// certificate pair when it is time-valid with more than the renewal window
+// remaining and covers every requested identifier (exact SANs or the route
+// wildcard). Callers invoke it after the shared issuance locks are held so a
+// concurrent issuer's fresh certificate is reused instead of re-issued.
+func (m *panelCertificateManager) reusableCertificateForIdentifiers(identifiers []string) *issuedPanelCertificate {
+	if m == nil || m.certFile == "" || m.keyFile == "" || len(identifiers) == 0 {
+		return nil
+	}
+	m.mu.Lock()
+	certFile, keyFile := m.certFile, m.keyFile
+	m.mu.Unlock()
+	data, err := os.ReadFile(certFile) // #nosec G304 G703 -- certFile is the manager-owned TLS path captured at construction.
+	if err != nil {
+		return nil
+	}
+	block, _ := pem.Decode(data)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil
+	}
+	certificate, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil
+	}
+	now := time.Now()
+	if now.Before(certificate.NotBefore) || !now.Before(certificate.NotAfter) {
+		return nil
+	}
+	if time.Until(certificate.NotAfter) <= panelCertificateRenewalWindow {
+		return nil
+	}
+	for _, identifier := range identifiers {
+		if strings.HasPrefix(identifier, "*.") {
+			if !certificateHasExactDNSName(certificate, identifier) {
+				return nil
+			}
+			continue
+		}
+		if certificate.VerifyHostname(identifier) != nil {
+			return nil
+		}
+	}
+	keyPEM, err := os.ReadFile(keyFile) // #nosec G304 G703 -- keyFile is the manager-owned TLS path captured at construction.
+	if err != nil {
+		return nil
+	}
+	pair, err := tls.X509KeyPair(data, keyPEM)
+	if err != nil {
+		return nil
+	}
+	return &issuedPanelCertificate{certPEM: data, keyPEM: keyPEM, certificate: pair}
+}
+
 func panelCertificateIdentifiers(settings PanelSettings) []string {
 	wildcard := wildcardDomainForSettings(settings)
 	if wildcard == "" {
@@ -1294,6 +1360,18 @@ func (m *panelCertificateManager) issueCloudflareForIdentifiers(ctx context.Cont
 				log.Printf("[acme] release shared issuance lock failed: %v", err)
 			}
 		}()
+	}
+
+	// Another issuer (web request, renewal scheduler, or CLI) may have finished
+	// while this request waited for the shared issuance lock. If the currently
+	// installed certificate already covers every requested identifier and is
+	// well inside its renewal window, reuse it instead of burning a duplicate
+	// against the CA's per-week duplicate-certificate quota. Staging requests
+	// are explicit test issuances and always proceed.
+	if !staging {
+		if reused := m.reusableCertificateForIdentifiers(cleanIdentifiers); reused != nil {
+			return reused, nil
+		}
 	}
 
 	if err := os.MkdirAll(m.accountDir, 0o700); err != nil { // #nosec G703 -- accountDir is captured from administrator-configured TLS paths.
@@ -1761,17 +1839,24 @@ func waitCloudflareRequestRetry(ctx context.Context, attempt int) error {
 // Cloudflare/API gateway failures without risking duplicate records from a
 // retried POST. The caller's context remains the overall retry budget.
 func (c *cloudflareClient) request(ctx context.Context, method, requestPath string, body io.Reader) (json.RawMessage, error) {
+	result, _, err := c.requestWithInfo(ctx, method, requestPath, body)
+	return result, err
+}
+
+// requestWithInfo behaves like request but also returns Cloudflare's
+// result_info block for paginated list endpoints.
+func (c *cloudflareClient) requestWithInfo(ctx context.Context, method, requestPath string, body io.Reader) (json.RawMessage, cloudflareResultInfo, error) {
 	if c == nil {
-		return nil, errors.New("Cloudflare DNS client is unavailable")
+		return nil, cloudflareResultInfo{}, errors.New("Cloudflare DNS client is unavailable")
 	}
 	var bodyBytes []byte
 	if body != nil {
 		data, err := io.ReadAll(io.LimitReader(body, cloudflareRequestBodyLimit+1))
 		if err != nil {
-			return nil, fmt.Errorf("read Cloudflare DNS request: %w", err)
+			return nil, cloudflareResultInfo{}, fmt.Errorf("read Cloudflare DNS request: %w", err)
 		}
 		if len(data) > cloudflareRequestBodyLimit {
-			return nil, errors.New("Cloudflare DNS request body is too large")
+			return nil, cloudflareResultInfo{}, errors.New("Cloudflare DNS request body is too large")
 		}
 		bodyBytes = data
 	}
@@ -1791,7 +1876,7 @@ func (c *cloudflareClient) request(ctx context.Context, method, requestPath stri
 		}
 		request, err := http.NewRequestWithContext(ctx, method, endpoint, requestBody)
 		if err != nil {
-			return nil, err
+			return nil, cloudflareResultInfo{}, err
 		}
 		request.Header.Set("Authorization", "Bearer "+c.token)
 		request.Header.Set("Content-Type", "application/json")
@@ -1802,7 +1887,7 @@ func (c *cloudflareClient) request(ctx context.Context, method, requestPath stri
 					continue
 				}
 			}
-			return nil, fmt.Errorf("cloudflare DNS request failed: %w", err)
+			return nil, cloudflareResultInfo{}, fmt.Errorf("cloudflare DNS request failed: %w", err)
 		}
 		data, readErr := io.ReadAll(io.LimitReader(response.Body, cloudflareRequestBodyLimit))
 		closeErr := response.Body.Close()
@@ -1812,10 +1897,10 @@ func (c *cloudflareClient) request(ctx context.Context, method, requestPath stri
 					continue
 				}
 			}
-			return nil, fmt.Errorf("read Cloudflare DNS response: %w", readErr)
+			return nil, cloudflareResultInfo{}, fmt.Errorf("read Cloudflare DNS response: %w", readErr)
 		}
 		if closeErr != nil {
-			return nil, fmt.Errorf("close Cloudflare DNS response: %w", closeErr)
+			return nil, cloudflareResultInfo{}, fmt.Errorf("close Cloudflare DNS response: %w", closeErr)
 		}
 		// Gate retries on the HTTP status before decoding the body. Gateways
 		// often return HTML or an empty body for 429/5xx responses, and those
@@ -1827,18 +1912,18 @@ func (c *cloudflareClient) request(ctx context.Context, method, requestPath stri
 		}
 		var envelope cloudflareResponse
 		if err := json.Unmarshal(data, &envelope); err != nil {
-			return nil, errors.New("cloudflare DNS returned an invalid response")
+			return nil, cloudflareResultInfo{}, errors.New("cloudflare DNS returned an invalid response")
 		}
 		if response.StatusCode < 200 || response.StatusCode >= 300 || !envelope.Success {
 			message := "cloudflare DNS request was rejected"
 			if len(envelope.Errors) > 0 && strings.TrimSpace(envelope.Errors[0].Message) != "" {
 				message += ": " + strings.TrimSpace(envelope.Errors[0].Message)
 			}
-			return nil, errors.New(message)
+			return nil, cloudflareResultInfo{}, errors.New(message)
 		}
-		return envelope.Result, nil
+		return envelope.Result, envelope.ResultInfo, nil
 	}
-	return nil, errors.New("cloudflare DNS request failed after retries")
+	return nil, cloudflareResultInfo{}, errors.New("cloudflare DNS request failed after retries")
 }
 
 func (c *cloudflareClient) findZone(ctx context.Context, zoneName string) (string, error) {

--- a/panel_settings.go
+++ b/panel_settings.go
@@ -229,6 +229,17 @@ func (d *DB) SaveManagedPanelSettings(panelDomain, routeDomain string, listenPor
 	if err := validatePanelListenPort(listenPort); err != nil {
 		return PanelSettings{}, 0, err
 	}
+	// The panel listener binds after the site listeners at startup. A port
+	// collision with a dedicated-port site would fatal the next boot and turn
+	// into a restart crash loop, so reject it up front.
+	var portConflicts int
+	if err := d.db.QueryRow(`SELECT COUNT(*) FROM sites WHERE listen_port=? AND ingress_mode IN (?,?)`,
+		listenPort, ingressModePort, ingressModeBoth).Scan(&portConflicts); err != nil {
+		return PanelSettings{}, 0, err
+	}
+	if portConflicts > 0 {
+		return PanelSettings{}, 0, fmt.Errorf("面板端口 %d 与站点专用端口冲突，请更换端口或调整站点入口", listenPort)
+	}
 	candidate, err := normalizeManagedPanelSettings(panelDomain, routeDomain)
 	if err != nil {
 		return PanelSettings{}, 0, err

--- a/proxy_manager.go
+++ b/proxy_manager.go
@@ -711,17 +711,42 @@ func (pm *ProxyManager) PublicHostSiteID(host string) (int64, bool) {
 func (pm *ProxyManager) PathRoute(requestPath string) (http.Handler, string, bool) {
 	pm.mu.RLock()
 	defer pm.mu.RUnlock()
+	// Selection must be deterministic: Go randomizes map iteration, so with a
+	// site registered under an app base (e.g. /emby) plus other path-ingress
+	// sites, one request path can match several prefixes via the direct and
+	// the /emby- or /jellyfin-embedded forms. The longest effective prefix
+	// wins, with the site id as a stable tie-breaker.
+	bestPrefix := ""
+	bestID := int64(0)
+	bestLength := -1
 	for prefix, id := range pm.pathPrefixes {
-		if !ingressPathMatches(requestPath, prefix) && !embeddedIngressPathMatches(requestPath, prefix) {
+		if ingressPathMatches(requestPath, prefix) {
+			if length := len(prefix); length > bestLength || (length == bestLength && (bestID == 0 || id < bestID)) {
+				bestPrefix, bestID, bestLength = prefix, id, length
+			}
 			continue
 		}
-		inst := pm.proxies[id]
-		if inst == nil {
-			return nil, prefix, true
+		if !embeddedIngressPathMatches(requestPath, prefix) {
+			continue
 		}
-		return inst.handler, prefix, true
+		for _, appBase := range []string{"/emby", "/jellyfin"} {
+			embedded := appBase + prefix
+			if len(requestPath) >= len(embedded) && strings.EqualFold(requestPath[:len(embedded)], embedded) {
+				if length := len(embedded); length > bestLength || (length == bestLength && (bestID == 0 || id < bestID)) {
+					bestPrefix, bestID, bestLength = prefix, id, length
+				}
+				break
+			}
+		}
 	}
-	return nil, "", false
+	if bestLength < 0 {
+		return nil, "", false
+	}
+	inst := pm.proxies[bestID]
+	if inst == nil {
+		return nil, bestPrefix, true
+	}
+	return inst.handler, bestPrefix, true
 }
 
 func embeddedIngressPathMatches(requestPath, prefix string) bool {

--- a/proxy_start.go
+++ b/proxy_start.go
@@ -564,11 +564,18 @@ func (pm *ProxyManager) StartSite(site Site) error {
 			closeNewListener()
 			return fmt.Errorf("final traffic flush of the instance being replaced: %w", err)
 		}
-		if flushed := existing.Site.TrafficUsed; flushed > inst.persistedTraffic.Load() {
-			inst.persistedTraffic.Store(flushed)
-			inst.persistedBytesIn.Store(existing.Site.TrafficUsedIn)
-			inst.persistedBytesOut.Store(existing.Site.TrafficUsedOut)
-			inst.Site.TrafficUsed = flushed
+		// The 60s flusher mutates these Site fields under trafficMu; take the
+		// same lock so a concurrent flush cannot hand us a torn baseline.
+		existing.trafficMu.Lock()
+		flushedTraffic := existing.Site.TrafficUsed
+		flushedIn := existing.Site.TrafficUsedIn
+		flushedOut := existing.Site.TrafficUsedOut
+		existing.trafficMu.Unlock()
+		if flushedTraffic > inst.persistedTraffic.Load() {
+			inst.persistedTraffic.Store(flushedTraffic)
+			inst.persistedBytesIn.Store(flushedIn)
+			inst.persistedBytesOut.Store(flushedOut)
+			inst.Site.TrafficUsed = flushedTraffic
 		}
 	}
 

--- a/redirect_transport.go
+++ b/redirect_transport.go
@@ -497,6 +497,20 @@ func (t *redirectFollowTransport) roundTripDynamic(req *http.Request, resp *http
 		}
 		return nil, t.denied(reasonCode, authority)
 	}
+	// releaseDynamicHops frees every per-request resource a previous dynamic
+	// hop acquired (transport, stream slot, authority leases) on return paths
+	// that hand the redirect back to the client instead of following it
+	// internally. Without it the site stream permits and authority in-flight
+	// counters leak a little on every client-redirected hop until the site
+	// restarts.
+	releaseDynamicHops := func() {
+		closeResponse()
+		lease.rollback()
+		if streamRelease != nil {
+			streamRelease()
+			streamRelease = nil
+		}
+	}
 	for {
 		if resp == nil {
 			return fail(dynamicObservationReasonResponseFailure, dynamicCanonicalAuthority(req.URL))
@@ -553,6 +567,7 @@ func (t *redirectFollowTransport) roundTripDynamic(req *http.Request, resp *http
 			if tracker := backendAddressTrackerFromContext(req.Context()); tracker != nil {
 				tracker.SetURL(locationURL)
 			}
+			releaseDynamicHops()
 			return replaceResponseWithMainVideoRedirect(resp, locationURL), nil
 		}
 		if !dynamicActive && sameAuthority {
@@ -671,6 +686,7 @@ func (t *redirectFollowTransport) roundTripDynamic(req *http.Request, resp *http
 				tracker.SetURL(normalized)
 			}
 			t.observe(dynamicObservationDecisionAllowed, dynamicObservationReasonRedirectAllowed, authority)
+			releaseDynamicHops()
 			return replaceResponseWithMainVideoRedirect(resp, normalized), nil
 		}
 		if t.followUnknownRedirects && shouldInternallyFollowDynamicRedirect(req) {
@@ -767,6 +783,7 @@ func (t *redirectFollowTransport) roundTripDynamic(req *http.Request, resp *http
 			resp.Header.Set("Content-Length", "0")
 			resp.Header.Set("Location", route)
 			t.observe(dynamicObservationDecisionAllowed, dynamicObservationReasonRedirectAllowed, authority)
+			releaseDynamicHops()
 			markDynamicResponse(resp, nil, expectedStructuredSource)
 			return resp, nil
 		}

--- a/request_logs.go
+++ b/request_logs.go
@@ -431,6 +431,10 @@ func (d *DB) writeRequestLogBatch(batch []queuedRequestLog) (int, error) {
 	return skipped, nil
 }
 
+// nodeRequestEventPendingLimit bounds unprocessed agent-event ledger rows;
+// it matches the Agent's own event spool capacity.
+const nodeRequestEventPendingLimit = 8192
+
 func pruneRequestLogsTx(tx *sql.Tx, now time.Time, retention time.Duration) error {
 	cutoffMS := now.Add(-retention).UnixMilli()
 	if _, err := tx.Exec("DELETE FROM request_logs WHERE recorded_at_ms<?", cutoffMS); err != nil {
@@ -439,11 +443,21 @@ func pruneRequestLogsTx(tx *sql.Tx, now time.Time, retention time.Duration) erro
 	if retention < 24*time.Hour {
 		retention = 24 * time.Hour
 	}
-	// The event ledger is only a replay/deduplication window. Keep pending
-	// (processed_at_ms=0) rows forever, but retire acknowledged identities after
-	// the request-log retention plus one extra day so an offline Agent can replay
-	// safely without allowing the table to grow without bound.
+	// The event ledger is only a replay/deduplication window. Retire
+	// acknowledged identities after the request-log retention plus one extra
+	// day so an offline Agent can replay safely without allowing the table to
+	// grow without bound.
 	if _, err := tx.Exec(`DELETE FROM node_request_events WHERE processed_at_ms>0 AND received_at_ms<?`, now.Add(-retention-24*time.Hour).UnixMilli()); err != nil {
+		return err
+	}
+	// Pending rows were previously kept forever. An event whose derived effect
+	// keeps failing would pin its row indefinitely, so cap the unprocessed
+	// ledger (the Agent spool is the authoritative redelivery source) and
+	// drop the oldest pending rows beyond the cap.
+	if _, err := tx.Exec(`DELETE FROM node_request_events WHERE processed_at_ms=0 AND (node_id, agent_boot_id, event_id) IN (
+		SELECT node_id, agent_boot_id, event_id FROM node_request_events WHERE processed_at_ms=0
+		ORDER BY received_at_ms ASC, node_id, agent_boot_id, event_id LIMIT -1 OFFSET ?
+	)`, nodeRequestEventPendingLimit); err != nil {
 		return err
 	}
 	_, err := tx.Exec(`

--- a/scripts/agent-install.sh
+++ b/scripts/agent-install.sh
@@ -133,8 +133,17 @@ Restart=always
 RestartSec=5
 NoNewPrivileges=true
 PrivateTmp=true
+PrivateDevices=true
 ProtectHome=true
 ProtectSystem=strict
+ProtectHostname=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
+RestrictRealtime=true
 ReadWritePaths=$state_dir $install_dir $token_dir
 
 [Install]

--- a/site_node_scheduler.go
+++ b/site_node_scheduler.go
@@ -1386,25 +1386,35 @@ func (c *cloudflareClient) dnsRecordByID(ctx context.Context, zoneID, recordID s
 	return cloudflareAddressRecord{ID: raw.ID, Type: raw.Type, Name: raw.Name, Content: raw.Content, Comment: raw.Comment}, nil
 }
 
+// maxCloudflareRecordPages bounds pagination of same-name record listings at
+// 20 pages x 100 records; beyond that the conflict scan degrades gracefully.
+const maxCloudflareRecordPages = 20
+
 func (c *cloudflareClient) exactAddressRecords(ctx context.Context, zoneID, name string) ([]cloudflareAddressRecord, error) {
-	result, err := c.request(ctx, http.MethodGet, "/zones/"+url.PathEscape(zoneID)+"/dns_records?name="+url.QueryEscape(name)+"&per_page=100", nil)
-	if err != nil {
-		return nil, err
-	}
-	var raw []struct {
-		ID      string `json:"id"`
-		Type    string `json:"type"`
-		Name    string `json:"name"`
-		Content string `json:"content"`
-		Comment string `json:"comment"`
-	}
-	if err := json.Unmarshal(result, &raw); err != nil {
-		return nil, errors.New("Cloudflare DNS returned invalid records")
-	}
-	values := make([]cloudflareAddressRecord, 0, len(raw))
-	for _, item := range raw {
-		if (item.Type == "A" || item.Type == "AAAA") && strings.EqualFold(item.Name, name) {
-			values = append(values, cloudflareAddressRecord{ID: item.ID, Type: item.Type, Name: item.Name, Content: item.Content, Comment: item.Comment})
+	query := "/zones/" + url.PathEscape(zoneID) + "/dns_records?name=" + url.QueryEscape(name) + "&per_page=100"
+	values := make([]cloudflareAddressRecord, 0, 8)
+	for page := 1; page <= maxCloudflareRecordPages; page++ {
+		result, info, err := c.requestWithInfo(ctx, http.MethodGet, query+"&page="+strconv.Itoa(page), nil)
+		if err != nil {
+			return nil, err
+		}
+		var raw []struct {
+			ID      string `json:"id"`
+			Type    string `json:"type"`
+			Name    string `json:"name"`
+			Content string `json:"content"`
+			Comment string `json:"comment"`
+		}
+		if err := json.Unmarshal(result, &raw); err != nil {
+			return nil, errors.New("Cloudflare DNS returned invalid records")
+		}
+		for _, item := range raw {
+			if (item.Type == "A" || item.Type == "AAAA") && strings.EqualFold(item.Name, name) {
+				values = append(values, cloudflareAddressRecord{ID: item.ID, Type: item.Type, Name: item.Name, Content: item.Content, Comment: item.Comment})
+			}
+		}
+		if len(raw) == 0 || info.TotalPages <= page {
+			break
 		}
 	}
 	return values, nil

--- a/site_repository.go
+++ b/site_repository.go
@@ -752,6 +752,11 @@ func (d *DB) DeleteSite(id int64) error {
 	if _, err := tx.Exec("DELETE FROM traffic_logs WHERE site_id=?", id); err != nil {
 		return err
 	}
+	// Foreign keys are not enforced by the SQLite DSN, so the node traffic
+	// ledger needs the same explicit cascade as traffic_logs above.
+	if _, err := tx.Exec("DELETE FROM node_site_traffic_logs WHERE site_id=?", id); err != nil {
+		return err
+	}
 	if _, err := tx.Exec("DELETE FROM dynamic_observations WHERE site_id=?", id); err != nil {
 		return err
 	}

--- a/site_routing.go
+++ b/site_routing.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -122,6 +123,15 @@ func applyUpstreamURL(requestURL, upstream *url.URL) {
 	requestURL.Scheme = upstream.Scheme
 	requestURL.Host = upstream.Host
 	requestURL.Path, requestURL.RawPath = joinURLPath(upstream, requestURL)
+	// Collapse dot segments so a request path like /prefix/../admin cannot
+	// escape the administrator-configured upstream base path on hosts that
+	// normalize before routing. Emby/Jellyfin never emit dot segments; if the
+	// join changed the path, the stale RawPath is discarded by EscapedPath's
+	// consistency check and the cleaned path is re-encoded.
+	if cleaned := cleanUpstreamDotSegments(requestURL.Path); cleaned != requestURL.Path {
+		requestURL.Path = cleaned
+		requestURL.RawPath = ""
+	}
 	switch {
 	case upstream.RawQuery == "":
 	case requestURL.RawQuery == "":
@@ -129,6 +139,23 @@ func applyUpstreamURL(requestURL, upstream *url.URL) {
 	default:
 		requestURL.RawQuery = upstream.RawQuery + "&" + requestURL.RawQuery
 	}
+}
+
+// cleanUpstreamDotSegments resolves . and .. segments in an already-rooted
+// URL path, preserving a trailing slash. Requests without dot segments are
+// returned unchanged.
+func cleanUpstreamDotSegments(p string) string {
+	if p == "" || !strings.Contains(p, "/.") {
+		return p
+	}
+	cleaned := path.Clean(p)
+	if cleaned == "." {
+		cleaned = "/"
+	}
+	if strings.HasSuffix(p, "/") && !strings.HasSuffix(cleaned, "/") {
+		cleaned += "/"
+	}
+	return cleaned
 }
 
 func normalizePublicHost(value string) (string, error) {

--- a/telemetry_writer.go
+++ b/telemetry_writer.go
@@ -121,6 +121,9 @@ func (d *DB) runDynamicObservationWriter() {
 				if err := d.pruneWatchHistory(); err != nil {
 					log.Printf("[watch-history] optional retention write failed: %v", err)
 				}
+				if err := d.pruneTrafficLogs(time.Now()); err != nil {
+					log.Printf("[traffic] optional retention write failed: %v", err)
+				}
 				continue
 			case <-inboxTicker.C:
 				d.drainWatchHistoryInbox(time.Now())

--- a/traffic_repository.go
+++ b/traffic_repository.go
@@ -472,3 +472,46 @@ func (d *DB) GetTrafficTrendLogsGroupedSnapshot(siteID *int64, start, end time.T
 	}
 	return logs, baselines, nil
 }
+
+// trafficLogRetention keeps minute-bucket rows for slightly longer than the
+// largest dashboard trend window (366 days) while bounding table growth.
+// Cycle and lifetime accounting live on the site/node rows and the persisted
+// baselines, not in these history tables.
+const trafficLogRetention = 400 * 24 * time.Hour
+
+// trafficLogPruneInterval throttles the retention sweep to once a day; the
+// DELETE is index-supported but still unnecessary work on every writer tick.
+const trafficLogPruneInterval = 24 * time.Hour
+
+// pruneTrafficLogs bounds traffic_logs and node_site_traffic_logs, which are
+// written once per site/node per minute and previously grew without limit —
+// eventually pushing the database past the backup size cap so exports failed
+// exactly when a backup was most needed.
+func (d *DB) pruneTrafficLogs(now time.Time) error {
+	last := d.lastTrafficPruneMS.Load()
+	if last != 0 && now.Sub(time.UnixMilli(last)) < trafficLogPruneInterval {
+		return nil
+	}
+	tx, err := d.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	cutoffMS := now.Add(-trafficLogRetention).UnixMilli()
+	if _, err := tx.Exec("DELETE FROM traffic_logs WHERE recorded_at_ms>0 AND recorded_at_ms<?", cutoffMS); err != nil {
+		return err
+	}
+	// Legacy rows written before recorded_at_ms existed only carry the
+	// DATETIME column and would otherwise be retained forever.
+	if _, err := tx.Exec("DELETE FROM traffic_logs WHERE recorded_at_ms=0 AND recorded_at<?", now.Add(-trafficLogRetention)); err != nil {
+		return err
+	}
+	if _, err := tx.Exec("DELETE FROM node_site_traffic_logs WHERE recorded_at_ms<?", cutoffMS); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	d.lastTrafficPruneMS.Store(now.UnixMilli())
+	return nil
+}


### PR DESCRIPTION
## 改动内容

本轮全方位审查（反代/重写引擎、备份恢复/持久化、面板/认证/TLS/ACME、前端/安装脚本四个方向）确认 7 个 P2 + 一批 P3，全部修复并附回归测试。前端 XSS/状态管理、CI 供应链、加密设计、认证核心经审查确认干净。

### 反代 / 动态调度
- **P2** roundTripDynamic 三处"客户端重定向"返回路径释放动态流槽位、authority 租约与 transport——此前每次泄漏一个站点流许可 + 一个 in-flight authority，累积后站点动态请求永久 503。
- **P2** committed authority 空闲 15 分钟后驱逐（本站 + 全局扫描），authority 表不再单调增长；全局扫描跳过调用方自身状态（修复我引入时的自死锁，已加防死锁回归测试）。
- **P2** PathRoute 确定性最长前缀选择，/emby 前缀站点不再与其他站点随机交替路由。
- **P3** 上游路径 join 后折叠 dot-segment，杜绝 /prefix/../admin 逃逸配置的上游基路径。

### 备份恢复
- **P2** 恢复回滚失败时保留回滚目录与标记（旧状态唯一副本），下次启动重试，不再静默销毁。
- **P2** traffic_logs/node_site_traffic_logs 400 天保留清理 + 站点删除级联节点流量台账——此前无界增长最终超过备份上限、导出静默失效。
- **P2** 临时 JWT 恢复防护扩展到 probe secret/观看 token/收件箱载荷（同为 JWT 派生密文）。
- **P2** 恢复上传读超时按 ContentLength 缩放（原 30 秒绝对超时使 <70Mbps 链路的 256MiB 恢复永久失败）。

### 面板 / 认证 / ACME
- **P3** ACME 共享锁获取后复查证书新鲜度，避免重复签发烧掉 CA 每周重复配额。
- **P3** 面板端口与站点专用端口冲突拒绝保存（原为必现重启崩溃循环）。
- **P3** logout 吊销服务端会话（原仅清 cookie，令牌可再用 72 小时）。
- **P3** panelCertificateManager.status 的磁盘 I/O/链链校验移出与 GetCertificate 共享的互斥锁。

### Agent / 遥测
- **P3** Cloudflare 记录列表完整翻页（原 100 条静默截断）；更新下载错误与校验和不匹配分开报告；Windows LockFileEx IO_PENDING 不再误判为"已有实例"；node_request_events 待处理台账上限 8192；实例替换时 TrafficUsed 基线读取加锁。

### 安装脚本 / 基础设施
- MERIDIAN_INSTALL_DIR 纳入安全路径校验；/home 数据目录时 ProtectHome 降为 read-only（原为必现装坏且报错误导）；purge 补 groupdel；agent 单元增加内核保护沙箱指令；.dockerignore 排除 scratch/规划目录。

## 改动类型

- [x] Bug 修复

## 验证方式

- [x] `go test ./...` / `go test -race ./...` 通过
- [x] `go vet ./...`（含 windows/darwin 交叉）
- [x] `govulncheck` 0；`gosec -severity medium -confidence medium` 0
- [x] `node --check` / `node --test` 176/176；`bash -n` 三脚本
- [x] 新增回归测试：PathRoute 确定性、dot-segment、流量保留+删除级联、DNS 翻页、面板端口冲突、authority 驱逐与全局扫描防死锁、pending 台账上限

## 影响范围

- [x] 反代引擎
- [x] 站点管理 API
- [x] 认证 / 登录
- [x] 流量计量
- [x] CI / Docker / 安装脚本

## 注意事项

- 全量测试在开发过程中两次捕获并修复了我引入的回归（旧库上索引先于列回填执行、全局驱逐自死锁），均已补防回归测试。
- 已评估暂缓项（收益/风险比不足，留待后续）：/api/agent/config 准入、failover 备线路 header 重放、307/308 POST body 回放、agent 非 root 化、SQLite foreign_keys、watch token 只写存储、Telegram/CF token 回显（按约定保持现状）。