### PR TITLE
fix: eighth-review remediation for restore ordering, retention, limiter, and quota (v1.9.88)

### DIFF
--- a/account_retention.go
+++ b/account_retention.go
@@ -158,9 +158,9 @@ func newAccountRetentionTracker(database *DB) *accountRetentionTracker {
 	}
 }
 
-// sweepLocked expires stale sessions and enforces the session cap. It runs at
-// most once per sweep interval (or immediately when the cap is reached) —
-// never on every observation.
+// sweepLocked expires stale sessions. It runs at most once per sweep interval;
+// capacity eviction is handled separately on the new-session path so a full
+// tracker never turns the observation hot path into a full-map scan.
 func (tracker *accountRetentionTracker) sweepLocked(now time.Time) {
 	tracker.lastSweep = now
 	for key, session := range tracker.sessions {
@@ -168,24 +168,32 @@ func (tracker *accountRetentionTracker) sweepLocked(now time.Time) {
 			delete(tracker.sessions, key)
 		}
 	}
-	if len(tracker.sessions) < accountRetentionSessionLimit {
-		return
+}
+
+// evictOldestLocked keeps the bounded tracker at its limit when a new
+// identity arrives. Expired entries are preferred, otherwise the least
+// recently observed identity is removed. This scan only runs when creating a
+// session at capacity, never for observations that reuse an existing key.
+func (tracker *accountRetentionTracker) evictOldestLocked(now time.Time) {
+	var oldestKey string
+	var oldestSeen time.Time
+	found := false
+	for key, session := range tracker.sessions {
+		if session == nil {
+			delete(tracker.sessions, key)
+			return
+		}
+		seen := session.LastObservedAt
+		if now.Sub(seen) > accountRetentionSessionTTL {
+			delete(tracker.sessions, key)
+			return
+		}
+		if !found || seen.Before(oldestSeen) {
+			oldestKey, oldestSeen, found = key, seen, true
+		}
 	}
-	overflow := len(tracker.sessions) - accountRetentionSessionLimit
-	for overflow > 0 && len(tracker.sessions) > 0 {
-		var oldestKey string
-		var oldestSeen time.Time
-		found := false
-		for key, session := range tracker.sessions {
-			if !found || session.LastObservedAt.Before(oldestSeen) {
-				oldestKey, oldestSeen, found = key, session.LastObservedAt, true
-			}
-		}
-		if !found {
-			break
-		}
+	if found {
 		delete(tracker.sessions, oldestKey)
-		overflow--
 	}
 }
 
@@ -290,7 +298,7 @@ func (tracker *accountRetentionTracker) Observe(site Site, request *http.Request
 
 	tracker.mu.Lock()
 	defer tracker.mu.Unlock()
-	if len(tracker.sessions) >= accountRetentionSessionLimit || endedAt.Sub(tracker.lastSweep) >= accountRetentionSweepInterval {
+	if tracker.lastSweep.IsZero() || endedAt.Sub(tracker.lastSweep) >= accountRetentionSweepInterval {
 		tracker.sweepLocked(endedAt)
 	}
 	cycleStartedAtMS := site.AccountRetentionStartedMS
@@ -301,6 +309,14 @@ func (tracker *accountRetentionTracker) Observe(site Site, request *http.Request
 	}
 	session := tracker.sessions[key]
 	if session == nil || session.SiteID != site.ID || session.CycleStartedAtMS != cycleStartedAtMS {
+		if session == nil {
+			for len(tracker.sessions) >= accountRetentionSessionLimit {
+				tracker.evictOldestLocked(endedAt)
+				if len(tracker.sessions) >= accountRetentionSessionLimit {
+					break
+				}
+			}
+		}
 		session = &accountRetentionSession{SiteID: site.ID, CycleStartedAtMS: cycleStartedAtMS}
 		tracker.sessions[key] = session
 	}

--- a/app_http.go
+++ b/app_http.go
@@ -27,6 +27,7 @@ type loginRateLimiter struct {
 	mu         sync.Mutex
 	attempts   map[string]loginAttempt
 	maxEntries int
+	overflow   loginAttempt
 }
 
 func newLoginRateLimiter() *loginRateLimiter {
@@ -51,6 +52,10 @@ func (l *loginRateLimiter) pruneExpired(now time.Time) {
 		if attempt.firstFailure.IsZero() || !now.Before(attempt.firstFailure.Add(loginFailureWindow)) {
 			delete(l.attempts, client)
 		}
+	}
+	if !now.Before(l.overflow.blockedUntil) &&
+		(l.overflow.firstFailure.IsZero() || !now.Before(l.overflow.firstFailure.Add(loginFailureWindow))) {
+		l.overflow = loginAttempt{}
 	}
 }
 
@@ -88,6 +93,9 @@ func (l *loginRateLimiter) allow(client string, now time.Time) (bool, time.Durat
 	l.pruneExpired(now)
 	attempt, ok := l.attempts[client]
 	if !ok {
+		if now.Before(l.overflow.blockedUntil) {
+			return false, l.overflow.blockedUntil.Sub(now)
+		}
 		return true, 0
 	}
 	attempt.lastSeen = now
@@ -105,8 +113,19 @@ func (l *loginRateLimiter) recordFailure(client string, now time.Time) {
 	l.pruneExpired(now)
 	attempt, exists := l.attempts[client]
 	if !exists && len(l.attempts) >= l.maxEntries && !l.evictLeastRecentlySeen(now) {
-		// The table is full of active lockouts; drop tracking for this new
-		// key instead of evicting a lockout.
+		// The table is full of active lockouts. Track failures in a bounded
+		// coarse bucket so exhaustion fails safe instead of allowing an
+		// untracked client to retry indefinitely.
+		attempt = l.overflow
+		if attempt.firstFailure.IsZero() || now.Sub(attempt.firstFailure) >= loginFailureWindow {
+			attempt = loginAttempt{firstFailure: now}
+		}
+		attempt.failures++
+		attempt.lastSeen = now
+		if attempt.failures >= maxLoginFailures {
+			attempt.blockedUntil = now.Add(loginLockoutDuration)
+		}
+		l.overflow = attempt
 		return
 	}
 	if attempt.firstFailure.IsZero() || now.Sub(attempt.firstFailure) >= loginFailureWindow {

--- a/backup_restore.go
+++ b/backup_restore.go
@@ -2589,6 +2589,39 @@ func rollbackRestoreFiles(dbPath, rollback string) error {
 	if rollback == "" {
 		return errors.New("恢复回滚目录为空")
 	}
+	// Preflight every rollback source before touching the live namespace. A
+	// missing snapshot must leave the currently running database intact so a
+	// recoverable deployment is not destroyed while reporting the error.
+	rollbackDB := filepath.Join(rollback, backupDatabaseEntry)
+	if info, err := os.Stat(rollbackDB); err != nil { // #nosec G304 G703 -- rollback is the fixed restore rollback suffix derived from the configured database path.
+		if errors.Is(err, os.ErrNotExist) {
+			return errors.New("恢复回滚副本缺少数据库")
+		}
+		return err
+	} else if !info.Mode().IsRegular() {
+		return errors.New("恢复回滚副本数据库不是普通文件")
+	}
+	for _, suffix := range []string{"-wal", "-shm"} {
+		source := filepath.Join(rollback, backupDatabaseEntry+suffix)
+		if info, err := os.Stat(source); err == nil { // #nosec G304 G703 -- rollback is the fixed restore rollback suffix derived from the configured database path.
+			if !info.Mode().IsRegular() {
+				return fmt.Errorf("恢复回滚副本 %s 不是普通文件", suffix)
+			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	if restoreDirectoryIncludesTLS(rollback) {
+		manifestPath := filepath.Join(rollback, "tls-namespace.json")
+		if data, err := os.ReadFile(manifestPath); err == nil { // #nosec G304 G703 -- rollback is the fixed restore rollback suffix derived from the configured database path.
+			var snapshot tlsNamespaceSnapshot
+			if err := json.Unmarshal(data, &snapshot); err != nil {
+				return fmt.Errorf("TLS 回滚清单损坏: %w", err)
+			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
 	// Copy-based restore: os.Rename would consume the only rollback snapshot,
 	// so a failure after the first rename would leave the deployment with a
 	// half-moved database and no recovery copy. The rollback directory stays

--- a/hardening_regression_test.go
+++ b/hardening_regression_test.go
@@ -750,3 +750,61 @@ func TestQuotaProbeSharedBoundedToOneCheck(t *testing.T) {
 		t.Fatal("small follow-up must not probe")
 	}
 }
+
+func TestAccountRetentionEvictsAtCapacityWithoutPerRequestSweep(t *testing.T) {
+	app := newTestApp(t)
+	tracker := newAccountRetentionTracker(app.db)
+	now := time.Now()
+	// Fill the tracker beyond the cap with distinct identities; each new
+	// identity at capacity must evict exactly one entry, never grow unbounded.
+	for i := 0; i < accountRetentionSessionLimit+50; i++ {
+		key := fmt.Sprintf("identity-%d", i)
+		session := &accountRetentionSession{SiteID: 1, CycleStartedAtMS: 1, LastObservedAt: now}
+		tracker.mu.Lock()
+		if tracker.sessions[key] == nil {
+			for len(tracker.sessions) >= accountRetentionSessionLimit {
+				tracker.evictOldestLocked(now)
+				if len(tracker.sessions) >= accountRetentionSessionLimit {
+					break
+				}
+			}
+		}
+		tracker.sessions[key] = session
+		if len(tracker.sessions) > accountRetentionSessionLimit {
+			tracker.mu.Unlock()
+			t.Fatalf("tracker grew past cap: %d", len(tracker.sessions))
+		}
+		tracker.mu.Unlock()
+	}
+	if len(tracker.sessions) != accountRetentionSessionLimit {
+		t.Fatalf("tracker size=%d, want exactly the cap", len(tracker.sessions))
+	}
+}
+
+func TestLoginLimiterOverflowFailsSafeWhenTableIsAllLockouts(t *testing.T) {
+	limiter := newLoginRateLimiter()
+	now := time.Now()
+	// Fill the table with distinct clients under active lockout.
+	for i := 0; i < limiter.maxEntries; i++ {
+		client := fmt.Sprintf("blocked-%d", i)
+		for attempt := 0; attempt < maxLoginFailures; attempt++ {
+			limiter.recordFailure(client, now)
+		}
+		if ok, _ := limiter.allow(client, now); ok {
+			t.Fatalf("client %s not locked after %d failures", client, maxLoginFailures)
+		}
+	}
+	// A brand-new client while the table is full of lockouts: the coarse
+	// overflow bucket must accumulate and lock, never silently fail open.
+	for attempt := 0; attempt < maxLoginFailures; attempt++ {
+		limiter.recordFailure("newcomer", now)
+	}
+	if ok, _ := limiter.allow("another-newcomer", now); ok {
+		t.Fatal("overflow lockout did not fail safe: untracked client allowed during saturation")
+	}
+	// After the lockout lapses, untracked clients are allowed again.
+	later := now.Add(loginLockoutDuration + time.Second)
+	if ok, _ := limiter.allow("post-lockout-client", later); !ok {
+		t.Fatal("overflow lockout did not lapse")
+	}
+}

--- a/proxy_io.go
+++ b/proxy_io.go
@@ -111,15 +111,15 @@ type quotaLimitedReader struct {
 
 func (q *quotaLimitedReader) Read(p []byte) (int, error) {
 	n, err := q.meteredReader.Read(p)
-	if err != nil {
-		return n, err
-	}
-	if quotaProbeShared(q.inst, int64(n)) {
+	// Readers may legally return data together with io.EOF. Account and probe
+	// that final chunk before propagating the underlying error so a checkpoint
+	// cannot be skipped at end of stream.
+	if n > 0 && quotaProbeShared(q.inst, int64(n)) {
 		if usage, usageErr := q.pm.currentTrafficCycleUsage(q.inst, time.Now()); usageErr == nil && usage >= q.quota {
 			return n, errTrafficQuotaExceeded
 		}
 	}
-	return n, nil
+	return n, err
 }
 
 // Flush support for streaming


### PR DESCRIPTION
## 改动内容

修复第八轮审查确认的 1 P2 + 3 P3（第五项 extreme 死代码删除继续暂缓，理由不变）。

### P2-1 Restore 删除顺序
rollbackRestoreFiles 新增完整 preflight：确认回滚数据库存在且为普通文件、-wal/-shm 存在时为普通文件、TLS namespace 清单可解析——**全部通过后才允许触碰 live 命名空间**。回滚目录损坏时不再先删仍可打开的 live DB。

### P3-1 Retention 满容量退化
分钟级 sweep 只做过期清理；容量淘汰移到新身份插入路径——满 8192 时仅淘汰一个（过期优先，否则最旧），不再每个 playback-sync 请求全表扫描，也不再短暂 8193。

### P3-2 Limiter 满表 fail-open
表满且全部活跃锁定时，新 client 失败进入有界粗粒度溢出桶；溢出桶锁定期间未跟踪 client 一律拒绝——存储耗尽 fail-safe 而非 fail-open；桶过期后自动恢复。

### P3-3 Quota reader 末块检查点
Read 返回 n>0 + EOF 时先记账并探测共享 16MiB 检查点再传播错误，流末不再跳过。

### 来源披露
工作区在本轮开始时已包含这四项修复的实现（来源不明，疑为共享工作区的并行 Codex 会话）。每个 hunk 均经逐行独立验收（无隐藏行为、无恶意逻辑）后采纳，并在本提交补齐了缺失的回归测试（容量上限不超、饱和锁定 fail-safe + 过期恢复）。新 preflight 的固定后缀路径按项目惯例补 #nosec 标注。

## 改动类型

- [x] Bug 修复

## 验证方式

- [x] go test / -race（900s 预算）全绿；新增 2 个回归测试
- [x] 交叉 vet（windows/darwin）；govulncheck 0；gosec 0（含新标注）
- [x] node 167/167；bash -n

## 注意事项

- 无 schema 变更；无产品行为变更（除 limiter 溢出 fail-safe 与回滚 preflight）。
- extreme 死代码物理删除继续按 findings.md 暂缓清单跟踪。