### PR TITLE
fix: seventh-review remediation across installer, restore, and enforcement paths (v1.9.87)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,16 @@ jobs:
           bash -n install.sh
           bash -n scripts/agent-install.sh
           bash -n docker-entrypoint.sh
+
+      # The installer runs under `set -euo pipefail`; a reference to an unset
+      # environment variable in the defaults block breaks every default
+      # install at load time, and bash -n cannot catch it. Execute just the
+      # defaults block in a shell that matches the script's flags.
+      - name: Installer defaults survive unset environment variables
+        run: |
+          sed -n '1,31p' install.sh > /tmp/install-defaults.sh
+          echo 'echo "defaults-ok"' >> /tmp/install-defaults.sh
+          env -u MERIDIAN_DATA_DIR -u MERIDIAN_INSTALL_DIR -u MERIDIAN_BACKUP_DIR -u MERIDIAN_SERVICE_NAME -u MERIDIAN_ROOT_GROUP bash /tmp/install-defaults.sh | grep -q 'defaults-ok'
           bash -n tests/install_test.sh
           bash -n tests/docker_entrypoint_test.sh
           bash -n tests/upstream_header_key_test.sh

--- a/account_retention.go
+++ b/account_retention.go
@@ -188,12 +188,14 @@ func accountRetentionViewerKey(siteID int64, request *http.Request, trustedProxi
 	if identity == "" {
 		identity = "anonymous"
 	}
-	raw := strings.Join([]string{
-		strconv.FormatInt(siteID, 10),
-		identity,
-		requestClientKey(request, trustedProxies),
-		request.Header.Get("User-Agent"),
-	}, "\x00")
+	parts := []string{strconv.FormatInt(siteID, 10), identity}
+	if identity == "anonymous" {
+		// Only the anonymous fallback needs volatile client markers: a viewer
+		// holding a token or device identity must not fork retention sessions
+		// by rotating User-Agent or roaming between IPs.
+		parts = append(parts, requestClientKey(request, trustedProxies), request.Header.Get("User-Agent"))
+	}
+	raw := strings.Join(parts, "\x00")
 	digest := sha256.Sum256([]byte(raw))
 	return fmt.Sprintf("%x", digest[:])
 }

--- a/account_retention.go
+++ b/account_retention.go
@@ -138,13 +138,54 @@ type accountRetentionTracker struct {
 	database       *DB
 	sessions       map[string]*accountRetentionSession
 	cycleOverrides map[int64]int64
+	lastSweep      time.Time
 }
+
+// accountRetentionSessionLimit bounds the tracker's memory; identities
+// beyond the cap evict by oldest observation after expiry has been applied.
+const accountRetentionSessionLimit = 8192
+
+// accountRetentionSweepInterval throttles the expiry sweep: the hot path used
+// to scan every session on every playback-sync observation, which made the
+// aggregate O(N^2) under load.
+const accountRetentionSweepInterval = time.Minute
 
 func newAccountRetentionTracker(database *DB) *accountRetentionTracker {
 	return &accountRetentionTracker{
 		database:       database,
 		sessions:       make(map[string]*accountRetentionSession),
 		cycleOverrides: make(map[int64]int64),
+	}
+}
+
+// sweepLocked expires stale sessions and enforces the session cap. It runs at
+// most once per sweep interval (or immediately when the cap is reached) —
+// never on every observation.
+func (tracker *accountRetentionTracker) sweepLocked(now time.Time) {
+	tracker.lastSweep = now
+	for key, session := range tracker.sessions {
+		if now.Sub(session.LastObservedAt) > accountRetentionSessionTTL {
+			delete(tracker.sessions, key)
+		}
+	}
+	if len(tracker.sessions) < accountRetentionSessionLimit {
+		return
+	}
+	overflow := len(tracker.sessions) - accountRetentionSessionLimit
+	for overflow > 0 && len(tracker.sessions) > 0 {
+		var oldestKey string
+		var oldestSeen time.Time
+		found := false
+		for key, session := range tracker.sessions {
+			if !found || session.LastObservedAt.Before(oldestSeen) {
+				oldestKey, oldestSeen, found = key, session.LastObservedAt, true
+			}
+		}
+		if !found {
+			break
+		}
+		delete(tracker.sessions, oldestKey)
+		overflow--
 	}
 }
 
@@ -249,10 +290,8 @@ func (tracker *accountRetentionTracker) Observe(site Site, request *http.Request
 
 	tracker.mu.Lock()
 	defer tracker.mu.Unlock()
-	for sessionKey, session := range tracker.sessions {
-		if endedAt.Sub(session.LastObservedAt) > accountRetentionSessionTTL {
-			delete(tracker.sessions, sessionKey)
-		}
+	if len(tracker.sessions) >= accountRetentionSessionLimit || endedAt.Sub(tracker.lastSweep) >= accountRetentionSweepInterval {
+		tracker.sweepLocked(endedAt)
 	}
 	cycleStartedAtMS := site.AccountRetentionStartedMS
 	if override := tracker.cycleOverrides[site.ID]; override > cycleStartedAtMS {

--- a/app_core.go
+++ b/app_core.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -15,6 +16,7 @@ type App struct {
 	dbPath               string
 	pm                   *ProxyManager
 	backupMu             sync.Mutex
+	sseConnections       atomic.Int64
 	siteLifecycleMu      sync.Mutex
 	setupTokenMu         sync.Mutex
 	setupToken           string

--- a/app_http.go
+++ b/app_http.go
@@ -54,10 +54,16 @@ func (l *loginRateLimiter) pruneExpired(now time.Time) {
 	}
 }
 
-func (l *loginRateLimiter) evictLeastRecentlySeen() {
+func (l *loginRateLimiter) evictLeastRecentlySeen(now time.Time) bool {
 	var oldestClient string
 	var oldestSeen time.Time
 	for client, attempt := range l.attempts {
+		// Never evict an active lockout: an attacker flooding distinct client
+		// keys must not be able to squeeze out an entry that is currently
+		// blocking them.
+		if now.Before(attempt.blockedUntil) {
+			continue
+		}
 		seen := attempt.lastSeen
 		if seen.IsZero() {
 			seen = attempt.firstFailure
@@ -67,9 +73,13 @@ func (l *loginRateLimiter) evictLeastRecentlySeen() {
 			oldestSeen = seen
 		}
 	}
-	if oldestClient != "" {
-		delete(l.attempts, oldestClient)
+	if oldestClient == "" {
+		// Every entry is an active lockout: refuse to track a new key rather
+		// than discard someone's lockout.
+		return false
 	}
+	delete(l.attempts, oldestClient)
+	return true
 }
 
 func (l *loginRateLimiter) allow(client string, now time.Time) (bool, time.Duration) {
@@ -94,8 +104,10 @@ func (l *loginRateLimiter) recordFailure(client string, now time.Time) {
 	defer l.mu.Unlock()
 	l.pruneExpired(now)
 	attempt, exists := l.attempts[client]
-	if !exists && len(l.attempts) >= l.maxEntries {
-		l.evictLeastRecentlySeen()
+	if !exists && len(l.attempts) >= l.maxEntries && !l.evictLeastRecentlySeen(now) {
+		// The table is full of active lockouts; drop tracking for this new
+		// key instead of evicting a lockout.
+		return
 	}
 	if attempt.firstFailure.IsZero() || now.Sub(attempt.firstFailure) >= loginFailureWindow {
 		attempt = loginAttempt{firstFailure: now}
@@ -578,6 +590,13 @@ func (a *App) handleLogout(w http.ResponseWriter, r *http.Request) {
 	if userID, _, err := a.authenticatedSessionIdentity(r); err == nil {
 		if revokeErr := a.db.RevokeUserSessions(userID); revokeErr != nil {
 			log.Printf("[auth] logout session revocation failed: %v", revokeErr)
+			// The browser cookie is cleared either way, but the server-side
+			// session is still alive; reporting success here would hide a
+			// still-valid copied token from an operator who logged out
+			// precisely because they suspected one.
+			a.clearSessionCookie(w, r)
+			a.jsonErr(w, http.StatusInternalServerError, "logout failed: server session could not be revoked; the session token may still be valid")
+			return
 		}
 	}
 	a.clearSessionCookie(w, r)

--- a/app_traffic.go
+++ b/app_traffic.go
@@ -145,12 +145,23 @@ func (a *App) handleUAProfiles(w http.ResponseWriter, r *http.Request) {
 	a.jsonOK(w, profiles)
 }
 
+// maxSSEConnections bounds concurrent dashboard event streams. Each stream
+// holds a connection, a ticker and its own loop; the snapshots are shared, so
+// the cap exists purely to bound connection and goroutine fan-out.
+const maxSSEConnections = 16
+
 func (a *App) handleSSE(w http.ResponseWriter, r *http.Request) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		a.jsonErr(w, 500, "SSE not supported")
 		return
 	}
+	if a.sseConnections.Add(1) > maxSSEConnections {
+		a.sseConnections.Add(-1)
+		a.jsonErr(w, http.StatusServiceUnavailable, "too many dashboard event streams; close other dashboard tabs and retry")
+		return
+	}
+	defer a.sseConnections.Add(-1)
 
 	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache, no-transform")

--- a/backup_restore.go
+++ b/backup_restore.go
@@ -2496,9 +2496,14 @@ func applyPendingRestore(dbPath string) (*restoreAppliedState, error) {
 				log.Printf("恢复回滚失败，保留回滚目录与标记等待下次启动重试: %v", rollbackErr)
 				return
 			}
-			_ = os.Remove(dbPath + backupAppliedSuffix) // #nosec G703 G304 -- fixed restore marker suffix.
-			_ = os.RemoveAll(rollback)                  // #nosec G703 G304 -- fixed rollback suffix path.
-			_ = os.RemoveAll(pending)                   // #nosec G703 G304 -- fixed pending suffix path.
+			if markerErr := os.Remove(dbPath + backupAppliedSuffix); markerErr != nil && !errors.Is(markerErr, os.ErrNotExist) { // #nosec G703 G304 -- fixed restore marker suffix.
+				// Marker still present: keep the snapshot so the next startup
+				// retries with a complete rollback directory.
+				log.Printf("移除恢复标记失败，保留回滚目录等待下次启动重试: %v", markerErr)
+				return
+			}
+			_ = os.RemoveAll(rollback) // #nosec G703 G304 -- fixed rollback suffix path.
+			_ = os.RemoveAll(pending)  // #nosec G703 G304 -- fixed pending suffix path.
 		}
 	}()
 	for _, suffix := range []string{"", "-wal", "-shm"} {
@@ -2578,19 +2583,24 @@ func rollbackRestoreFiles(dbPath, rollback string) error {
 	if rollback == "" {
 		return errors.New("恢复回滚目录为空")
 	}
+	// Copy-based restore: os.Rename would consume the only rollback snapshot,
+	// so a failure after the first rename would leave the deployment with a
+	// half-moved database and no recovery copy. The rollback directory stays
+	// complete until the caller removes the applied marker; copyPrivateFile
+	// writes durably (temp file + fsync + rename + directory sync).
 	for _, suffix := range []string{"", "-wal", "-shm"} {
 		_ = os.Remove(dbPath + suffix) // #nosec G703 G304 -- fixed SQLite sidecar suffix.
 		source := filepath.Join(rollback, backupDatabaseEntry+suffix)
 		if _, err := os.Stat(source); err == nil { // #nosec G703 G304 -- source is the fixed rollback database entry.
-			if err := os.Rename(source, dbPath+suffix); err != nil {
-				return err
-			}
-			if err := syncDirectory(filepath.Dir(dbPath)); err != nil {
+			if err := copyPrivateFile(source, dbPath+suffix); err != nil {
 				return err
 			}
 		} else if suffix == "" {
 			return errors.New("恢复回滚副本缺少数据库")
 		}
+	}
+	if err := syncDirectory(filepath.Dir(dbPath)); err != nil {
+		return err
 	}
 	if restoreDirectoryIncludesTLS(rollback) {
 		if _, err := os.Stat(filepath.Join(rollback, "tls-namespace.json")); err == nil { // #nosec G703 -- rollback is the private fixed restore directory.
@@ -2629,8 +2639,13 @@ func rollbackAppliedRestore(dbPath string, state *restoreAppliedState) error {
 	if err := rollbackRestoreFiles(dbPath, state.RollbackDir); err != nil {
 		return err
 	}
-	_ = os.Remove(dbPath + backupAppliedSuffix) // #nosec G703 G304 -- fixed restore marker suffix.
-	return os.RemoveAll(state.RollbackDir)      // #nosec G703 G304 -- rollback directory was created by Meridian.
+	// Invariant: as long as the applied marker exists, the complete rollback
+	// snapshot must still exist. Remove the marker first and propagate its
+	// error; only then is it safe to discard the snapshot.
+	if err := os.Remove(dbPath + backupAppliedSuffix); err != nil && !errors.Is(err, os.ErrNotExist) { // #nosec G703 G304 -- fixed restore marker suffix.
+		return fmt.Errorf("移除恢复标记失败，保留回滚快照: %w", err)
+	}
+	return os.RemoveAll(state.RollbackDir) // #nosec G703 G304 -- rollback directory was created by Meridian.
 }
 
 func finalizeAppliedRestore(dbPath string) error {

--- a/backup_restore.go
+++ b/backup_restore.go
@@ -2455,8 +2455,14 @@ func applyPendingRestore(dbPath string) (*restoreAppliedState, error) {
 		if err := rollbackRestoreFiles(dbPath, rollback); err != nil {
 			return nil, fmt.Errorf("回滚上次未完成的恢复: %w", err)
 		}
-		_ = os.Remove(appliedMarker) // #nosec G703 G304 -- fixed suffix path derived from the configured database path.
-		_ = os.RemoveAll(rollback)   // #nosec G703 G304 -- fixed suffix path derived from the configured database path.
+		// Invariant: as long as the applied marker exists, the complete
+		// rollback snapshot must still exist. Remove the marker first and
+		// propagate its error; only then may the snapshot be discarded. A
+		// stale marker with a deleted snapshot would brick every later boot.
+		if err := os.Remove(appliedMarker); err != nil && !errors.Is(err, os.ErrNotExist) { // #nosec G703 G304 -- fixed suffix path derived from the configured database path.
+			return nil, fmt.Errorf("移除恢复标记失败，保留回滚快照: %w", err)
+		}
+		_ = os.RemoveAll(rollback) // #nosec G703 G304 -- fixed suffix path derived from the configured database path.
 		// A crash after the staged database was moved leaves an incomplete
 		// pending directory. The old installation is authoritative after the
 		// rollback; discard that stage instead of trying to apply it again.

--- a/dash_rewrite.go
+++ b/dash_rewrite.go
@@ -35,7 +35,7 @@ func dashFixedTemplateClaimMarker(index int) string {
 func sanitizeDASHTemplate(value string) (string, []dashTemplateMarker, error) {
 	const markerPrefix = dashTemplateMarkerPrefix
 	if value == "" || len(value) > maxDynamicTargetURLBytes || strings.Contains(value, markerPrefix) || strings.Contains(strings.ToLower(value), dashFixedTemplateClaimMarkerPrefix) || containsDynamicUnsafeRune(value) {
-		return "", nil, fmt.Errorf("invalid DASH URL template")
+		return "", nil, newDynamicPolicyDenialError(fmt.Errorf("invalid DASH URL template"))
 	}
 	markers := make([]dashTemplateMarker, 0, 4)
 	var output strings.Builder
@@ -112,7 +112,7 @@ func formatDASHFixedTemplateValue(expression string, bindings dashTemplateBindin
 func prepareDASHTemplateReferences(sanitized string, markers []dashTemplateMarker, bindings dashTemplateBindings) (string, string, []string, error) {
 	reference, err := url.Parse(sanitized)
 	if err != nil || reference.User != nil || reference.Fragment != "" || reference.RawFragment != "" || reference.Opaque != "" {
-		return "", "", nil, fmt.Errorf("invalid DASH URL template")
+		return "", "", nil, newDynamicPolicyDenialError(fmt.Errorf("invalid DASH URL template"))
 	}
 	validationText := sanitized
 	claimText := sanitized
@@ -216,7 +216,7 @@ func rewriteDASHTemplate(value string, base *url.URL, session *dynamicRewriteSes
 	validationReference, validationErr := url.Parse(validationText)
 	claimReference, claimErr := url.Parse(claimText)
 	if validationErr != nil || claimErr != nil || validationReference.User != nil || claimReference.User != nil || validationReference.Fragment != "" || claimReference.Fragment != "" || validationReference.RawFragment != "" || claimReference.RawFragment != "" || validationReference.Opaque != "" || claimReference.Opaque != "" {
-		return "", fmt.Errorf("invalid DASH URL template")
+		return "", newDynamicPolicyDenialError(fmt.Errorf("invalid DASH URL template"))
 	}
 	resolvedValidation := base.ResolveReference(validationReference)
 	resolvedClaim := base.ResolveReference(claimReference)
@@ -231,7 +231,7 @@ func rewriteDASHTemplate(value string, base *url.URL, session *dynamicRewriteSes
 		claimURL, claimErr = normalizeDynamicURL(resolvedClaim.String())
 	}
 	if validationErr != nil || claimErr != nil {
-		return "", fmt.Errorf("invalid DASH URL template")
+		return "", newDynamicPolicyDenialError(fmt.Errorf("invalid DASH URL template"))
 	}
 	claimTarget, expressions, err := restoreDASHTemplateClaimMarkers(claimURL.String(), markers)
 	if err != nil {
@@ -243,7 +243,7 @@ func rewriteDASHTemplate(value string, base *url.URL, session *dynamicRewriteSes
 	}
 	session.urlCount++
 	if session.urlCount > session.issuer.policy.limits.MaxURLsPerResponse {
-		return "", fmt.Errorf("discovered URL count exceeds its limit")
+		return "", newDynamicPolicyDenialError(fmt.Errorf("discovered URL count exceeds its limit"))
 	}
 	seenKey := "dash-template\x00" + strconv.FormatBool(configured) + "\x00" + claimTarget + "\x00" + strings.Join(expressions, "\x1f") + "\x00" + strings.Join(fixedValues, "\x1f")
 	if route, exists := session.seen[seenKey]; exists {
@@ -457,9 +457,9 @@ func rewriteDASHNode(node *dashXMLNode, inheritedBase *url.URL, inheritedAddress
 				return 0, err
 			}
 			reloadDepth := max(1, session.depth)
-			rewritten, err := session.rewriteAgainstSourceKindDepth(value, session.base, dynamicDiscoverySourceDASH, dynamicCapabilityKindManifest, reloadDepth)
+			rewritten, err := session.rewriteAgainstSourceKindDepthWithRequiredHeaders(value, session.base, dynamicDiscoverySourceDASH, dynamicCapabilityKindManifest, reloadDepth, nil)
 			if err != nil {
-				return 0, err
+				return 0, newDynamicPolicyDenialError(err)
 			}
 			setDASHNodeText(node, rewritten)
 		}

--- a/dash_xml.go
+++ b/dash_xml.go
@@ -209,16 +209,16 @@ func dashAttributeIndex(node *dashXMLNode, local string, extremeCompatibility bo
 
 func resolveDASHReference(base *url.URL, value string) (*url.URL, error) {
 	if base == nil || value == "" || value != strings.TrimSpace(value) || containsDynamicUnsafeRune(value) || strings.Contains(value, `\`) {
-		return nil, fmt.Errorf("invalid DASH URL")
+		return nil, newDynamicPolicyDenialError(fmt.Errorf("invalid DASH URL"))
 	}
 	reference, err := url.Parse(value)
 	if err != nil || reference.User != nil || reference.Fragment != "" || reference.RawFragment != "" {
-		return nil, fmt.Errorf("invalid DASH URL")
+		return nil, newDynamicPolicyDenialError(fmt.Errorf("invalid DASH URL"))
 	}
 	resolved := base.ResolveReference(reference)
 	resolved.Scheme = strings.ToLower(resolved.Scheme)
 	if resolved.Scheme != "http" && resolved.Scheme != "https" || resolved.Host == "" || resolved.User != nil {
-		return nil, fmt.Errorf("unsupported DASH URL")
+		return nil, newDynamicPolicyDenialError(fmt.Errorf("unsupported DASH URL"))
 	}
 	return resolved, nil
 }

--- a/database.go
+++ b/database.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"crypto/rand"
 	"database/sql"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log"
@@ -42,6 +44,7 @@ type DB struct {
 	agentSecurityMu             sync.Mutex
 	agentSecurityLastLog        map[string]time.Time
 	lastTrafficPruneMS          atomic.Int64
+	installUUID                 string
 	systemSettings              atomic.Pointer[SystemSettings]
 	nodeTLSMutationMu           sync.Mutex
 	watchHistoryMetadataMu      sync.Mutex
@@ -59,6 +62,10 @@ func openDB(path string) (*DB, error) {
 	sqlDB.SetMaxOpenConns(1)
 	d := &DB{db: sqlDB, dbPath: path, agentSecurityLastLog: make(map[string]time.Time), agentLive: make(map[nodeLiveTrafficKey]nodeLiveTrafficState)}
 	if err := d.migrate(); err != nil {
+		sqlDB.Close()
+		return nil, err
+	}
+	if err := d.ensureInstallationUUID(); err != nil {
 		sqlDB.Close()
 		return nil, err
 	}
@@ -131,4 +138,36 @@ func sqliteBool(value bool) int {
 		return 1
 	}
 	return 0
+}
+
+// ensureInstallationUUID loads or creates the random identity that scopes
+// Cloudflare DNS ownership markers to this Meridian installation, so two
+// controllers sharing one zone can never treat each other's records as their
+// own.
+func (d *DB) ensureInstallationUUID() error {
+	if d == nil || d.db == nil {
+		return errors.New("database is unavailable")
+	}
+	var value string
+	err := d.db.QueryRow("SELECT install_uuid FROM installation_meta WHERE id=1").Scan(&value)
+	if err == nil && strings.TrimSpace(value) != "" {
+		d.installUUID = strings.TrimSpace(value)
+		return nil
+	}
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	raw := make([]byte, 16)
+	if _, err := rand.Read(raw); err != nil {
+		return err
+	}
+	value = hex.EncodeToString(raw)
+	if _, err := d.db.Exec("INSERT OR IGNORE INTO installation_meta(id, install_uuid) VALUES(1,?)", value); err != nil {
+		return err
+	}
+	if err := d.db.QueryRow("SELECT install_uuid FROM installation_meta WHERE id=1").Scan(&value); err != nil {
+		return err
+	}
+	d.installUUID = strings.TrimSpace(value)
+	return nil
 }

--- a/database_migrations.go
+++ b/database_migrations.go
@@ -20,7 +20,7 @@ const (
 	// databaseSchemaVersion is independent from the application and backup
 	// format versions. It is persisted in SQLite so restores can reject a
 	// database whose columns/state are newer than this binary understands.
-	databaseSchemaVersion = 49
+	databaseSchemaVersion = 50
 )
 
 func (d *DB) migrate() error {
@@ -942,6 +942,12 @@ func (d *DB) migrateOnce() error {
 	);
 	CREATE INDEX IF NOT EXISTS idx_node_site_traffic_site_time ON node_site_traffic_logs(site_id, recorded_at_ms);
 	CREATE INDEX IF NOT EXISTS idx_node_site_traffic_node_time ON node_site_traffic_logs(node_id, recorded_at_ms);`); err != nil {
+		return err
+	}
+	if _, err := conn.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS installation_meta (
+		id INTEGER PRIMARY KEY CHECK (id=1),
+		install_uuid TEXT NOT NULL DEFAULT ''
+	)`); err != nil {
 		return err
 	}
 	if _, err := conn.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS watch_history_inbox (

--- a/dynamic_rewrite_core.go
+++ b/dynamic_rewrite_core.go
@@ -216,8 +216,28 @@ func normalizeTrustedCapabilityURL(value string) (*url.URL, error) {
 	return target, nil
 }
 
+// dynamicPolicyDenialError marks a rewrite failure as a security or policy
+// refusal (unsafe URL, userinfo, scheme, fragment, count/depth limits, mint
+// denial) rather than a format-compatibility problem. The upstream-preserve
+// fallback must fail closed on these: relaying the original payload would
+// hand the client raw absolute URLs the dynamic boundary refused to proxy.
+type dynamicPolicyDenialError struct{ reason string }
+
+func newDynamicPolicyDenialError(err error) *dynamicPolicyDenialError {
+	if err == nil {
+		return nil
+	}
+	return &dynamicPolicyDenialError{reason: err.Error()}
+}
+
+func (e *dynamicPolicyDenialError) Error() string { return e.reason }
+
 func (s *dynamicRewriteSession) rewriteAgainstKind(raw string, base *url.URL, kind string) (string, error) {
-	return s.rewriteAgainstSourceKind(raw, base, s.source, kind)
+	route, err := s.rewriteAgainstSourceKind(raw, base, s.source, kind)
+	if err != nil {
+		return route, newDynamicPolicyDenialError(err)
+	}
+	return route, nil
 }
 
 func (s *dynamicRewriteSession) rewriteAgainstSourceKind(raw string, base *url.URL, source, kind string) (string, error) {
@@ -824,8 +844,10 @@ func rewriteDynamicStructuredResponseAccepted(resp *http.Response, issuer *dynam
 		// for the whole site. PlaybackInfo keeps its own stricter chain: its
 		// denials (for example required headers on a relative URL that no
 		// capability could carry) must stay hard errors.
+		var denial *dynamicPolicyDenialError
 		if resp != nil && resp.Body != nil && resp.StatusCode < http.StatusBadRequest &&
-			(source == dynamicDiscoverySourceHLS || source == dynamicDiscoverySourceDASH) {
+			(source == dynamicDiscoverySourceHLS || source == dynamicDiscoverySourceDASH) &&
+			!errors.As(err, &denial) {
 			log.Printf("[%s] %s rewrite rejected; preserving upstream response: %v", issuer.site.Name, source, err)
 			issuer.observe(source, dynamicObservationDecisionDenied, dynamicStructuredRewriteDeniedReason(source), authority)
 			installDynamicStructuredBody(resp, payload, false)

--- a/edge_agent.go
+++ b/edge_agent.go
@@ -338,9 +338,12 @@ func (s *edgeEventStore) add(event NodeRequestEvent) error {
 				s.dropped++
 			}
 		} else {
+			// A dropped event does not change the queue contents, so it must
+			// not pay a synchronous whole-file rewrite: persisting the counter
+			// on the same debounce cadence keeps a full queue from degrading
+			// into per-event fsyncs under controller-outage load.
 			s.dropped++
-			s.lastPersist = time.Now()
-			return s.persistLocked()
+			return s.persistDebouncedLocked()
 		}
 	}
 	s.items = append(s.items, event)
@@ -360,8 +363,13 @@ func (s *edgeEventStore) persistDebouncedLocked() error {
 	if !s.lastPersist.IsZero() && now.Sub(s.lastPersist) < edgeEventPersistInterval {
 		return nil
 	}
+	// Stamp only after a successful write: a failed persist must not push the
+	// next retry two seconds out, and the error stays visible to add/ack.
+	if err := s.persistLocked(); err != nil {
+		return err
+	}
 	s.lastPersist = now
-	return s.persistLocked()
+	return nil
 }
 
 // flush performs a synchronous persist for shutdown paths where the
@@ -2562,8 +2570,14 @@ func edgeMaybeUpdate(ctx context.Context, client *http.Client, controller, token
 	if err := os.Rename(temporaryName, executable); err != nil {
 		return err
 	}
+	// The rename already committed the replacement: from here the on-disk
+	// binary is the new one, so a failed durability sync must NOT turn into a
+	// plain update error — the process would keep running the old code while
+	// the next digest check reads the new binary from disk and concludes no
+	// restart is needed. Surface the sync failure as a warning and still
+	// demand the restart.
 	if err := syncDirectory(filepath.Dir(executable)); err != nil {
-		return err
+		fmt.Fprintf(os.Stderr, "Meridian Agent update directory sync failed (replacement already applied): %v\n", err)
 	}
 	return errEdgeAgentUpdated
 }

--- a/edge_agent.go
+++ b/edge_agent.go
@@ -377,8 +377,11 @@ func (s *edgeEventStore) persistDebouncedLocked() error {
 func (s *edgeEventStore) flush() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if err := s.persistLocked(); err != nil {
+		return err
+	}
 	s.lastPersist = time.Now()
-	return s.persistLocked()
+	return nil
 }
 
 func (s *edgeEventStore) snapshot() []NodeRequestEvent {
@@ -420,8 +423,11 @@ func (s *edgeEventStore) ack(events []NodeRequestEvent) error {
 		}
 	}
 	s.items = kept
+	if err := s.persistLocked(); err != nil {
+		return err
+	}
 	s.lastPersist = time.Now()
-	return s.persistLocked()
+	return nil
 }
 
 type edgeSiteStats struct {

--- a/hardening_regression_test.go
+++ b/hardening_regression_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -41,22 +43,35 @@ func TestAgentInstanceLockRejectsSecondOwner(t *testing.T) {
 }
 
 func TestClassifyOwnedAddressRecordsDetectsContentChangesAndConflicts(t *testing.T) {
+	isOwned := func(comment string) bool { return siteDNSMarkerOwned(comment, 7, "test-install-uuid") }
 	owned, ok, unowned, ambiguous := classifyOwnedAddressRecords([]cloudflareAddressRecord{{
-		ID: "owned", Type: "A", Name: "site.example", Content: "198.51.100.2", Comment: "Meridian site=7",
-	}}, "site.example", "Meridian site=7")
+		ID: "owned", Type: "A", Name: "site.example", Content: "198.51.100.2", Comment: siteDNSOwnershipMarker(7, "test-install-uuid"),
+	}}, "site.example", isOwned)
 	if !ok || ambiguous || unowned != 0 || owned.ID != "owned" {
 		t.Fatalf("owned classification=%#v,%v,%d,%v", owned, ok, unowned, ambiguous)
 	}
+	// The legacy pre-UUID marker stays owned during the migration window.
+	if owned, ok, _, _ := classifyOwnedAddressRecords([]cloudflareAddressRecord{{
+		ID: "legacy", Type: "A", Name: "site.example", Content: "198.51.100.2", Comment: legacySiteDNSOwnershipMarker(7),
+	}}, "site.example", isOwned); !ok || owned.ID != "legacy" {
+		t.Fatalf("legacy marker not classified as owned: ok=%v owned=%#v", ok, owned)
+	}
+	// A different installation's scoped marker is NOT ours.
+	if _, ok, unowned, _ := classifyOwnedAddressRecords([]cloudflareAddressRecord{{
+		ID: "other", Type: "A", Name: "site.example", Content: "198.51.100.2", Comment: siteDNSOwnershipMarker(7, "another-install"),
+	}}, "site.example", isOwned); ok || unowned != 1 {
+		t.Fatalf("foreign controller marker classified as owned: ok=%v unowned=%d", ok, unowned)
+	}
 	_, ok, unowned, ambiguous = classifyOwnedAddressRecords([]cloudflareAddressRecord{{
 		ID: "operator", Type: "A", Name: "site.example", Content: "198.51.100.2",
-	}}, "site.example", "Meridian site=7")
+	}}, "site.example", isOwned)
 	if ok || ambiguous || unowned != 1 {
 		t.Fatalf("unowned classification ok=%v unowned=%d ambiguous=%v", ok, unowned, ambiguous)
 	}
 	_, ok, unowned, ambiguous = classifyOwnedAddressRecords([]cloudflareAddressRecord{
-		{ID: "one", Type: "A", Name: "site.example", Comment: "Meridian site=7"},
-		{ID: "two", Type: "A", Name: "site.example", Comment: "Meridian site=7"},
-	}, "site.example", "Meridian site=7")
+		{ID: "one", Type: "A", Name: "site.example", Comment: siteDNSOwnershipMarker(7, "test-install-uuid")},
+		{ID: "two", Type: "A", Name: "site.example", Comment: legacySiteDNSOwnershipMarker(7)},
+	}, "site.example", isOwned)
 	if ok || !ambiguous || unowned != 0 {
 		t.Fatalf("ambiguous classification ok=%v unowned=%d ambiguous=%v", ok, unowned, ambiguous)
 	}
@@ -253,6 +268,7 @@ func TestDeleteTrackedSiteDNSRemoteVerifiesOwnership(t *testing.T) {
 		return `{"success":true,"result":{"id":"` + id + `","type":"` + recordType + `","name":"` + name + `","content":"` + content + `","comment":"` + comment + `"}}`
 	}
 	schedule := SiteNodeSchedule{SiteID: 7, PublicHost: "site.example", cfZoneID: "zone-1", cfRecordID: "rec-1"}
+	marker := siteDNSOwnershipMarker(7, "test-install-uuid")
 	cases := []struct {
 		name       string
 		body       string
@@ -260,7 +276,9 @@ func TestDeleteTrackedSiteDNSRemoteVerifiesOwnership(t *testing.T) {
 		wantErr    string
 		wantDelete bool
 	}{
-		{name: "owned record is deleted", body: recordJSON("rec-1", "A", "site.example", "203.0.113.5", "Meridian site=7"), status: http.StatusOK, wantDelete: true},
+		{name: "owned record is deleted", body: recordJSON("rec-1", "A", "site.example", "203.0.113.5", marker), status: http.StatusOK, wantDelete: true},
+		{name: "legacy marker is deleted", body: recordJSON("rec-1", "A", "site.example", "203.0.113.5", legacySiteDNSOwnershipMarker(7)), status: http.StatusOK, wantDelete: true},
+		{name: "foreign controller marker refuses delete", body: recordJSON("rec-1", "A", "site.example", "203.0.113.5", siteDNSOwnershipMarker(7, "another-install")), status: http.StatusOK, wantErr: "refusing to delete"},
 		{name: "operator-edited comment refuses delete", body: recordJSON("rec-1", "A", "site.example", "203.0.113.5", ""), status: http.StatusOK, wantErr: "refusing to delete"},
 		// A record whose host no longer matches the site still carries the
 		// ownership marker and record ID, so cleanup may proceed: refusing it
@@ -281,7 +299,7 @@ func TestDeleteTrackedSiteDNSRemoteVerifiesOwnership(t *testing.T) {
 				_, _ = w.Write([]byte(testCase.body))
 			}))
 			defer server.Close()
-			cf := &cloudflareClient{token: "test", httpClient: server.Client(), apiBase: server.URL}
+			cf := &cloudflareClient{token: "test", httpClient: server.Client(), apiBase: server.URL, installUUID: "test-install-uuid"}
 			err := deleteTrackedSiteDNSRemote(context.Background(), cf, schedule)
 			if testCase.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), testCase.wantErr) {
@@ -323,11 +341,11 @@ func TestRecreateReplacedDNSRecordRestoresPreimage(t *testing.T) {
 	}))
 	defer server.Close()
 	cf := &cloudflareClient{token: "test", httpClient: server.Client(), apiBase: server.URL}
-	previous := cloudflareAddressRecord{ID: "old", Type: "A", Name: "site.example", Content: "203.0.113.5", Comment: "Meridian site=7"}
+	previous := cloudflareAddressRecord{ID: "old", Type: "A", Name: "site.example", Content: "203.0.113.5", Comment: siteDNSOwnershipMarker(7, "test-install-uuid")}
 	if err := recreateReplacedDNSRecordBestEffort(context.Background(), cf, "zone-1", previous); err != nil {
 		t.Fatalf("recreate: %v", err)
 	}
-	if payload.Type != "A" || payload.Name != "site.example" || payload.Content != "203.0.113.5" || payload.Comment != "Meridian site=7" {
+	if payload.Type != "A" || payload.Name != "site.example" || payload.Content != "203.0.113.5" || payload.Comment != siteDNSOwnershipMarker(7, "test-install-uuid") {
 		t.Fatalf("restore payload=%+v, want the deleted record preimage", payload)
 	}
 }
@@ -566,7 +584,6 @@ func TestNodeRequestEventPendingLedgerIsCapped(t *testing.T) {
 	}
 }
 
-
 func TestAgentConfigHashKeepsPreV1986SiteWireCompatibility(t *testing.T) {
 	config := AgentRuntimeConfig{
 		SchemaVersion: agentConfigSchemaVersion,
@@ -640,9 +657,9 @@ func TestQuotaLimitedWriterAbortsPastQuota(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	writer := &quotaLimitedWriter{
 		meteredWriter: meteredWriter{ResponseWriter: recorder, written: inst.trafficBytesOut(), cumulative: inst.trafficCumulativeOut()},
-		pm:    pm,
-		inst:  inst,
-		quota: 1024,
+		pm:            pm,
+		inst:          inst,
+		quota:         1024,
 	}
 	payload := make([]byte, quotaCheckBytes+1)
 	_, err = writer.Write(payload)
@@ -671,5 +688,65 @@ func TestDynamicPreserveStripsStaleContentEncoding(t *testing.T) {
 	installDynamicStructuredBody(resp, []byte("#EXTM3U\n#rewritten\n"), true)
 	if got := resp.Header.Get("ETag"); got != "" {
 		t.Fatal("rewritten response kept a stale ETag validator")
+	}
+}
+
+func TestHLSRewriteDenialsFailClosedUnderPreserveFallback(t *testing.T) {
+	// Policy denials (userinfo, scheme, fragment) must remain hard errors even
+	// though format-compatibility failures now preserve the upstream manifest.
+	if newDynamicPolicyDenialError(fmt.Errorf("x")) == nil {
+		t.Fatal("denial constructor returned nil")
+	}
+	wrapped := newDynamicPolicyDenialError(fmt.Errorf("discovered URL: userinfo"))
+	var decoded *dynamicPolicyDenialError
+	if !errors.As(error(wrapped), &decoded) {
+		t.Fatal("errors.As does not unwrap the denial")
+	}
+	session := &dynamicRewriteSession{ctx: context.Background(), base: mustStructuredURL(t, "https://api.example.com/live/master.m3u8"), source: dynamicDiscoverySourceHLS}
+	issuer := &dynamicCapabilityIssuer{key: make([]byte, 32), siteID: 1, policyRevision: 1, policy: dynamicRedirectPolicy{limits: dynamicDefaultProfileLimits()}, state: newDynamicSiteState(newDynamicRuntime(), dynamicDefaultProfileLimits())}
+	session.issuer = issuer
+	if _, err := rewriteHLSURIKind("http://user:pass@cdn.example.com/video.ts", session, dynamicCapabilityKindResource); err == nil {
+		t.Fatal("userinfo URI was accepted")
+	} else if !errors.As(err, &decoded) {
+		t.Fatalf("userinfo denial not typed: %v", err)
+	}
+	if _, err := rewriteHLSURIKind("ftp://cdn.example.com/video.ts", session, dynamicCapabilityKindResource); err == nil || !errors.As(err, &decoded) {
+		t.Fatalf("scheme denial not typed: %v", err)
+	}
+	if _, err := rewriteHLSURIKind("https://cdn.example.com/video.ts#frag", session, dynamicCapabilityKindResource); err == nil || !errors.As(err, &decoded) {
+		t.Fatalf("fragment denial not typed: %v", err)
+	}
+}
+
+func TestSaturatingAddInt64DoesNotWrap(t *testing.T) {
+	if got := saturatingAddInt64(math.MaxInt64, 1); got != math.MaxInt64 {
+		t.Fatalf("overflow wrapped: %d", got)
+	}
+	if got := saturatingAddInt64(math.MaxInt64-5, 10); got != math.MaxInt64 {
+		t.Fatalf("partial overflow wrapped: %d", got)
+	}
+	if got := saturatingAddInt64(100, 200); got != 300 {
+		t.Fatalf("normal add broken: %d", got)
+	}
+	if got := saturatingAddInt64(math.MinInt64, -1); got != math.MinInt64 {
+		t.Fatalf("underflow wrapped: %d", got)
+	}
+}
+
+func TestQuotaProbeSharedBoundedToOneCheck(t *testing.T) {
+	inst := &ProxyInstance{}
+	if quotaProbeShared(nil, 100) {
+		t.Fatal("nil instance must not probe")
+	}
+	first := inst.quotaCheckSince.Add(quotaCheckBytes - 1)
+	_ = first
+	if !quotaProbeShared(inst, 1) {
+		t.Fatal("crossing the threshold must claim the probe")
+	}
+	if inst.quotaCheckSince.Load() != 0 {
+		t.Fatalf("probe did not reset the accumulator: %d", inst.quotaCheckSince.Load())
+	}
+	if quotaProbeShared(inst, 10) {
+		t.Fatal("small follow-up must not probe")
 	}
 }

--- a/hls_rewrite.go
+++ b/hls_rewrite.go
@@ -165,7 +165,7 @@ func validateHLSURIAttributes(tag, value string, attributes []hlsAttributeSpan) 
 		}
 		reference, err := url.Parse(uri)
 		if err != nil || reference.IsAbs() || reference.Host != "" {
-			return fmt.Errorf("HLS rendition report URI must be relative")
+			return newDynamicPolicyDenialError(fmt.Errorf("HLS rendition report URI must be relative"))
 		}
 		return nil
 	case "#EXT-X-DATERANGE":
@@ -177,17 +177,17 @@ func validateHLSURIAttributes(tag, value string, attributes []hlsAttributeSpan) 
 
 func rewriteHLSURIKind(value string, session *dynamicRewriteSession, kind string) (string, error) {
 	if value == "" || value != strings.TrimSpace(value) || containsDynamicUnsafeRune(value) || strings.Contains(value, `\`) {
-		return "", fmt.Errorf("invalid HLS URI")
+		return "", newDynamicPolicyDenialError(fmt.Errorf("invalid HLS URI"))
 	}
 	if strings.Contains(value, "{$") {
-		return "", fmt.Errorf("HLS variable substitution is unsupported")
+		return "", newDynamicPolicyDenialError(fmt.Errorf("HLS variable substitution is unsupported"))
 	}
 	parsed, err := url.Parse(value)
 	if err != nil || parsed.Fragment != "" || parsed.RawFragment != "" {
-		return "", fmt.Errorf("invalid HLS URI")
+		return "", newDynamicPolicyDenialError(fmt.Errorf("invalid HLS URI"))
 	}
 	if parsed.Scheme != "" && !strings.EqualFold(parsed.Scheme, "http") && !strings.EqualFold(parsed.Scheme, "https") {
-		return "", fmt.Errorf("unsupported HLS URI scheme")
+		return "", newDynamicPolicyDenialError(fmt.Errorf("unsupported HLS URI scheme"))
 	}
 	return session.rewriteAgainstKind(value, session.base, kind)
 }

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ SYSTEMD_RESTRICT_ADDRESS_FAMILIES="AF_UNIX AF_INET AF_INET6 AF_NETLINK"
 # A data directory under /home cannot coexist with ProtectHome=true: systemd
 # would hide it from the sandboxed service and the install would fail its
 # health check with a misleading error. Allow read-only protection instead.
-case "$MERIDIAN_DATA_DIR" in
+case "$DATA_DIR" in
     /home/*) SYSTEMD_PROTECT_HOME="read-only" ;;
     *) SYSTEMD_PROTECT_HOME="true" ;;
 esac

--- a/node_repository.go
+++ b/node_repository.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"math"
 	"crypto/rand"
 	"crypto/sha256"
 	"database/sql"
@@ -496,7 +497,7 @@ func scanControlNode(scanner rowScanner, now time.Time) (ControlNode, error) {
 		node.Status = "pending"
 	}
 	if node.BillingMode == "bidirectional" {
-		node.TrafficUsed = node.PeriodRXBytes + node.PeriodTXBytes
+		node.TrafficUsed = saturatingAddInt64(node.PeriodRXBytes, node.PeriodTXBytes)
 	} else {
 		node.TrafficUsed = node.PeriodTXBytes
 	}
@@ -1627,6 +1628,19 @@ func claimAgentLeaseTx(tx *sql.Tx, nodeID int64, sessionID string, sessionEpoch 
 		return "", err
 	}
 	return newLease, nil
+}
+
+// saturatingAddInt64 adds two byte counters without wrapping: a counter that
+// reaches the int64 ceiling must read as the ceiling, not wrap negative and
+// get zeroed by downstream clamp-to-zero logic.
+func saturatingAddInt64(a, b int64) int64 {
+	if b > 0 && a > math.MaxInt64-b {
+		return math.MaxInt64
+	}
+	if b < 0 && a < math.MinInt64-b {
+		return math.MinInt64
+	}
+	return a + b
 }
 
 func (d *DB) recordNodeReportCommit(agentToken string, report NodeReport, now time.Time) (nodeReportCommitResult, error) {

--- a/node_repository.go
+++ b/node_repository.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"math"
 	"crypto/rand"
 	"crypto/sha256"
 	"database/sql"
@@ -11,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"net/http"
 	"net/url"
 	"sort"

--- a/panel_acme.go
+++ b/panel_acme.go
@@ -417,6 +417,9 @@ type cloudflareClient struct {
 	token      string
 	httpClient *http.Client
 	apiBase    string
+	// installUUID scopes DNS ownership markers to one Meridian installation;
+	// empty means the pre-scoped legacy marker.
+	installUUID string
 }
 
 type cloudflareResponse struct {

--- a/proxy_io.go
+++ b/proxy_io.go
@@ -58,33 +58,68 @@ func (m *meteredWriter) Write(b []byte) (int, error) {
 	return n, err
 }
 
-// quotaLimitedWriter aborts a streaming response once the site's billing-cycle
-// usage crosses its quota. The admission check only guards request start; a
-// single long-lived stream admitted just under the quota could otherwise
-// transfer unboundedly past it. The usage probe runs at most once per
-// quotaCheckBytes to bound its cost, and never while the handler holds the
-// instance traffic lock.
-type quotaLimitedWriter struct {
-	meteredWriter
-	pm         *ProxyManager
-	inst       *ProxyInstance
-	quota      int64
-	sinceCheck int64
+// quotaCheckBytes bounds how often the site-wide mid-stream quota probe runs.
+const quotaCheckBytes = 16 << 20
+
+// errTrafficQuotaExceeded aborts request bodies and tunnel transfers whose
+// site has crossed its billing quota; it is not exposed to clients.
+var errTrafficQuotaExceeded = errors.New("traffic quota exceeded")
+
+// quotaProbeShared records bytes against the instance-wide probe accumulator
+// and reports whether the caller must run the quota check now. The first
+// stream to cross the threshold claims the check.
+func quotaProbeShared(inst *ProxyInstance, n int64) bool {
+	if inst == nil || n <= 0 {
+		return false
+	}
+	return inst.quotaCheckSince.Add(n) >= quotaCheckBytes && inst.quotaCheckSince.Swap(0) >= 0
 }
 
-const quotaCheckBytes = 16 << 20
+// quotaLimitedWriter aborts a streaming response once the site's billing-cycle
+// usage crosses its quota. The probe uses the instance-wide byte accumulator
+// shared by every concurrent stream, request body and tunnel, so the
+// undetected overshoot is bounded by ~quotaCheckBytes of aggregate traffic
+// rather than per-stream windows.
+type quotaLimitedWriter struct {
+	meteredWriter
+	pm    *ProxyManager
+	inst  *ProxyInstance
+	quota int64
+}
 
 func (q *quotaLimitedWriter) Write(b []byte) (int, error) {
 	n, err := q.meteredWriter.Write(b)
-	q.sinceCheck += int64(n)
-	if q.sinceCheck < quotaCheckBytes {
+	if err != nil {
 		return n, err
 	}
-	q.sinceCheck = 0
-	if usage, usageErr := q.pm.currentTrafficCycleUsage(q.inst, time.Now()); usageErr == nil && usage >= q.quota {
-		return n, http.ErrAbortHandler
+	if quotaProbeShared(q.inst, int64(n)) {
+		if usage, usageErr := q.pm.currentTrafficCycleUsage(q.inst, time.Now()); usageErr == nil && usage >= q.quota {
+			return n, http.ErrAbortHandler
+		}
 	}
 	return n, err
+}
+
+// quotaLimitedReader aborts an upload body once the site crosses its quota;
+// bidirectional billing must not admit an unbounded POST after admission.
+type quotaLimitedReader struct {
+	meteredReader
+	pm    *ProxyManager
+	inst  *ProxyInstance
+	quota int64
+}
+
+func (q *quotaLimitedReader) Read(p []byte) (int, error) {
+	n, err := q.meteredReader.Read(p)
+	if err != nil {
+		return n, err
+	}
+	if quotaProbeShared(q.inst, int64(n)) {
+		if usage, usageErr := q.pm.currentTrafficCycleUsage(q.inst, time.Now()); usageErr == nil && usage >= q.quota {
+			return n, errTrafficQuotaExceeded
+		}
+	}
+	return n, nil
 }
 
 // Flush support for streaming
@@ -193,12 +228,27 @@ type tunnelWriter struct {
 	bytesPerSec int64
 	written     int64
 	start       time.Time
+	quota       *quotaTunnelProbe
+}
+
+// quotaTunnelProbe lets a WebSocket tunnel share the site-wide quota
+// checkpoint: a long-lived connection must stop transferring once its site
+// is over quota, exactly like the HTTP response path.
+type quotaTunnelProbe struct {
+	pm    *ProxyManager
+	inst  *ProxyInstance
+	limit int64
 }
 
 func (t *tunnelWriter) Write(b []byte) (int, error) {
 	if t.bytesPerSec <= 0 {
 		n, err := t.dst.Write(b)
 		addMeteredBytes(t.counter, t.cumulative, n)
+		if err == nil && n > 0 && t.quota != nil && quotaProbeShared(t.quota.inst, int64(n)) {
+			if usage, usageErr := t.quota.pm.currentTrafficCycleUsage(t.quota.inst, time.Now()); usageErr == nil && usage >= t.quota.limit {
+				return n, errTrafficQuotaExceeded
+			}
+		}
 		return n, err
 	}
 	total := 0
@@ -226,6 +276,11 @@ func (t *tunnelWriter) Write(b []byte) (int, error) {
 		}
 		if n == 0 {
 			return total, io.ErrNoProgress
+		}
+		if t.quota != nil && quotaProbeShared(t.quota.inst, int64(n)) {
+			if usage, usageErr := t.quota.pm.currentTrafficCycleUsage(t.quota.inst, time.Now()); usageErr == nil && usage >= t.quota.limit {
+				return total, errTrafficQuotaExceeded
+			}
 		}
 	}
 	return total, nil

--- a/proxy_manager.go
+++ b/proxy_manager.go
@@ -53,6 +53,11 @@ type ProxyInstance struct {
 	// local instances (no Agent runtime counter). The dashboard trend snapshot
 	// uses it to detect a flush that raced its SQLite history read.
 	trafficGeneration         atomic.Uint64
+	// quotaCheckSince is the site-wide byte accumulator for mid-stream quota
+	// probes: writers and readers across all concurrent streams share it, so
+	// the first stream to push it past quotaCheckBytes performs one shared
+	// check instead of each stream maintaining its own 16 MiB blind spot.
+	quotaCheckSince           atomic.Int64
 	trafficCycleStart         time.Time
 	trafficCycleMode          string
 	trafficCycleUsage         int64

--- a/proxy_start.go
+++ b/proxy_start.go
@@ -431,7 +431,7 @@ func (pm *ProxyManager) StartSite(site Site) error {
 			if isRedirectMode {
 				wsTarget = target
 			}
-			handleWebSocket(w, r, wsTarget, target, policy, inst, speedLimitBytes, configuredHeaders)
+			handleWebSocket(w, r, wsTarget, target, policy, inst, speedLimitBytes, pm, trafficQuota, configuredHeaders)
 			return
 		}
 
@@ -459,7 +459,11 @@ func (pm *ProxyManager) StartSite(site Site) error {
 		}
 
 		if r.Body != nil {
-			r.Body = &meteredReader{ReadCloser: r.Body, read: inst.trafficBytesIn(), cumulative: inst.trafficCumulativeIn()}
+			if trafficQuota > 0 {
+				r.Body = &quotaLimitedReader{meteredReader: meteredReader{ReadCloser: r.Body, read: inst.trafficBytesIn(), cumulative: inst.trafficCumulativeIn()}, pm: pm, inst: inst, quota: trafficQuota}
+			} else {
+				r.Body = &meteredReader{ReadCloser: r.Body, read: inst.trafficBytesIn(), cumulative: inst.trafficCumulativeIn()}
+			}
 		}
 		if len(failoverTargets) > 1 {
 			if err := prepareFailoverPlaybackInfoBody(r, redirectPolicy.limits.MaxBodyBytes); err != nil {

--- a/site_node_scheduler.go
+++ b/site_node_scheduler.go
@@ -1575,7 +1575,7 @@ func (a *App) cloudflareForScheduling() (*cloudflareClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &cloudflareClient{token: token, httpClient: &http.Client{Timeout: 15 * time.Second}, apiBase: "https://api.cloudflare.com/client/v4"}, nil
+	return &cloudflareClient{token: token, httpClient: &http.Client{Timeout: 15 * time.Second}, apiBase: "https://api.cloudflare.com/client/v4", installUUID: a.db.installUUID}, nil
 }
 
 type cloudflareAddressRecord struct{ ID, Type, Name, Content, Comment string }
@@ -1628,6 +1628,12 @@ func (c *cloudflareClient) exactAddressRecords(ctx context.Context, zoneID, name
 		if len(raw) == 0 || info.TotalPages <= page {
 			break
 		}
+		if info.TotalPages > maxCloudflareRecordPages {
+			// A truncated listing must never feed ownership or conflict
+			// decisions: refuse the whole scan instead of judging a partial
+			// set.
+			return nil, fmt.Errorf("Cloudflare returned %d pages of DNS records; ownership scan supports at most %d", info.TotalPages, maxCloudflareRecordPages)
+		}
 	}
 	return values, nil
 }
@@ -1673,13 +1679,29 @@ func ownedAddressRecord(records []cloudflareAddressRecord, recordType, name, add
 // caller. Any unowned exact record is a hard conflict because Cloudflare would
 // otherwise round-robin traffic between an operator record and Meridian's.
 // siteDNSOwnershipMarker is the Cloudflare comment that marks an address
-// record as owned by this Meridian instance for one site. Create, adopt,
-// update and delete paths must all verify against this exact value.
-func siteDNSOwnershipMarker(siteID int64) string {
+// record as owned by this Meridian installation for one site. The
+// installation UUID keeps two controllers sharing one zone from treating
+// each other's records as their own. Create, adopt, update and delete paths
+// must all verify against this exact value.
+func siteDNSOwnershipMarker(siteID int64, installUUID string) string {
+	return fmt.Sprintf("Meridian controller=%s site=%d", installUUID, siteID)
+}
+
+// legacySiteDNSOwnershipMarker is the pre-installation-UUID marker. Records
+// carrying it are still accepted as owned during the transition; the next
+// reconcile PUT rewrites the comment to the scoped marker.
+func legacySiteDNSOwnershipMarker(siteID int64) string {
 	return fmt.Sprintf("Meridian site=%d", siteID)
 }
 
-func classifyOwnedAddressRecords(records []cloudflareAddressRecord, name, marker string) (cloudflareAddressRecord, bool, int, bool) {
+// siteDNSMarkerOwned reports whether a record comment proves ownership by
+// this installation for the given site.
+func siteDNSMarkerOwned(comment string, siteID int64, installUUID string) bool {
+	trimmed := strings.TrimSpace(comment)
+	return trimmed == siteDNSOwnershipMarker(siteID, installUUID) || trimmed == legacySiteDNSOwnershipMarker(siteID)
+}
+
+func classifyOwnedAddressRecords(records []cloudflareAddressRecord, name string, marker func(string) bool) (cloudflareAddressRecord, bool, int, bool) {
 	var owned cloudflareAddressRecord
 	ownedCount := 0
 	unownedCount := 0
@@ -1687,7 +1709,7 @@ func classifyOwnedAddressRecords(records []cloudflareAddressRecord, name, marker
 		if (record.Type != "A" && record.Type != "AAAA") || !strings.EqualFold(record.Name, name) {
 			continue
 		}
-		if strings.TrimSpace(record.Comment) == marker {
+		if marker(strings.TrimSpace(record.Comment)) {
 			owned = record
 			ownedCount++
 		} else {
@@ -1875,7 +1897,7 @@ func verifyTrackedSiteDNSOwnership(ctx context.Context, cf *cloudflareClient, sc
 	// renamed after the record was created, and refusing the delete then would
 	// wedge cleanup and site deletion forever on a record Meridian still owns.
 	if (record.Type != "A" && record.Type != "AAAA") ||
-		strings.TrimSpace(record.Comment) != siteDNSOwnershipMarker(schedule.SiteID) {
+		!siteDNSMarkerOwned(record.Comment, schedule.SiteID, cf.installUUID) {
 		return errors.New("tracked DNS record no longer carries the Meridian ownership marker; refusing to delete")
 	}
 	return nil
@@ -2083,7 +2105,10 @@ func (a *App) reconcileOneSiteScheduleLocked(ctx context.Context, schedule SiteN
 			return err
 		}
 	}
-	marker := siteDNSOwnershipMarker(schedule.SiteID)
+	marker := siteDNSOwnershipMarker(schedule.SiteID, a.db.installUUID)
+	isOwnedComment := func(comment string) bool {
+		return siteDNSMarkerOwned(comment, schedule.SiteID, a.db.installUUID)
+	}
 	trackedRecordID := strings.TrimSpace(schedule.cfRecordID)
 	recordID := trackedRecordID
 	dnsRecordCreated := false
@@ -2113,7 +2138,7 @@ func (a *App) reconcileOneSiteScheduleLocked(ctx context.Context, schedule SiteN
 			return err
 		}
 		if len(records) > 0 {
-			owned, ok, unowned, ambiguous := classifyOwnedAddressRecords(records, schedule.PublicHost, marker)
+			owned, ok, unowned, ambiguous := classifyOwnedAddressRecords(records, schedule.PublicHost, isOwnedComment)
 			if ambiguous {
 				return errors.New("multiple Meridian DNS records match this site; manual cleanup required")
 			}
@@ -2148,7 +2173,7 @@ func (a *App) reconcileOneSiteScheduleLocked(ctx context.Context, schedule SiteN
 		// record even when the response was lost. Re-read exact records and
 		// adopt only a uniquely matching Meridian marker.
 		if records, getErr := cf.exactAddressRecords(ctx, zoneID, schedule.PublicHost); getErr == nil {
-			owned, ok, unowned, ambiguous := classifyOwnedAddressRecords(records, schedule.PublicHost, marker)
+			owned, ok, unowned, ambiguous := classifyOwnedAddressRecords(records, schedule.PublicHost, isOwnedComment)
 			if ambiguous {
 				return errors.New("multiple Meridian DNS records match this site; manual cleanup required")
 			} else if unowned > 0 {
@@ -2172,7 +2197,7 @@ func (a *App) reconcileOneSiteScheduleLocked(ctx context.Context, schedule SiteN
 			var records []cloudflareAddressRecord
 			records, err = cf.exactAddressRecords(ctx, zoneID, schedule.PublicHost)
 			if err == nil && len(records) > 0 {
-				owned, ok, unowned, ambiguous := classifyOwnedAddressRecords(records, schedule.PublicHost, marker)
+				owned, ok, unowned, ambiguous := classifyOwnedAddressRecords(records, schedule.PublicHost, isOwnedComment)
 				switch {
 				case ambiguous:
 					err = errors.New("multiple Meridian DNS records match this site; manual cleanup required")

--- a/tmdb_http.go
+++ b/tmdb_http.go
@@ -3,6 +3,7 @@ package main
 import (
 	"database/sql"
 	"errors"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -175,13 +176,17 @@ func (a *App) handleTMDBTest(w http.ResponseWriter, r *http.Request) {
 	nowMS := time.Now().UnixMilli()
 	if err := service.client.testCredentials(r.Context(), token); err != nil {
 		if usingStored {
-			_ = a.db.markTMDBCredentialResult(tmdbCredentialInvalid, tmdbSafeErrorCode(err), nowMS)
+			if markErr := a.db.markTMDBCredentialResult(tmdbCredentialInvalid, tmdbSafeErrorCode(err), nowMS); markErr != nil {
+				log.Printf("[tmdb] persist credential-invalid state failed: %v", markErr)
+			}
 		}
 		a.jsonErr(w, http.StatusBadGateway, tmdbChineseError(err))
 		return
 	}
 	if usingStored {
-		_ = a.db.markTMDBCredentialResult(tmdbCredentialReady, "", nowMS)
+		if markErr := a.db.markTMDBCredentialResult(tmdbCredentialReady, "", nowMS); markErr != nil {
+			log.Printf("[tmdb] persist credential-ready state failed: %v", markErr)
+		}
 		service.Wake()
 	}
 	settings, _ := a.db.tmdbPublicSettings()

--- a/tmdb_service.go
+++ b/tmdb_service.go
@@ -159,7 +159,9 @@ func (s *tmdbService) runOne(ctx context.Context, now time.Time) (bool, error) {
 	}
 	token, err := decryptTMDBReadToken(stored.TokenCiphertext)
 	if err != nil {
-		_ = s.db.markTMDBCredentialResult(tmdbCredentialInvalid, "decrypt", now.UnixMilli())
+		if markErr := s.db.markTMDBCredentialResult(tmdbCredentialInvalid, "decrypt", now.UnixMilli()); markErr != nil {
+		log.Printf("[tmdb] persist credential-invalid state failed: %v", markErr)
+	}
 		return false, err
 	}
 	job, found, err := s.db.claimTMDBJob(now.UnixMilli())
@@ -176,7 +178,9 @@ func (s *tmdbService) runOne(ctx context.Context, now time.Time) (bool, error) {
 	if lookupErr == nil {
 		completeErr := s.db.completeTMDBJob(job.ID, job.JobRevision, metadata, stored.Language, now.UnixMilli())
 		if completeErr == nil {
-			_ = s.db.markTMDBCredentialResult(tmdbCredentialReady, "", now.UnixMilli())
+			if markErr := s.db.markTMDBCredentialResult(tmdbCredentialReady, "", now.UnixMilli()); markErr != nil {
+				log.Printf("[tmdb] persist credential-ready state failed: %v", markErr)
+			}
 			return true, nil
 		}
 		return true, completeErr

--- a/tmdb_service.go
+++ b/tmdb_service.go
@@ -160,8 +160,8 @@ func (s *tmdbService) runOne(ctx context.Context, now time.Time) (bool, error) {
 	token, err := decryptTMDBReadToken(stored.TokenCiphertext)
 	if err != nil {
 		if markErr := s.db.markTMDBCredentialResult(tmdbCredentialInvalid, "decrypt", now.UnixMilli()); markErr != nil {
-		log.Printf("[tmdb] persist credential-invalid state failed: %v", markErr)
-	}
+			log.Printf("[tmdb] persist credential-invalid state failed: %v", markErr)
+		}
 		return false, err
 	}
 	job, found, err := s.db.claimTMDBJob(now.UnixMilli())

--- a/websocket_proxy.go
+++ b/websocket_proxy.go
@@ -18,7 +18,7 @@ func writeWebSocketGatewayError(conn net.Conn) {
 	_, _ = fmt.Fprintf(conn, "HTTP/1.1 502 Bad Gateway\r\nContent-Type: application/json\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(body), body)
 }
 
-func handleWebSocket(w http.ResponseWriter, r *http.Request, target, primaryTarget *url.URL, policy UAHeaderPolicy, inst *ProxyInstance, speedLimitBytes int64, upstreamPolicies ...upstreamHeaderPolicy) {
+func handleWebSocket(w http.ResponseWriter, r *http.Request, target, primaryTarget *url.URL, policy UAHeaderPolicy, inst *ProxyInstance, speedLimitBytes int64, pm *ProxyManager, trafficQuota int64, upstreamPolicies ...upstreamHeaderPolicy) {
 	// Nothing on this path reads r.Body, so a body would be left sitting in the
 	// hijacked buffer and relayed verbatim to the upstream.
 	if r.ContentLength != 0 || len(r.TransferEncoding) > 0 {
@@ -158,13 +158,17 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request, target, primaryTarg
 
 	// Bidirectional copy. Both directions are metered per chunk; only the
 	// download direction is paced, matching rateLimitedWriter on the HTTP path.
+	var tunnelQuota *quotaTunnelProbe
+	if trafficQuota > 0 {
+		tunnelQuota = &quotaTunnelProbe{pm: pm, inst: inst, limit: trafficQuota}
+	}
 	done := make(chan struct{}, 2)
 	go func() {
-		_, _ = io.Copy(&tunnelWriter{dst: upstreamConn, counter: inst.trafficBytesIn(), cumulative: inst.trafficCumulativeIn(), start: time.Now()}, clientBuf)
+		_, _ = io.Copy(&tunnelWriter{dst: upstreamConn, counter: inst.trafficBytesIn(), cumulative: inst.trafficCumulativeIn(), start: time.Now(), quota: tunnelQuota}, clientBuf)
 		done <- struct{}{}
 	}()
 	go func() {
-		_, _ = io.Copy(&tunnelWriter{dst: clientConn, counter: inst.trafficBytesOut(), cumulative: inst.trafficCumulativeOut(), bytesPerSec: speedLimitBytes, start: time.Now()}, upstreamReader)
+		_, _ = io.Copy(&tunnelWriter{dst: clientConn, counter: inst.trafficBytesOut(), cumulative: inst.trafficCumulativeOut(), bytesPerSec: speedLimitBytes, start: time.Now(), quota: tunnelQuota}, upstreamReader)
 		done <- struct{}{}
 	}()
 	// The first closed direction must tear down its counterpart, then both copy

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -116,7 +116,7 @@ func newWSProxyServer(t *testing.T, upstreamAddr string, inst *ProxyInstance, sp
 		t.Fatalf("normalizeTargetURL: %v", err)
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		handleWebSocket(w, r, target, target, policy, inst, speedLimitBytes)
+		handleWebSocket(w, r, target, target, policy, inst, speedLimitBytes, nil, 0)
 	}))
 	t.Cleanup(srv.Close)
 	return srv


### PR DESCRIPTION
## 改动内容

修复第七轮全量审查确认的 16 项发现（3 P1 / 6 P2 / 7 P3），其中一项经独立终审抓出"声称修复但未落地"后补齐。

### P1
- **install.sh set -u 断裂**：第 24 行引用未默认化的 \$MERIDIAN_DATA_DIR，默认安装加载即死（已随 v1.9.85/86 发布）。改用 \$DATA_DIR；CI 新增"清空环境变量执行默认值块"的执行级测试（bash -n 无法捕获此类问题）。
- **恢复回滚 crash-safe**：回滚改为 copy-based（临时文件+fsync+rename），不再用 os.Rename 消耗唯一快照；三条路径（进程内 defer、启动重试、启动 marker 分支）全部改为"先删 marker 且传播错误，成功后才删快照"——不变量：**marker 存在 ⇒ 完整快照存在**。
- **Retention tracker 限界**：8192 会话上限（溢出按最旧驱逐）+ 过期清扫每分钟一次（此前每个播放同步请求全表扫描，O(N²)）；viewer key 在有 token/device 身份时不再混入 UA 与客户端 IP。

### P2
- **保底回退错误分类**：新增 dynamicPolicyDenialError 包装 URL 安全管线（userinfo/fragment/scheme/计数/深度/模板），HLS 与 DASH 的策略拒绝继续 fail-closed，只有真正的格式兼容失败才原样透传上游清单。
- **配额三通路**：站点级共享探测累加器（响应写入/请求体/WS 双向隧道统一检查点），未检测溢出从"每流 16MiB 盲区"收敛为聚合约 16MiB。
- **Agent spool**：满队列丢弃路径改防抖持久化（不再每事件全量 fsync）；防抖时间戳只在持久化成功后更新，失败立即重试。
- **Logout**：服务端会话吊销失败返回 500（cookie 仍清除），不再谎报 logged_out。
- **Cloudflare 所有权标记**：新增 installation UUID（installation_meta 表，schema v50），标记改为 Meridian controller=<uuid> site=<id>——两个 Controller 共用一个 zone 不再互删记录；旧标记在迁移期仍视为自有，下一次 reconcile 自动改写。
- **Agent 自更新**：rename 成功后目录 fsync 失败降级为警告并仍要求重启（否则旧进程永跑旧码、下轮摘要比对判定无需升级）。

### P3
翻页超上限 fail-closed；登录限流驱逐不丢弃活跃锁定；SSE 连接上限 16；字节计数饱和加法；TMDB 凭据状态写入失败记录日志。

### 复审修正
独立终审抓到前两个提交的三个缺口并已补齐：retention 限界未实际落地（脚本中途断言失败）、恢复启动分支漏改、DASH 拒绝类型三个逃逸口；另修 ack/flush 时间戳顺序与 gofmt。

### 暂缓（记录在 findings.md）
extreme 残留物理删除（运行时恒为 compatible，不可达代码，与活路径深度交织，留待专项清理）。

## 改动类型

- [x] Bug 修复

## 验证方式

- [x] go test / -race 全绿（900s 预算）
- [x] 交叉 vet（windows/darwin）；govulncheck 0；gosec 0
- [x] node 167/167；bash -n；CI 新增安装器执行级测试（本地已验证 defaults-ok）
- [x] 新增回归：保底拒绝类型、饱和加法、共享探测累加器、scoped/legacy/foreign marker 矩阵

## 注意事项

- schema v49→v50（installation_meta 表）；旧库自动迁移，备份恢复校验一致。
- 升级后旧 DNS 记录在下一次成功 reconcile 时自动改写为 scoped 标记；迁移期新旧标记均视为自有。