### PR TITLE
fix: ninth-review hardening for DNS ownership, URL preservation, and quota

### DIFF
--- a/backup_restore.go
+++ b/backup_restore.go
@@ -2013,11 +2013,147 @@ type tlsSnapshotPath struct {
 	Present bool   `json:"present"`
 }
 
+// tlsSnapshotRoot records one owned namespace root together with whether it
+// existed when the snapshot was taken. Without the presence bit a rollback
+// cannot tell "the operator had no TLS state yet" (nothing to copy, success)
+// from "the rollback copy of a root that did exist has been lost" (nothing to
+// copy, but the live TLS directory must not be destroyed).
+type tlsSnapshotRoot struct {
+	Path    string `json:"path"`
+	Present bool   `json:"present"`
+}
+
 type tlsNamespaceSnapshot struct {
 	// Roots is retained for rollback compatibility with v1.9.34 snapshots.
 	Roots []string          `json:"roots,omitempty"`
 	Scope tlsRestoreScope   `json:"scope,omitempty"`
 	Exact []tlsSnapshotPath `json:"exact,omitempty"`
+	// Owned mirrors Scope.OwnedRoots with the presence metadata described
+	// above. A legacy snapshot without it is validated against the tree
+	// contents instead.
+	Owned []tlsSnapshotRoot `json:"owned,omitempty"`
+}
+
+// maxTLSGenerationEntriesPerRoot bounds the rollback preflight's cross-check
+// of generation roots. A rollback tree that lists more entries than this is
+// corrupt rather than merely large, and walking it before every restore would
+// trade one availability risk for another.
+const maxTLSGenerationEntriesPerRoot = 4096
+
+// tlsRollbackOwnedPath returns where one owned root was copied inside the
+// rollback tree. v1.9.34 wrote it directly under tls-tree; the owned/
+// subdirectory was introduced in v1.9.35.
+func tlsRollbackOwnedPath(base string, index int, legacyLayout bool) string {
+	if legacyLayout {
+		return filepath.Join(base, fmt.Sprintf("%d", index))
+	}
+	return filepath.Join(base, "owned", fmt.Sprintf("%d", index))
+}
+
+// tlsRollbackLayout resolves which tree shape a rollback manifest describes and
+// normalizes the manifest's scope into the effective scope the rollback works
+// with. Both the preflight and the restore must use this one decision, because
+// they read the same tree: if they disagree, a complete snapshot is refused (an
+// unbootable installation) or an incomplete one is restored as empty.
+//
+// The discriminator is the manifest's own `roots` field, not the absence of
+// `owned` metadata. Only v1.9.34 wrote `roots`, and it copied each owned root
+// straight to tls-tree/<index>; every release from v1.9.35 through at least
+// v1.9.88 wrote a `scope` and copied to tls-tree/owned/<index>. Because `owned`
+// presence metadata was introduced after that range, treating "no owned field"
+// as legacy would misclassify every snapshot those versions wrote.
+func tlsRollbackLayout(dbPath string, snapshot tlsNamespaceSnapshot) (tlsRestoreScope, bool, error) {
+	scope := snapshot.Scope
+	if len(scope.OwnedRoots) == 0 && len(scope.ExactPaths) == 0 && len(scope.GenerationRoots) == 0 && len(snapshot.Roots) > 0 {
+		// v1.9.34 snapshots may only be safely replayed when their roots are
+		// the default DB-local TLS namespace. Never trust a legacy custom
+		// parent directory as an owned root.
+		defaultRoot, absErr := filepath.Abs(filepath.Join(filepath.Dir(dbPath), "tls"))
+		if absErr != nil {
+			return tlsRestoreScope{}, false, fmt.Errorf("解析旧版 TLS 回滚目录: %w", absErr)
+		}
+		for _, root := range snapshot.Roots {
+			rootAbsolute, rootErr := filepath.Abs(root)
+			if rootErr != nil || filepath.Clean(rootAbsolute) != filepath.Clean(defaultRoot) {
+				return tlsRestoreScope{}, false, errors.New("旧版 TLS 回滚清单包含不安全的自定义目录")
+			}
+		}
+		return tlsRestoreScope{OwnedRoots: append([]string(nil), snapshot.Roots...)}, true, nil
+	}
+	return scope, false, nil
+}
+
+// validateTLSRollbackSnapshot runs before anything is deleted. It proves the
+// rollback tree can actually restore every path the snapshot claims to hold,
+// including roots that existed but whose copy is missing or unreadable. A
+// snapshot that fails this check must abort the rollback while the live
+// database and live TLS namespace are still intact.
+func validateTLSRollbackSnapshot(rollback string, snapshot tlsNamespaceSnapshot, scope tlsRestoreScope, legacyLayout bool) error {
+	if len(snapshot.Owned) > 0 {
+		if len(snapshot.Owned) != len(scope.OwnedRoots) {
+			return fmt.Errorf("TLS 回滚清单的目录数量与快照不一致: %d/%d", len(snapshot.Owned), len(scope.OwnedRoots))
+		}
+	} else if len(scope.OwnedRoots) > 0 {
+		// A manifest without presence metadata still recorded which roots it
+		// copied, so every root is assumed present; the tree check below is what
+		// actually proves it.
+		assumed := make([]tlsSnapshotRoot, len(scope.OwnedRoots))
+		for index, root := range scope.OwnedRoots {
+			assumed[index] = tlsSnapshotRoot{Path: root, Present: true}
+		}
+		snapshot.Owned = assumed
+	}
+	base := filepath.Join(rollback, "tls-tree")
+	for index, entry := range snapshot.Owned {
+		if !entry.Present {
+			continue
+		}
+		copied := tlsRollbackOwnedPath(base, index, legacyLayout)
+		info, err := os.Stat(copied) // #nosec G703 -- copied is the generated rollback namespace for one owned root.
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("TLS 回滚副本缺少目录 %s", entry.Path)
+			}
+			return err
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("TLS 回滚副本目录不是目录: %s", entry.Path)
+		}
+	}
+	for index, entry := range snapshot.Exact {
+		if !entry.Present {
+			continue
+		}
+		copied := filepath.Join(base, "exact", fmt.Sprintf("%d", index))
+		if _, err := os.Lstat(copied); err != nil { // #nosec G703 -- copied is the generated rollback path for one exact entry.
+			if errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("TLS 回滚副本缺少文件 %s", entry.Path)
+			}
+			return err
+		}
+	}
+	for index, root := range scope.GenerationRoots {
+		dir := filepath.Join(base, "generations", fmt.Sprintf("%d", index))
+		entries, err := os.ReadDir(dir)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if len(entries) > maxTLSGenerationEntriesPerRoot {
+			return fmt.Errorf("TLS 回滚副本 generation 目录条目过多: %s", root)
+		}
+		for _, entry := range entries {
+			if !strings.HasPrefix(entry.Name(), "generation-") {
+				continue
+			}
+			if _, err := os.Lstat(filepath.Join(dir, entry.Name())); err != nil { // #nosec G703 -- re-checked entry beneath a generated rollback directory.
+				return fmt.Errorf("TLS 回滚副本缺少 generation 条目: %s", entry.Name())
+			}
+		}
+	}
+	return nil
 }
 
 func appendUniqueTLSPath(values []string, seen map[string]struct{}, value string) []string {
@@ -2322,7 +2458,16 @@ func snapshotTLSNamespace(dbPath, rollback string) error {
 		_, statErr := os.Lstat(path) // #nosec G703 -- path is an explicitly tracked TLS path.
 		exact[index] = tlsSnapshotPath{Path: path, Present: statErr == nil}
 	}
-	snapshot := tlsNamespaceSnapshot{Scope: scope, Exact: exact}
+	// Record root presence next to the copy attempt. copyTLSNamespaceTree
+	// succeeds for an absent source, so without this bit a rollback could not
+	// distinguish a root that never existed from one whose rollback copy was
+	// later lost and would delete the live namespace for nothing.
+	owned := make([]tlsSnapshotRoot, len(scope.OwnedRoots))
+	for index, root := range scope.OwnedRoots {
+		_, statErr := os.Lstat(root) // #nosec G703 -- root is an explicitly owned Meridian TLS namespace.
+		owned[index] = tlsSnapshotRoot{Path: root, Present: statErr == nil}
+	}
+	snapshot := tlsNamespaceSnapshot{Scope: scope, Exact: exact, Owned: owned}
 	data, err := json.Marshal(snapshot)
 	if err != nil {
 		return err
@@ -2354,22 +2499,9 @@ func restoreTLSNamespaceSnapshot(dbPath, rollback string) error {
 		return err
 	}
 	currentScope := managedTLSRestoreScope(dbPath)
-	scope := snapshot.Scope
-	if len(scope.OwnedRoots) == 0 && len(scope.ExactPaths) == 0 && len(scope.GenerationRoots) == 0 && len(snapshot.Roots) > 0 {
-		// v1.9.34 snapshots may only be safely replayed when their roots are
-		// the default DB-local TLS namespace. Never trust a legacy custom
-		// parent directory as an owned root.
-		defaultRoot, absErr := filepath.Abs(filepath.Join(filepath.Dir(dbPath), "tls"))
-		if absErr != nil {
-			return fmt.Errorf("解析旧版 TLS 回滚目录: %w", absErr)
-		}
-		for _, root := range snapshot.Roots {
-			rootAbsolute, rootErr := filepath.Abs(root)
-			if rootErr != nil || filepath.Clean(rootAbsolute) != filepath.Clean(defaultRoot) {
-				return errors.New("旧版 TLS 回滚清单包含不安全的自定义目录")
-			}
-		}
-		scope = tlsRestoreScope{OwnedRoots: append([]string(nil), snapshot.Roots...)}
+	scope, legacyLayout, err := tlsRollbackLayout(dbPath, snapshot)
+	if err != nil {
+		return err
 	}
 	if !sameTLSRestoreScope(scope, currentScope) {
 		return errors.New("TLS 回滚清单与当前配置不一致")
@@ -2377,12 +2509,20 @@ func restoreTLSNamespaceSnapshot(dbPath, rollback string) error {
 	if err := validateTLSRestoreScope(dbPath, currentScope); err != nil {
 		return err
 	}
+	// Prove the rollback tree is complete before the first destructive step.
+	// removeTLSRestoreScope below deletes the live TLS namespace, and
+	// copyTLSNamespaceTree treats a missing source as success, so an
+	// incomplete rollback copy would otherwise leave the installation with no
+	// TLS state while still reporting a successful rollback.
+	if err := validateTLSRollbackSnapshot(rollback, snapshot, scope, legacyLayout); err != nil {
+		return err
+	}
 	if err := removeTLSRestoreScope(currentScope); err != nil {
 		return err
 	}
 	base := filepath.Join(rollback, "tls-tree")
 	for index, root := range scope.OwnedRoots {
-		if err := copyTLSNamespaceTree(filepath.Join(base, "owned", fmt.Sprintf("%d", index)), root); err != nil {
+		if err := copyTLSNamespaceTree(tlsRollbackOwnedPath(base, index, legacyLayout), root); err != nil {
 			return err
 		}
 	}
@@ -2617,6 +2757,21 @@ func rollbackRestoreFiles(dbPath, rollback string) error {
 			var snapshot tlsNamespaceSnapshot
 			if err := json.Unmarshal(data, &snapshot); err != nil {
 				return fmt.Errorf("TLS 回滚清单损坏: %w", err)
+			}
+			// The manifest parsing above only proves the JSON is readable. The
+			// tree it points at must also be complete, because the rollback
+			// deletes the live database first and the live TLS namespace after
+			// that; discovering a missing rollback root at that point would
+			// destroy both copies of the state.
+			//
+			// The layout decision is shared with restoreTLSNamespaceSnapshot so
+			// the preflight probes exactly the tree the restore will read.
+			scope, legacyLayout, layoutErr := tlsRollbackLayout(dbPath, snapshot)
+			if layoutErr != nil {
+				return layoutErr
+			}
+			if err := validateTLSRollbackSnapshot(rollback, snapshot, scope, legacyLayout); err != nil {
+				return err
 			}
 		} else if !errors.Is(err, os.ErrNotExist) {
 			return err

--- a/command_line.go
+++ b/command_line.go
@@ -97,7 +97,7 @@ func runHealthcheckCommand() error {
 
 func runAdminCommand(args []string, input io.Reader, output io.Writer) error {
 	if len(args) == 0 {
-		return errors.New("usage: meridian admin reset-password --db <path> --password-stdin | issue-panel-certificate | issue-edge-certificate")
+		return errors.New("usage: meridian admin reset-password --db <path> --password-stdin | issue-panel-certificate | issue-edge-certificate | rotate-installation-identity")
 	}
 	if args[0] == "issue-edge-certificate" {
 		if len(args) != 1 {
@@ -111,8 +111,14 @@ func runAdminCommand(args []string, input io.Reader, output io.Writer) error {
 		}
 		return runIssuePanelCertificateCommand(output)
 	}
+	if args[0] == "rotate-installation-identity" {
+		if len(args) != 1 {
+			return errors.New("rotate-installation-identity does not accept arguments")
+		}
+		return runRotateInstallationIdentityCommand(output)
+	}
 	if args[0] != "reset-password" {
-		return errors.New("usage: meridian admin reset-password --db <path> --password-stdin | issue-panel-certificate | issue-edge-certificate")
+		return errors.New("usage: meridian admin reset-password --db <path> --password-stdin | issue-panel-certificate | issue-edge-certificate | rotate-installation-identity")
 	}
 	var dbPath string
 	passwordStdin := false
@@ -150,6 +156,57 @@ func runAdminCommand(args []string, input io.Reader, output io.Writer) error {
 		return fmt.Errorf("reset administrator password: %w", err)
 	}
 	_, err = fmt.Fprintln(output, "administrator password updated")
+	return err
+}
+
+// runRotateInstallationIdentityCommand gives this installation a new identity.
+// A controller cloned from another controller's backup shares its predecessor's
+// identity, which would let both installations claim the same Cloudflare DNS
+// records. Disaster-recovery takeover keeps the restored identity; a clone runs
+// this command instead. No secret material is printed.
+//
+// The target database must already exist. openDB migrates a missing file into a
+// fresh schema, so without this check a forgotten DB_PATH would rotate the
+// identity of a brand-new empty database and report success while the running
+// installation kept its old one.
+func runRotateInstallationIdentityCommand(output io.Writer) error {
+	dbPath := strings.TrimSpace(os.Getenv("DB_PATH"))
+	if dbPath == "" {
+		dbPath = "/app/data/meridian.db"
+	}
+	// #nosec G703 G304 -- dbPath is the administrator-controlled local database location from the DB_PATH environment variable; this only checks that the file the command is about to open already exists.
+	if _, err := os.Stat(dbPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("database %s does not exist; set DB_PATH to the installation's database", dbPath)
+		}
+		return err
+	}
+	db, err := openDB(dbPath)
+	if err != nil {
+		return fmt.Errorf("open database: %w", err)
+	}
+	defer db.Close()
+	value, err := db.rotateInstallationUUID()
+	if err != nil {
+		return fmt.Errorf("rotate installation identity: %w", err)
+	}
+	if _, err := fmt.Fprintln(output, "installation identity rotated"); err != nil {
+		return err
+	}
+	// The running process caches the identity, so it must be restarted; the
+	// warning about existing DNS records matters because rotating the identity
+	// makes every record stamped with the previous one look foreign, and the
+	// scheduler will then refuse to touch it.
+	if _, err := fmt.Fprintln(output, "restart the panel to apply the new identity"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(output, "DNS records created under the previous identity keep their old marker and will be treated as foreign; delete them and let the scheduler re-create them"); err != nil {
+		return err
+	}
+	// Only the length is reported: the identity scopes DNS ownership and is
+	// not otherwise secret, but printing it would put an installation
+	// fingerprint into logs and screen captures.
+	_, err = fmt.Fprintf(output, "new identity length: %d\n", len(value))
 	return err
 }
 

--- a/dash_rewrite.go
+++ b/dash_rewrite.go
@@ -273,11 +273,11 @@ func rewriteDASHTemplate(value string, base *url.URL, session *dynamicRewriteSes
 	return route, nil
 }
 func rewriteDASHUTCTiming(node *dashXMLNode, base *url.URL, session *dynamicRewriteSession) error {
-	schemeIndex, err := dashAttributeIndex(node, "schemeIdUri", dashExtremeCompatibilityEnabled(session))
+	schemeIndex, err := dashAttributeIndex(node, "schemeIdUri")
 	if err != nil || schemeIndex < 0 {
 		return fmt.Errorf("DASH UTCTiming requires one supported scheme")
 	}
-	valueIndex, err := dashAttributeIndex(node, "value", dashExtremeCompatibilityEnabled(session))
+	valueIndex, err := dashAttributeIndex(node, "value")
 	if err != nil || valueIndex < 0 {
 		return fmt.Errorf("DASH UTCTiming requires a value")
 	}
@@ -299,13 +299,12 @@ func rewriteDASHUTCTiming(node *dashXMLNode, base *url.URL, session *dynamicRewr
 }
 
 func rewriteDASHEventDescriptor(node *dashXMLNode, base *url.URL, session *dynamicRewriteSession) error {
-	extremeCompatibility := dashExtremeCompatibilityEnabled(session)
-	schemeIndex, err := dashAttributeIndex(node, "schemeIdUri", extremeCompatibility)
+	schemeIndex, err := dashAttributeIndex(node, "schemeIdUri")
 	if err != nil || schemeIndex < 0 {
 		return err
 	}
 	scheme := node.start.Attr[schemeIndex].Value
-	valueIndex, err := dashAttributeIndex(node, "value", extremeCompatibility)
+	valueIndex, err := dashAttributeIndex(node, "value")
 	if err != nil {
 		return err
 	}
@@ -330,21 +329,15 @@ func rewriteDASHEventDescriptor(node *dashXMLNode, base *url.URL, session *dynam
 		}
 		event := content.node
 		if event.start.Name.Space != "urn:mpeg:dash:schema:mpd:2011" {
-			if !extremeCompatibility {
-				return fmt.Errorf("DASH callback EventStream has an unsupported child")
-			}
-			if err := validateDASHExtremeCompatibilityInertSubtree(session.ctx, event); err != nil {
-				return err
-			}
-			continue
+			return fmt.Errorf("DASH callback EventStream has an unsupported child")
 		}
 		if event.start.Name.Local != "Event" {
 			return fmt.Errorf("DASH callback EventStream has an unsupported child")
 		}
-		if err := validateDASHLeafElement(event, session.ctx, extremeCompatibility); err != nil {
+		if err := validateDASHLeafElement(event, session.ctx); err != nil {
 			return err
 		}
-		messageIndex, err := dashAttributeIndex(event, "messageData", extremeCompatibility)
+		messageIndex, err := dashAttributeIndex(event, "messageData")
 		if err != nil || messageIndex < 0 {
 			return fmt.Errorf("DASH callback Event requires messageData")
 		}
@@ -362,8 +355,7 @@ func rewriteDASHNode(node *dashXMLNode, inheritedBase *url.URL, inheritedAddress
 	if err := session.ctx.Err(); err != nil {
 		return 0, fmt.Errorf("DASH parsing deadline exceeded")
 	}
-	extremeCompatibility := dashExtremeCompatibilityEnabled(session)
-	if err := validateDASHNodeNamespace(node, extremeCompatibility); err != nil {
+	if err := validateDASHNodeNamespace(node); err != nil {
 		return 0, err
 	}
 	standardNode := node.start.Name.Space == "urn:mpeg:dash:schema:mpd:2011"
@@ -375,13 +367,10 @@ func rewriteDASHNode(node *dashXMLNode, inheritedBase *url.URL, inheritedAddress
 		case "PatchLocation", "ContentSteering", "ImportedMPD", "Metrics", "Reporting":
 			return 0, fmt.Errorf("unsupported DASH external document or reporting")
 		case "ContentProtection":
-			if !extremeCompatibility {
-				return 0, fmt.Errorf("DASH DRM is unsupported")
-			}
-			if err := validateDASHExtremeCompatibilityContentProtection(session.ctx, node); err != nil {
-				return 0, err
-			}
-			return 0, nil
+			// DRM was accepted only under the removed permissive profile; the
+			// single remaining policy cannot rewrite license or certificate
+			// references, so DRM stays unsupported.
+			return 0, fmt.Errorf("DASH DRM is unsupported")
 		}
 	}
 	currentBase := inheritedBase
@@ -394,12 +383,12 @@ func rewriteDASHNode(node *dashXMLNode, inheritedBase *url.URL, inheritedAddress
 		}
 		switch child.node.start.Name.Local {
 		case "BaseURL":
-			if err := validateDASHNodeNamespace(child.node, extremeCompatibility); err != nil {
+			if err := validateDASHNodeNamespace(child.node); err != nil {
 				return 0, err
 			}
 			baseIndexes = append(baseIndexes, index)
 		case "SegmentTemplate", "SegmentList", "SegmentBase":
-			if err := validateDASHNodeNamespace(child.node, extremeCompatibility); err != nil {
+			if err := validateDASHNodeNamespace(child.node); err != nil {
 				return 0, err
 			}
 			if localAddressing != nil {
@@ -427,7 +416,7 @@ func rewriteDASHNode(node *dashXMLNode, inheritedBase *url.URL, inheritedAddress
 	}
 	effectiveAddressing := mergeDASHSegmentAddressing(inheritedAddressing, localAddressing)
 	if standardNode && node.start.Name.Local == "Representation" && effectiveAddressing != nil {
-		bindings, err := dashRepresentationBindings(node, extremeCompatibility)
+		bindings, err := dashRepresentationBindings(node)
 		if err != nil {
 			return 0, err
 		}
@@ -563,7 +552,7 @@ func rewriteDASHResponse(payload []byte, session *dynamicRewriteSession) ([]byte
 		return nil, err
 	}
 	encoder := xml.NewEncoder(&output)
-	if err := encodeDASHXMLNode(session.ctx, encoder, root, dashExtremeCompatibilityEnabled(session)); err != nil {
+	if err := encodeDASHXMLNode(session.ctx, encoder, root); err != nil {
 		return nil, err
 	}
 	if err := encoder.Flush(); err != nil {

--- a/dash_segments.go
+++ b/dash_segments.go
@@ -1,15 +1,12 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/xml"
 	"fmt"
 	"net/url"
 	"sort"
 	"strings"
-	"unicode"
 )
 
 type dashSegmentAddressing struct {
@@ -96,7 +93,7 @@ func mergeDASHSegmentAddressing(inherited, local *dashSegmentAddressing) *dashSe
 }
 
 func rewriteDASHURLAttribute(node *dashXMLNode, name string, base *url.URL, template bool, session *dynamicRewriteSession, bindings *dashTemplateBindings) error {
-	index, err := dashAttributeIndex(node, name, dashExtremeCompatibilityEnabled(session))
+	index, err := dashAttributeIndex(node, name)
 	if err != nil || index < 0 {
 		return err
 	}
@@ -120,19 +117,13 @@ func rewriteDASHURLAttribute(node *dashXMLNode, name string, base *url.URL, temp
 	return nil
 }
 
-func validateDASHLeafElement(node *dashXMLNode, ctx context.Context, extremeCompatibility bool) error {
-	if err := validateDASHNodeNamespace(node, extremeCompatibility); err != nil {
+func validateDASHLeafElement(node *dashXMLNode, ctx context.Context) error {
+	if err := validateDASHNodeNamespace(node); err != nil {
 		return err
 	}
 	for _, child := range node.content {
 		if child.node != nil {
-			if !extremeCompatibility || child.node.start.Name.Space == "urn:mpeg:dash:schema:mpd:2011" {
-				return fmt.Errorf("DASH segment addressing element has unsupported content")
-			}
-			if err := validateDASHExtremeCompatibilityInertSubtree(ctx, child.node); err != nil {
-				return err
-			}
-			continue
+			return fmt.Errorf("DASH segment addressing element has unsupported content")
 		}
 		if strings.TrimSpace(string(child.text)) != "" {
 			return fmt.Errorf("DASH segment addressing element has unsupported content")
@@ -141,8 +132,8 @@ func validateDASHLeafElement(node *dashXMLNode, ctx context.Context, extremeComp
 	return nil
 }
 
-func validateDASHSegmentTimeline(node *dashXMLNode, ctx context.Context, extremeCompatibility bool) error {
-	if err := validateDASHNodeNamespace(node, extremeCompatibility); err != nil {
+func validateDASHSegmentTimeline(node *dashXMLNode, ctx context.Context) error {
+	if err := validateDASHNodeNamespace(node); err != nil {
 		return err
 	}
 	for _, child := range node.content {
@@ -153,18 +144,12 @@ func validateDASHSegmentTimeline(node *dashXMLNode, ctx context.Context, extreme
 			continue
 		}
 		if child.node.start.Name.Space != "urn:mpeg:dash:schema:mpd:2011" {
-			if !extremeCompatibility {
-				return fmt.Errorf("DASH SegmentTimeline has an unsupported child")
-			}
-			if err := validateDASHExtremeCompatibilityInertSubtree(ctx, child.node); err != nil {
-				return err
-			}
-			continue
+			return fmt.Errorf("DASH SegmentTimeline has an unsupported child")
 		}
 		if child.node.start.Name.Local != "S" {
 			return fmt.Errorf("DASH SegmentTimeline has an unsupported child")
 		}
-		if err := validateDASHLeafElement(child.node, ctx, extremeCompatibility); err != nil {
+		if err := validateDASHLeafElement(child.node, ctx); err != nil {
 			return err
 		}
 	}
@@ -175,8 +160,7 @@ func rewriteDASHSegmentAddressing(addressing *dashSegmentAddressing, base *url.U
 	if addressing == nil || addressing.node == nil || !isDASHSegmentAddressing(addressing.kind) || addressing.node.start.Name.Local != addressing.kind {
 		return fmt.Errorf("DASH segment addressing is unavailable")
 	}
-	extremeCompatibility := dashExtremeCompatibilityEnabled(session)
-	if err := validateDASHNodeNamespace(addressing.node, extremeCompatibility); err != nil {
+	if err := validateDASHNodeNamespace(addressing.node); err != nil {
 		return err
 	}
 	if addressing.kind == "SegmentTemplate" {
@@ -194,14 +178,11 @@ func rewriteDASHSegmentAddressing(addressing *dashSegmentAddressing, base *url.U
 			continue
 		}
 		child := content.node
-		if err := validateDASHNodeNamespace(child, extremeCompatibility); err != nil {
+		if err := validateDASHNodeNamespace(child); err != nil {
 			return err
 		}
 		if child.start.Name.Space != "urn:mpeg:dash:schema:mpd:2011" {
-			if err := validateDASHExtremeCompatibilityInertSubtree(session.ctx, child); err != nil {
-				return err
-			}
-			continue
+			return fmt.Errorf("DASH segment addressing has an unsupported child")
 		}
 		switch child.start.Name.Local {
 		case "SegmentURL":
@@ -213,7 +194,7 @@ func rewriteDASHSegmentAddressing(addressing *dashSegmentAddressing, base *url.U
 					return err
 				}
 			}
-			if err := validateDASHLeafElement(child, session.ctx, extremeCompatibility); err != nil {
+			if err := validateDASHLeafElement(child, session.ctx); err != nil {
 				return err
 			}
 		case "Initialization", "RepresentationIndex", "BitstreamSwitching":
@@ -223,14 +204,14 @@ func rewriteDASHSegmentAddressing(addressing *dashSegmentAddressing, base *url.U
 			if err := rewriteDASHURLAttribute(child, "sourceURL", base, false, session, nil); err != nil {
 				return err
 			}
-			if err := validateDASHLeafElement(child, session.ctx, extremeCompatibility); err != nil {
+			if err := validateDASHLeafElement(child, session.ctx); err != nil {
 				return err
 			}
 		case "SegmentTimeline":
 			if addressing.kind == "SegmentBase" {
 				return fmt.Errorf("DASH SegmentBase has an unsupported timeline")
 			}
-			if err := validateDASHSegmentTimeline(child, session.ctx, extremeCompatibility); err != nil {
+			if err := validateDASHSegmentTimeline(child, session.ctx); err != nil {
 				return err
 			}
 		default:
@@ -240,252 +221,36 @@ func rewriteDASHSegmentAddressing(addressing *dashSegmentAddressing, base *url.U
 	return nil
 }
 
-func validateDASHNodeNamespace(node *dashXMLNode, extremeCompatibility bool) error {
-	if !extremeCompatibility {
-		if node == nil || node.start.Name.Space != "urn:mpeg:dash:schema:mpd:2011" {
-			return fmt.Errorf("DASH foreign-namespace elements are unsupported")
-		}
-		for _, attribute := range node.start.Attr {
-			if attribute.Name.Space == "http://www.w3.org/1999/xlink" && attribute.Name.Local == "href" {
-				return fmt.Errorf("DASH xlink fetches are unsupported")
-			}
-			if attribute.Name.Space != "" && !(attribute.Name.Space == "http://www.w3.org/XML/1998/namespace" && attribute.Name.Local == "lang") {
-				return fmt.Errorf("DASH foreign-namespace attributes are unsupported")
-			}
-		}
-		return nil
-	}
-	if node == nil {
+// validateDASHNodeNamespace accepts only the ISO/IEC 23009-1 namespace and its
+// explicitly allowed attributes. The permissive "extreme" profile that used to
+// tolerate foreign wrappers, xlink fetches, xml:base references, and vendor
+// network attributes was removed, so every deviation is now an unsupported
+// manifest feature.
+func validateDASHNodeNamespace(node *dashXMLNode) error {
+	if node == nil || node.start.Name.Space != "urn:mpeg:dash:schema:mpd:2011" {
 		return fmt.Errorf("DASH foreign-namespace elements are unsupported")
 	}
-	if node.start.Name.Space == "http://www.w3.org/1999/xlink" {
-		return fmt.Errorf("DASH xlink fetches are unsupported")
-	}
 	for _, attribute := range node.start.Attr {
-		if err := validateDASHExtremeCompatibilityAttribute(node.start.Name.Space, attribute); err != nil {
-			return err
+		if attribute.Name.Space == "http://www.w3.org/1999/xlink" && attribute.Name.Local == "href" {
+			return fmt.Errorf("DASH xlink fetches are unsupported")
 		}
-	}
-	if node.start.Name.Space != "urn:mpeg:dash:schema:mpd:2011" {
-		if dashExtremeCompatibilityActiveNamespace(node.start.Name.Space) || dashExtremeCompatibilityNetworkName(node.start.Name.Local) {
-			return fmt.Errorf("DASH foreign extension has active network semantics")
-		}
-		for _, content := range node.content {
-			if content.node == nil && dashExtremeCompatibilityNetworkReference(string(content.text)) {
-				return fmt.Errorf("DASH foreign extension contains an external reference")
-			}
+		if attribute.Name.Space != "" && !(attribute.Name.Space == "http://www.w3.org/XML/1998/namespace" && attribute.Name.Local == "lang") {
+			return fmt.Errorf("DASH foreign-namespace attributes are unsupported")
 		}
 	}
 	return nil
 }
 
-func dashExtremeCompatibilityNamespaceDeclaration(attribute xml.Attr) bool {
-	return attribute.Name.Space == "xmlns" || attribute.Name.Space == "" && attribute.Name.Local == "xmlns"
-}
-
-func dashExtremeCompatibilityNormalizedName(value string) string {
-	return strings.Map(func(character rune) rune {
-		if unicode.IsLetter(character) || unicode.IsDigit(character) {
-			return unicode.ToLower(character)
-		}
-		return -1
-	}, value)
-}
-
-func dashExtremeCompatibilityNetworkName(value string) bool {
-	switch dashExtremeCompatibilityNormalizedName(value) {
-	case "baseurl", "segmentbase", "segmentlist", "segmenturl", "segmenttemplate",
-		"initialization", "representationindex", "bitstreamswitching", "location", "utctiming",
-		"patchlocation", "contentsteering", "importedmpd", "metrics", "reporting",
-		"href", "src", "url", "uri", "sourceurl", "sourceuri", "serverurl", "serveruri",
-		"licenseurl", "licenseuri", "laurl", "certurl", "certificateurl", "callbackurl", "reloaduri",
-		"targeturl", "asseturl", "asseturi", "manifesturl", "manifesturi", "resourceurl", "resourceuri",
-		"fonturl", "fonturi", "endpoint", "redirect", "querytemplate", "includeinrequests",
-		"urlqueryinfo", "exturlqueryinfo", "exthttpheaderinfo", "fontdownload":
-		return true
-	default:
-		return false
-	}
-}
-
-func dashExtremeCompatibilityActiveNamespace(namespace string) bool {
-	switch namespace {
-	case "urn:dvb:dash:fontdownload:2014",
-		"urn:mpeg:dash:schema:urlparam:2014", "urn:mpeg:dash:schema:urlparam:2016",
-		"urn:mpeg:dash:urlparam:2014", "urn:mpeg:dash:urlparam:2016":
-		return true
-	default:
-		return false
-	}
-}
-
-func dashExtremeCompatibilityNetworkReference(value string) bool {
-	lower := strings.ToLower(strings.TrimSpace(value))
-	if lower == "" {
-		return false
-	}
-	for _, marker := range []string{"http://", "https://", "ws://", "wss://", "ftp://", "ftps://", "file://", "smb://", "rtsp://"} {
-		if strings.Contains(lower, marker) {
-			return true
-		}
-	}
-	return strings.HasPrefix(lower, "/") || strings.HasPrefix(lower, "./") || strings.HasPrefix(lower, "../") || strings.HasPrefix(lower, "?")
-}
-
-func validateDASHExtremeCompatibilityAttribute(ownerNamespace string, attribute xml.Attr) error {
-	if dashExtremeCompatibilityNamespaceDeclaration(attribute) {
-		return nil
-	}
-	if attribute.Name.Space == "http://www.w3.org/1999/xlink" {
-		return fmt.Errorf("DASH xlink fetches are unsupported")
-	}
-	if attribute.Name.Space == "http://www.w3.org/XML/1998/namespace" && attribute.Name.Local == "base" {
-		return fmt.Errorf("DASH xml:base references are unsupported")
-	}
-	if ownerNamespace == "urn:mpeg:dash:schema:mpd:2011" && attribute.Name.Space == "" {
-		return nil
-	}
-	name := dashExtremeCompatibilityNormalizedName(attribute.Name.Local)
-	if dashExtremeCompatibilityActiveNamespace(attribute.Name.Space) || dashExtremeCompatibilityNetworkName(name) || name != "schemeiduri" && dashExtremeCompatibilityNetworkReference(attribute.Value) {
-		return fmt.Errorf("DASH foreign attribute has active network semantics")
-	}
-	return nil
-}
-
-func validateDASHExtremeCompatibilityEncodedDRMMetadata(value string) error {
-	compact := strings.Map(func(character rune) rune {
-		if unicode.IsSpace(character) {
-			return -1
-		}
-		return character
-	}, value)
-	if compact == "" {
-		return fmt.Errorf("DASH DRM metadata is empty")
-	}
-	decoded, err := base64.StdEncoding.DecodeString(compact)
-	if err != nil {
-		decoded, err = base64.RawStdEncoding.DecodeString(compact)
-	}
-	if err != nil || len(decoded) == 0 {
-		return fmt.Errorf("DASH DRM metadata is malformed")
-	}
-	normalized := make([]byte, 0, len(decoded))
-	for _, value := range decoded {
-		if value == 0 {
-			continue
-		}
-		if value >= 'A' && value <= 'Z' {
-			value += 'a' - 'A'
-		}
-		normalized = append(normalized, value)
-	}
-	markers := [...][]byte{
-		[]byte("http://"), []byte("https://"), []byte("la_url"), []byte("lui_url"),
-		[]byte("laurl"), []byte("certurl"), []byte("licenseurl"), []byte("license_url"),
-		[]byte("serverurl"), []byte("server_url"),
-	}
-	for _, marker := range markers {
-		if bytes.Contains(normalized, marker) {
-			return fmt.Errorf("DASH DRM metadata contains an external license or certificate reference")
-		}
-	}
-	return nil
-}
-
-func validateDASHExtremeCompatibilityDRMNode(ctx context.Context, node *dashXMLNode) error {
-	if ctx == nil || ctx.Err() != nil {
-		return fmt.Errorf("DASH parsing deadline exceeded")
-	}
-	if err := validateDASHNodeNamespace(node, true); err != nil {
-		return err
-	}
-	if dashExtremeCompatibilityNetworkName(node.start.Name.Local) {
-		return fmt.Errorf("DASH DRM metadata contains active network semantics")
-	}
-	for _, attribute := range node.start.Attr {
-		if dashExtremeCompatibilityNamespaceDeclaration(attribute) {
-			continue
-		}
-		name := dashExtremeCompatibilityNormalizedName(attribute.Name.Local)
-		if dashExtremeCompatibilityNetworkName(name) || name != "schemeiduri" && dashExtremeCompatibilityNetworkReference(attribute.Value) {
-			return fmt.Errorf("DASH DRM metadata contains an external license or certificate reference")
-		}
-	}
-	name := dashExtremeCompatibilityNormalizedName(node.start.Name.Local)
-	if name == "pssh" || name == "pro" || name == "protectionheader" {
-		value, err := dashNodeText(node)
-		if err != nil {
-			return fmt.Errorf("DASH DRM metadata is malformed")
-		}
-		return validateDASHExtremeCompatibilityEncodedDRMMetadata(value)
-	}
-	for _, content := range node.content {
-		if content.node != nil {
-			if err := validateDASHExtremeCompatibilityDRMNode(ctx, content.node); err != nil {
-				return err
-			}
-			continue
-		}
-		if dashExtremeCompatibilityNetworkReference(string(content.text)) {
-			return fmt.Errorf("DASH DRM metadata contains an external license or certificate reference")
-		}
-	}
-	return nil
-}
-
-func validateDASHExtremeCompatibilityContentProtection(ctx context.Context, node *dashXMLNode) error {
-	if node == nil || node.start.Name.Space != "urn:mpeg:dash:schema:mpd:2011" || node.start.Name.Local != "ContentProtection" {
-		return fmt.Errorf("DASH ContentProtection metadata is unavailable")
-	}
-	return validateDASHExtremeCompatibilityDRMNode(ctx, node)
-}
-
-func validateDASHExtremeCompatibilityInertSubtree(ctx context.Context, node *dashXMLNode) error {
-	if ctx == nil || ctx.Err() != nil {
-		return fmt.Errorf("DASH parsing deadline exceeded")
-	}
-	if err := validateDASHNodeNamespace(node, true); err != nil {
-		return err
-	}
-	if node.start.Name.Space == "urn:mpeg:dash:schema:mpd:2011" && node.start.Name.Local == "ContentProtection" {
-		return validateDASHExtremeCompatibilityContentProtection(ctx, node)
-	}
-	if node.start.Name.Space == "urn:mpeg:dash:schema:mpd:2011" && dashExtremeCompatibilityNetworkName(node.start.Name.Local) {
-		return fmt.Errorf("DASH inert extension contains a fetch-capable element")
-	}
-	for _, attribute := range node.start.Attr {
-		if dashExtremeCompatibilityNamespaceDeclaration(attribute) {
-			continue
-		}
-		name := dashExtremeCompatibilityNormalizedName(attribute.Name.Local)
-		if dashExtremeCompatibilityNetworkName(name) || name != "schemeiduri" && dashExtremeCompatibilityNetworkReference(attribute.Value) {
-			return fmt.Errorf("DASH inert extension contains an external reference")
-		}
-	}
-	for _, content := range node.content {
-		if content.node != nil {
-			if err := validateDASHExtremeCompatibilityInertSubtree(ctx, content.node); err != nil {
-				return err
-			}
-			continue
-		}
-		if dashExtremeCompatibilityNetworkReference(string(content.text)) {
-			return fmt.Errorf("DASH inert extension contains an external reference")
-		}
-	}
-	return nil
-}
-
-func dashRepresentationBindings(node *dashXMLNode, extremeCompatibility bool) (dashTemplateBindings, error) {
+func dashRepresentationBindings(node *dashXMLNode) (dashTemplateBindings, error) {
 	var bindings dashTemplateBindings
-	idIndex, err := dashAttributeIndex(node, "id", extremeCompatibility)
+	idIndex, err := dashAttributeIndex(node, "id")
 	if err != nil {
 		return bindings, err
 	}
 	if idIndex >= 0 {
 		bindings.representationID = node.start.Attr[idIndex].Value
 	}
-	bandwidthIndex, err := dashAttributeIndex(node, "bandwidth", extremeCompatibility)
+	bandwidthIndex, err := dashAttributeIndex(node, "bandwidth")
 	if err != nil {
 		return bindings, err
 	}

--- a/dash_xml.go
+++ b/dash_xml.go
@@ -113,28 +113,19 @@ func parseDASHXML(ctx context.Context, payload []byte) (*dashXMLNode, error) {
 	return root, nil
 }
 
-func encodeDASHXMLNode(ctx context.Context, encoder *xml.Encoder, node *dashXMLNode, extremeCompatibility bool) error {
+func encodeDASHXMLNode(ctx context.Context, encoder *xml.Encoder, node *dashXMLNode) error {
 	if node == nil {
 		return fmt.Errorf("DASH XML node is unavailable")
 	}
 	if ctx == nil || ctx.Err() != nil {
 		return fmt.Errorf("DASH encoding deadline exceeded")
 	}
-	if extremeCompatibility {
-		attributes := node.start.Attr[:0]
-		for _, attribute := range node.start.Attr {
-			if !dashExtremeCompatibilityNamespaceDeclaration(attribute) || attribute.Name.Space == "" && attribute.Name.Local == "xmlns" && attribute.Value == "" {
-				attributes = append(attributes, attribute)
-			}
-		}
-		node.start.Attr = attributes
-	}
 	if err := encoder.EncodeToken(node.start); err != nil {
 		return err
 	}
 	for _, child := range node.content {
 		if child.node != nil {
-			if err := encodeDASHXMLNode(ctx, encoder, child.node, extremeCompatibility); err != nil {
+			if err := encodeDASHXMLNode(ctx, encoder, child.node); err != nil {
 				return err
 			}
 		} else if len(child.text) > 0 {
@@ -183,20 +174,18 @@ func setDASHNodeText(node *dashXMLNode, value string) {
 	node.content = []dashXMLContent{{text: []byte(value)}}
 }
 
-func dashExtremeCompatibilityEnabled(session *dynamicRewriteSession) bool {
-	return session != nil && session.issuer != nil && session.issuer.policy.profile == dynamicProfileExtreme
-}
-
-func dashAttributeIndex(node *dashXMLNode, local string, extremeCompatibility bool) (int, error) {
+// dashAttributeIndex resolves a DASH attribute by its local name. An attribute
+// that carries the expected local name inside a foreign namespace is rejected
+// rather than skipped: the permissive "extreme" profile that accepted those
+// wrappers was removed, so a foreign-namespace attribute is always an
+// unsupported manifest feature.
+func dashAttributeIndex(node *dashXMLNode, local string) (int, error) {
 	index := -1
 	for candidate := range node.start.Attr {
 		if node.start.Attr[candidate].Name.Local != local {
 			continue
 		}
 		if node.start.Attr[candidate].Name.Space != "" {
-			if extremeCompatibility {
-				continue
-			}
 			return -1, fmt.Errorf("DASH standard attribute uses a foreign namespace")
 		}
 		if index >= 0 {

--- a/database.go
+++ b/database.go
@@ -171,3 +171,38 @@ func (d *DB) ensureInstallationUUID() error {
 	d.installUUID = strings.TrimSpace(value)
 	return nil
 }
+
+// rotateInstallationUUID replaces the installation identity and returns the
+// new value. It exists because restoring a backup copies installation_meta
+// along with every other table: a disaster-recovery takeover must keep the
+// original identity so it can keep managing the DNS records that controller
+// created, while a controller cloned from a backup must adopt a new one or the
+// two installations would present the same Cloudflare ownership marker and
+// each would treat the other's records as its own.
+//
+// Note that this only updates the cached value for the calling process. A
+// running panel reads installUUID once at startup, so an operator who rotates
+// the identity through the CLI must restart the service.
+func (d *DB) rotateInstallationUUID() (string, error) {
+	if d == nil || d.db == nil {
+		return "", errors.New("database is unavailable")
+	}
+	raw := make([]byte, 16)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	value := hex.EncodeToString(raw)
+	if _, err := d.db.Exec("INSERT INTO installation_meta(id, install_uuid) VALUES(1,?) ON CONFLICT(id) DO UPDATE SET install_uuid=excluded.install_uuid", value); err != nil {
+		return "", err
+	}
+	var stored string
+	if err := d.db.QueryRow("SELECT install_uuid FROM installation_meta WHERE id=1").Scan(&stored); err != nil {
+		return "", err
+	}
+	stored = strings.TrimSpace(stored)
+	if stored != value {
+		return "", errors.New("installation identity was not updated")
+	}
+	d.installUUID = stored
+	return stored, nil
+}

--- a/dynamic_policy.go
+++ b/dynamic_policy.go
@@ -39,14 +39,16 @@ const (
 )
 
 const (
-	dynamicProfileSafe                 = "safe"
-	dynamicProfileCompatible           = "compatible"
-	dynamicCapabilityVersion           = 1
-	maxDynamicCapabilityBytes          = 16384
-	dynamicCapabilityAAD               = "meridian-dynamic-capability-v1"
-	dynamicProfileExtreme              = "extreme"
-	maxExtremeRequiredHeaderClaims     = 8
-	maxExtremeRequiredHeaderClaimBytes = 4 << 10
+	// dynamicProfileCompatible is the only profile the runtime assigns. The
+	// "safe" and "extreme" profiles are gone: per-site policy was removed in
+	// v1.9.86 and the code that branched on them was removed in v1.9.89, so a
+	// policy comparison here would always compare equal to this value.
+	dynamicProfileCompatible    = "compatible"
+	dynamicCapabilityVersion    = 1
+	maxDynamicCapabilityBytes   = 16384
+	dynamicCapabilityAAD        = "meridian-dynamic-capability-v1"
+	maxRequiredHeaderClaims     = 8
+	maxRequiredHeaderClaimBytes = 4 << 10
 
 	maxDynamicTargetURLBytes  = 4096
 	maxDynamicResolvedIPCount = 64

--- a/dynamic_rewrite_core.go
+++ b/dynamic_rewrite_core.go
@@ -12,6 +12,7 @@ import (
 	"mime"
 	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"strconv"
 	"strings"
@@ -228,6 +229,501 @@ func newDynamicPolicyDenialError(err error) *dynamicPolicyDenialError {
 		return nil
 	}
 	return &dynamicPolicyDenialError{reason: err.Error()}
+}
+
+// dynamicURLScanCandidate reports whether a downstream-visible string is
+// shaped like an absolute URL a client would follow, and whether it is safe to
+// hand over unproxied. Only the destination selector is considered: a fragment
+// or userinfo cannot be carried by a Meridian capability, so a URL using either
+// would be followed by the player directly.
+//
+// A string that is not URL-shaped (a relative path, a bare filename, a DRM
+// key-format identifier) is deliberately not a candidate: it cannot reach a
+// third-party host on its own, and an unrelated string that merely parses as a
+// URL must not block a compatibility preserve.
+func dynamicURLScanCandidate(value string) (candidate, safe bool) {
+	trimmed := strings.TrimSpace(value)
+	lowered := strings.ToLower(trimmed)
+	scheme := ""
+	switch {
+	case strings.HasPrefix(lowered, "http://"):
+		scheme = "http://"
+	case strings.HasPrefix(lowered, "https://"):
+		scheme = "https://"
+	default:
+		// Non-http schemes are deliberately not candidates here. The strict
+		// parsers already refuse them as a policy denial, so those bodies are
+		// never preserved, and several of them — skd://, for instance — are DRM
+		// identifiers that a player resolves through its own licence stack
+		// rather than a URL it fetches. Treating them as unroutable would
+		// reject ordinary FairPlay manifests for no security gain.
+		//
+		// A scheme followed by an authority is the one shape that could still
+		// reach a third-party host, so it is refused unless it is known not to
+		// name one. This keeps the scan conservative if a future strict parser
+		// stops rejecting an unfamiliar scheme.
+		if marker := strings.Index(lowered, "://"); marker > 0 {
+			switch lowered[:marker] {
+			case "skd", "blob", "data":
+				return false, false
+			default:
+				return true, false
+			}
+		}
+		return false, false
+	}
+	if len(trimmed) < len("http://x") {
+		return true, false
+	}
+	// A URL-shaped string must be safe. Anything about it that cannot be
+	// proven safe stays unsafe, including a host-less or opaque remainder.
+	if trimmed != value || containsDynamicUnsafeRune(trimmed) || strings.Contains(trimmed, `\`) || strings.Contains(trimmed, "{$") {
+		return true, false
+	}
+	hostPort := trimmed[len(scheme):]
+	if cut := strings.IndexAny(hostPort, "/?#"); cut >= 0 {
+		hostPort = hostPort[:cut]
+	}
+	if strings.HasPrefix(hostPort, "[") {
+		// A bracketed host is the RFC 3986 IPv6-literal form. Accept exactly
+		// the well-formed `[address]` or `[address]:port` shapes; every other
+		// use of a bracket stays unsafe.
+		closing := strings.IndexByte(hostPort, ']')
+		if closing < 0 {
+			return true, false
+		}
+		literal := net.ParseIP(hostPort[1:closing])
+		remainder := hostPort[closing+1:]
+		if literal == nil {
+			return true, false
+		}
+		// An IPv4-mapped literal such as [::ffff:198.51.100.7] is an IPv4
+		// destination in disguise, so it is judged by the address it maps to
+		// rather than rejected for having a mapped form.
+		addr, ok := netip.AddrFromSlice(literal)
+		if !ok {
+			return true, false
+		}
+		addr = addr.Unmap()
+		if addr.Is4() {
+			return true, false
+		}
+		if !dynamicIPIsPublic(addr) {
+			return true, false
+		}
+		if remainder != "" && (remainder[0] != ':' || len(remainder) == 1) {
+			return true, false
+		}
+		hostPort = hostPort[closing+1:]
+	} else if strings.ContainsAny(hostPort, "[]") {
+		return true, false
+	}
+	if strings.ContainsAny(hostPort, " \t\"'<>(){}|^`") {
+		return true, false
+	}
+	if at := strings.LastIndexByte(hostPort, '@'); at >= 0 {
+		return true, false
+	}
+	if strings.Contains(hostPort, "#") {
+		return true, false
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil || !parsed.IsAbs() || parsed.Opaque != "" || parsed.Host == "" || parsed.Hostname() == "" {
+		return true, false
+	}
+	if len(parsed.String()) > maxDynamicTargetURLBytes {
+		return true, false
+	}
+	// A fragment is carried by the client, never by the capability, so a
+	// fragment-bearing URL would be followed outside Meridian.
+	if parsed.Fragment != "" || parsed.RawFragment != "" {
+		return true, false
+	}
+	if !strings.EqualFold(parsed.Scheme, "http") && !strings.EqualFold(parsed.Scheme, "https") {
+		return true, false
+	}
+	if !dynamicURLDecodedComponentIsSafe(parsed.EscapedPath(), false) || !dynamicURLDecodedComponentIsSafe(parsed.RawQuery, true) {
+		return true, false
+	}
+	if dynamicURLPathHasDotSegments(parsed.EscapedPath()) {
+		return true, false
+	}
+	if port := parsed.Port(); port != "" {
+		number, err := strconv.Atoi(port)
+		if err != nil || number < 1 || number > 65535 {
+			return true, false
+		}
+	}
+	// The strict rewriter refuses non-public resolved addresses, so an IP
+	// literal pointing at a private, loopback, or otherwise special range is a
+	// destination Meridian would never have proxied. Preserving the body would
+	// hand that address to the client instead. The alternative numeric IPv4
+	// spellings (127.1, 0x7f000001, 2130706433) are not parsed by net.ParseIP,
+	// so they are matched by name below.
+	host := parsed.Hostname()
+	if literal := net.ParseIP(host); literal != nil {
+		addr, ok := netip.AddrFromSlice(literal)
+		if !ok || !dynamicIPIsPublic(addr.Unmap()) {
+			return true, false
+		}
+	} else if dynamicScanHostIsNonPublicShorthand(host) {
+		return true, false
+	}
+	return true, true
+}
+
+// dynamicScanHostIsNonPublicShorthand recognizes host names that resolve
+// without DNS to a local or otherwise special address: the literal "localhost"
+// and the alternative numeric IPv4 spellings that the resolver accepts but
+// net.ParseIP does not. A strict rewrite never proxies these, so preserving a
+// body that names one would expose it to the client instead.
+func dynamicScanHostIsNonPublicShorthand(host string) bool {
+	trimmed := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	if trimmed == "" {
+		return false
+	}
+	if trimmed == "localhost" || strings.HasSuffix(trimmed, ".localhost") {
+		return true
+	}
+	parts := strings.Split(trimmed, ".")
+	if len(parts) > 4 {
+		return false
+	}
+	octets := make([]int64, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			return false
+		}
+		// Base 0 accepts the decimal, octal and hexadecimal spellings a
+		// resolver accepts; anything outside a 32-bit range is not an address.
+		value, err := strconv.ParseInt(part, 0, 64)
+		if err != nil || value < 0 || value > 0xffffffff {
+			return false
+		}
+		octets = append(octets, value)
+	}
+	// Every part before the last is a single octet; the last absorbs all
+	// remaining bytes, which is why "127.1" means 127.0.0.1 and "2130706433"
+	// means 127.0.0.1 as well. Every shift below operates on a value already
+	// proven to be in [0, 0xffffffff], so the additions cannot overflow.
+	address := int64(0)
+	if len(octets) == 1 {
+		address = octets[0]
+	} else {
+		for index := 0; index < len(octets)-1; index++ {
+			if octets[index] > 0xff {
+				return false
+			}
+			address |= octets[index] << (8 * (3 - index))
+		}
+		trailing := octets[len(octets)-1]
+		switch len(octets) {
+		case 2:
+			trailing <<= 16
+		case 3:
+			trailing <<= 8
+		}
+		address |= trailing
+	}
+	bytes4 := [4]byte{
+		byte((address >> 24) & 0xff),
+		byte((address >> 16) & 0xff),
+		byte((address >> 8) & 0xff),
+		byte(address & 0xff),
+	}
+	return !dynamicIPIsPublic(netip.AddrFrom4(bytes4))
+}
+
+// scanHLSManifestURLs extracts every string a strict HLS rewrite would treat
+// as a network location: media URI lines and the URL-bearing attributes of
+// known tags. It is deliberately tolerant of the syntax errors that made the
+// strict parser give up, because its only job is to prove that no URL in the
+// payload would be followed outside Meridian.
+func scanHLSManifestURLs(payload []byte) (candidate, unsafe bool) {
+	sawCandidate := false
+	for _, rawLine := range strings.Split(string(payload), "\n") {
+		line := strings.TrimSuffix(rawLine, "\r")
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, "#") {
+			found, bad := dynamicURLScanValue(line)
+			sawCandidate = sawCandidate || found
+			if bad {
+				return true, true
+			}
+			continue
+		}
+		colon := strings.IndexByte(line, ':')
+		if colon < 0 || colon+1 >= len(line) {
+			continue
+		}
+		tag := line[:colon]
+		attributes, err := parseHLSAttributeList(line[colon+1:])
+		if err != nil {
+			// The strict parser stops at the first syntax error, which is often
+			// the only reason this body is being preserved. A malformed list
+			// must not hide a URL that appears earlier on the same line, so
+			// fall back to scanning every quoted or bare value on it.
+			for _, value := range hlsScanRawAttributeValues(line[colon+1:]) {
+				found, bad := dynamicURLScanValue(value)
+				sawCandidate = sawCandidate || found
+				if bad {
+					return true, true
+				}
+			}
+			continue
+		}
+		for _, attribute := range attributes {
+			value := line[colon+1:][attribute.valueStart:attribute.valueEnd]
+			if !hlsAttributeNameCarriesURL(tag, attribute.name) {
+				// Even an attribute that is not supposed to hold a URL must not
+				// smuggle one. #EXT-X-DEFINE VALUE is the documented case: a
+				// later {$name} reference expands it into a URI, so the URL
+				// reaches the player through a tag the strict rewriter rejected
+				// before it ever looked at the reference. Scanning every
+				// attribute value covers that case without having to enumerate
+				// which extension tags can feed a URI.
+				if found, bad := dynamicURLScanValue(value); bad {
+					return true, true
+				} else {
+					sawCandidate = sawCandidate || found
+				}
+				continue
+			}
+			found, bad := dynamicURLScanValue(value)
+			sawCandidate = sawCandidate || found
+			if bad {
+				return true, true
+			}
+		}
+	}
+	return sawCandidate, false
+}
+
+// hlsScanRawAttributeValues extracts value-shaped tokens from an attribute
+// list that failed to parse, so a syntax error cannot hide a URL on that line.
+func hlsScanRawAttributeValues(body string) []string {
+	values := make([]string, 0, 8)
+	for index := 0; index < len(body); index++ {
+		switch body[index] {
+		case '"':
+			close := strings.IndexByte(body[index+1:], '"')
+			if close < 0 {
+				values = append(values, body[index+1:])
+				return values
+			}
+			values = append(values, body[index+1:index+1+close])
+			index += close + 1
+		case '=':
+			start := index + 1
+			if start < len(body) && body[start] == '"' {
+				continue
+			}
+			end := start
+			for end < len(body) && body[end] != ',' {
+				end++
+			}
+			values = append(values, body[start:end])
+			index = end
+		}
+	}
+	return values
+}
+
+// hlsAttributeNameCarriesURL reports whether an attribute value is expected to
+// name a network location, so the scan can distinguish a missing rewrite from a
+// smuggled URL. It is intentionally broader than the strict rewriter's rewrite
+// list: a tag the strict parser refused (content steering, for example) still
+// carries an origin the player would fetch. Values of every other attribute are
+// still scanned by the caller, so an unlisted URL-bearing name is not a hole.
+func hlsAttributeNameCarriesURL(tag, name string) bool {
+	switch name {
+	case "URI", "URL", "X-URI", "X-URL", "X-ASSET-URI", "X-ASSET-LIST", "SERVER-URI", "BASE-URI":
+		return true
+	}
+	return strings.HasSuffix(name, "-URI") || strings.HasSuffix(name, "-URL")
+}
+
+// scanDASHManifestURLs extracts XML attribute values and text nodes that are
+// shaped like absolute URLs. Text nodes are included because the strict
+// rewriter rewrites recognized text content and, more importantly, because an
+// unrecognized feature inside a text node must not be handed to the player
+// with a live third-party destination.
+func scanDASHManifestURLs(payload []byte) (candidate, unsafe bool) {
+	sawCandidate := false
+	scan := func(value string) bool {
+		for _, decoded := range dashScanDecodedValues(value) {
+			found, bad := dynamicURLScanValue(decoded)
+			sawCandidate = sawCandidate || found
+			if bad {
+				return true
+			}
+		}
+		return false
+	}
+	rest := string(payload)
+	for {
+		open := strings.IndexByte(rest, '<')
+		if open < 0 {
+			break
+		}
+		rest = rest[open+1:]
+		end := strings.IndexByte(rest, '>')
+		if end < 0 {
+			break
+		}
+		tag := rest[:end]
+		rest = rest[end+1:]
+		if strings.HasPrefix(tag, "!") {
+			// CDATA carries text, not markup, so its content must be scanned as
+			// a value rather than skipped with the other declarations.
+			if body, ok := dashCDataBody(tag); ok {
+				if scan(body) {
+					return true, true
+				}
+			}
+			continue
+		}
+		if strings.HasPrefix(tag, "/") || strings.HasPrefix(tag, "?") {
+			continue
+		}
+		nameEnd := strings.IndexAny(tag, " \t\r\n/")
+		if nameEnd < 0 {
+			continue
+		}
+		for _, attribute := range dashScanAttributes(tag[nameEnd:]) {
+			if scan(attribute) {
+				return true, true
+			}
+		}
+	}
+	for _, text := range dashTextNodes(string(payload)) {
+		if scan(text) {
+			return true, true
+		}
+	}
+	return sawCandidate, false
+}
+
+// dashCDataBody returns the section content when a `<!...>` token is a CDATA
+// section.
+func dashCDataBody(tag string) (string, bool) {
+	const prefix = "![CDATA["
+	if !strings.HasPrefix(tag, prefix) {
+		return "", false
+	}
+	body := tag[len(prefix):]
+	return strings.TrimSuffix(body, "]]"), true
+}
+
+// dashScanDecodedValues returns the value together with its numeric-character-
+// reference decoding. An XML producer may legally write a scheme as entities
+// (`&#104;ttp://…`), and the parsed document would then carry a real URL even
+// though the raw bytes never contain the literal scheme.
+func dashScanDecodedValues(value string) []string {
+	values := []string{value}
+	if !strings.Contains(value, "&#") {
+		return values
+	}
+	var builder strings.Builder
+	builder.Grow(len(value))
+	for index := 0; index < len(value); {
+		if value[index] == '&' && index+1 < len(value) && value[index+1] == '#' {
+			end := strings.IndexByte(value[index:], ';')
+			if end > 2 {
+				digits := value[index+2 : index+end]
+				base := 10
+				if digits[0] == 'x' || digits[0] == 'X' {
+					digits, base = digits[1:], 16
+				}
+				if code, err := strconv.ParseInt(digits, base, 32); err == nil && code > 0 && code <= 0x10ffff {
+					builder.WriteRune(rune(code))
+					index += end + 1
+					continue
+				}
+			}
+		}
+		builder.WriteByte(value[index])
+		index++
+	}
+	if decoded := builder.String(); decoded != value {
+		values = append(values, decoded)
+	}
+	return values
+}
+
+// dashScanAttributes returns the quoted attribute values of one XML start tag.
+func dashScanAttributes(body string) []string {
+	values := make([]string, 0, 8)
+	for index := 0; index < len(body); index++ {
+		quote := body[index]
+		if quote != '"' && quote != '\'' {
+			continue
+		}
+		close := strings.IndexByte(body[index+1:], quote)
+		if close < 0 {
+			break
+		}
+		values = append(values, body[index+1:index+1+close])
+		index += close + 1
+	}
+	return values
+}
+
+// dashTextNodes returns the character data between XML tags.
+func dashTextNodes(document string) []string {
+	nodes := make([]string, 0, 16)
+	rest := document
+	for {
+		open := strings.IndexByte(rest, '>')
+		if open < 0 {
+			break
+		}
+		rest = rest[open+1:]
+		next := strings.IndexByte(rest, '<')
+		if next < 0 {
+			if trimmed := strings.TrimSpace(rest); trimmed != "" {
+				nodes = append(nodes, trimmed)
+			}
+			break
+		}
+		if trimmed := strings.TrimSpace(rest[:next]); trimmed != "" {
+			nodes = append(nodes, trimmed)
+		}
+		rest = rest[next:]
+	}
+	return nodes
+}
+
+// dynamicURLScanValue classifies one extracted string.
+func dynamicURLScanValue(value string) (candidate, unsafe bool) {
+	candidate, safe := dynamicURLScanCandidate(value)
+	return candidate, candidate && !safe
+}
+
+// preservedStructuredBodyIsSafe proves that preserving an upstream structured
+// body verbatim will not hand the client a network destination Meridian cannot
+// represent. Every URL-shaped string the strict rewriter would have rewritten
+// must be one a capability could have carried.
+//
+// This closes the gap between "the strict parser rejected this manifest" and
+// "therefore the original bytes are safe to forward". A parser that stops
+// early on a vendor tag, an unsupported DRM descriptor, or an attribute error
+// never reaches its per-URL validation, so its failure alone proves nothing
+// about the URLs still in the payload. A relative path or a non-URL token
+// proves nothing either way and is ignored.
+func preservedStructuredBodyIsSafe(source string, payload []byte) bool {
+	switch source {
+	case dynamicDiscoverySourceHLS:
+		_, unsafe := scanHLSManifestURLs(payload)
+		return !unsafe
+	case dynamicDiscoverySourceDASH:
+		_, unsafe := scanDASHManifestURLs(payload)
+		return !unsafe
+	default:
+		return true
+	}
 }
 
 func (e *dynamicPolicyDenialError) Error() string { return e.reason }
@@ -826,9 +1322,14 @@ func rewriteDynamicStructuredResponseAccepted(resp *http.Response, issuer *dynam
 			if accept != nil && !accept() {
 				return errDynamicCapabilityExpiredDuringUse
 			}
-			log.Printf("[%s] PlaybackInfo automatic URL proxy fallback preserved the upstream response", issuer.site.Name)
-			installDynamicStructuredBody(resp, payload, false)
-			return nil
+			// The schema-free walker refused a URL it recognized but could not
+			// route. Falling back to the upstream bytes here would be worse
+			// than the failure it avoids: the client would receive the whole
+			// body with every URL unproxied, so one unroutable field would cost
+			// the capability, the traffic accounting and the quota for all of
+			// them. Fail the response instead.
+			log.Printf("[%s] PlaybackInfo rewrite and automatic fallback both rejected: diagnostic=%s", issuer.site.Name, playbackInfoRewriteDiagnosticCode(fallbackErr))
+			return recordFailure(dynamicObservationReasonPlaybackInfoDenied)
 		}
 	}
 	if err != nil {
@@ -844,10 +1345,19 @@ func rewriteDynamicStructuredResponseAccepted(resp *http.Response, issuer *dynam
 		// for the whole site. PlaybackInfo keeps its own stricter chain: its
 		// denials (for example required headers on a relative URL that no
 		// capability could carry) must stay hard errors.
+		//
+		// Preserving is only safe once the payload has been proven to contain
+		// no network destination Meridian could not have represented: the
+		// strict parser stops at the first unsupported feature, so its failure
+		// says nothing about the URLs that follow it.
 		var denial *dynamicPolicyDenialError
 		if resp != nil && resp.Body != nil && resp.StatusCode < http.StatusBadRequest &&
 			(source == dynamicDiscoverySourceHLS || source == dynamicDiscoverySourceDASH) &&
 			!errors.As(err, &denial) {
+			if !preservedStructuredBodyIsSafe(source, payload) {
+				log.Printf("[%s] %s rewrite rejected and the body contains an unroutable URL; refusing to preserve it", issuer.site.Name, source)
+				return recordFailure(dynamicStructuredRewriteDeniedReason(source))
+			}
 			log.Printf("[%s] %s rewrite rejected; preserving upstream response: %v", issuer.site.Name, source, err)
 			issuer.observe(source, dynamicObservationDecisionDenied, dynamicStructuredRewriteDeniedReason(source), authority)
 			installDynamicStructuredBody(resp, payload, false)

--- a/dynamic_runtime_state.go
+++ b/dynamic_runtime_state.go
@@ -429,7 +429,7 @@ type dynamicCapabilityClaims struct {
 	RequiredHeaders []dynamicCapabilityHeaderClaim `json:"h,omitempty"`
 }
 
-func normalizeExtremeRequiredHeaderName(value string) (string, error) {
+func normalizeRequiredHeaderName(value string) (string, error) {
 	value = strings.TrimSpace(value)
 	if value == "" || len(value) > maxUpstreamHeaderName {
 		return "", fmt.Errorf("RequiredHttpHeaders contains an invalid name")
@@ -448,7 +448,7 @@ func normalizeExtremeRequiredHeaderName(value string) (string, error) {
 	}
 }
 
-func normalizeExtremeRequiredHeaderValue(value string) (string, error) {
+func normalizeRequiredHeaderValue(value string) (string, error) {
 	value = strings.TrimSpace(value)
 	if value == "" {
 		return "", fmt.Errorf("RequiredHttpHeaders contains an empty value")
@@ -465,22 +465,22 @@ func validateDynamicCapabilityRequiredHeaderClaims(headers []dynamicCapabilityHe
 	if headers == nil {
 		return nil
 	}
-	if len(headers) == 0 || len(headers) > maxExtremeRequiredHeaderClaims {
+	if len(headers) == 0 || len(headers) > maxRequiredHeaderClaims {
 		return fmt.Errorf("invalid capability required header count")
 	}
 	totalBytes := 0
 	previousName := ""
 	for _, header := range headers {
-		name, err := normalizeExtremeRequiredHeaderName(header.Name)
+		name, err := normalizeRequiredHeaderName(header.Name)
 		if err != nil || name != header.Name || previousName != "" && header.Name <= previousName {
 			return fmt.Errorf("invalid capability required header name")
 		}
-		value, err := normalizeExtremeRequiredHeaderValue(header.Value)
+		value, err := normalizeRequiredHeaderValue(header.Value)
 		if err != nil || value != header.Value {
 			return fmt.Errorf("invalid capability required header value")
 		}
 		totalBytes += len(header.Name) + len(header.Value)
-		if totalBytes > maxExtremeRequiredHeaderClaimBytes {
+		if totalBytes > maxRequiredHeaderClaimBytes {
 			return fmt.Errorf("capability required headers exceed their size limit")
 		}
 		previousName = header.Name
@@ -499,18 +499,18 @@ func dynamicRequiredHeadersConflictWithFixedPolicy(headers []dynamicCapabilityHe
 	return false
 }
 
-func normalizeExtremeRequiredHeaderClaims(headers map[string]any, fixedPolicy upstreamHeaderPolicy) ([]dynamicCapabilityHeaderClaim, error) {
+func normalizeRequiredHeaderClaims(headers map[string]any, fixedPolicy upstreamHeaderPolicy) ([]dynamicCapabilityHeaderClaim, error) {
 	if len(headers) == 0 {
 		return nil, nil
 	}
-	if len(headers) > maxExtremeRequiredHeaderClaims {
+	if len(headers) > maxRequiredHeaderClaims {
 		return nil, fmt.Errorf("RequiredHttpHeaders exceeds its entry limit")
 	}
 	normalized := make([]dynamicCapabilityHeaderClaim, 0, len(headers))
 	seen := make(map[string]bool, len(headers))
 	totalBytes := 0
 	for rawName, rawValue := range headers {
-		name, err := normalizeExtremeRequiredHeaderName(rawName)
+		name, err := normalizeRequiredHeaderName(rawName)
 		if err != nil {
 			return nil, err
 		}
@@ -523,12 +523,12 @@ func normalizeExtremeRequiredHeaderClaims(headers map[string]any, fixedPolicy up
 		if !ok {
 			return nil, fmt.Errorf("RequiredHttpHeaders contains a non-string value")
 		}
-		value, err = normalizeExtremeRequiredHeaderValue(value)
+		value, err = normalizeRequiredHeaderValue(value)
 		if err != nil {
 			return nil, err
 		}
 		totalBytes += len(name) + len(value)
-		if totalBytes > maxExtremeRequiredHeaderClaimBytes {
+		if totalBytes > maxRequiredHeaderClaimBytes {
 			return nil, fmt.Errorf("RequiredHttpHeaders exceeds its size limit")
 		}
 		normalized = append(normalized, dynamicCapabilityHeaderClaim{Name: name, Value: value})

--- a/dynamic_structured_discovery_test.go
+++ b/dynamic_structured_discovery_test.go
@@ -214,16 +214,32 @@ func TestPlaybackInfoRewriteDiagnosticCodeIsStableAndSecretFree(t *testing.T) {
 	if got := playbackInfoRewriteDiagnosticFingerprint(errors.New("unexpected upstream value bearer-secret")); len(got) != 8 || strings.Contains(got, "secret") {
 		t.Fatalf("diagnostic fingerprint is unsafe: %q", got)
 	}
-	if !playbackInfoAutomaticFallbackAllowed(errors.New("invalid discovered URL: target normalization host")) {
-		t.Fatal("URL normalization failure must allow automatic proxy fallback")
+	// A URL whose destination cannot be proven safe must not enter the
+	// schema-free walker: that walker is the path that keeps individual URLs on
+	// the proxy, so re-deciding a security failure there would route around the
+	// strict rules. Only genuinely compatibility-level syntax failures qualify.
+	if playbackInfoAutomaticFallbackAllowed(errors.New("invalid discovered URL: target normalization host")) {
+		t.Fatal("a URL normalization decision must not allow automatic proxy fallback")
 	}
 	for _, err := range []error{
+		errors.New("invalid discovered URL: userinfo"),
+		errors.New("invalid discovered URL: fragment"),
+		errors.New("invalid discovered URL: target normalization scheme"),
+		errors.New("invalid discovered URL: target normalization dot_segments"),
 		errors.New("external subtitle URL requires unsupported origin headers"),
 		errors.New("PlaybackInfo RequiredHttpHeaders has an invalid value"),
 		errors.New("invalid PlaybackInfo JSON"),
 	} {
 		if playbackInfoAutomaticFallbackAllowed(err) {
 			t.Fatalf("security or structure error unexpectedly allowed fallback: %v", err)
+		}
+	}
+	for _, err := range []error{
+		errors.New("invalid discovered URL: surrounding whitespace"),
+		errors.New("invalid discovered URL: parse"),
+	} {
+		if !playbackInfoAutomaticFallbackAllowed(err) {
+			t.Fatalf("compatibility-only error must allow fallback: %v", err)
 		}
 	}
 }
@@ -238,7 +254,12 @@ func TestPlaybackInfoRelativeExternalDeliveryURLWithRequiredHeadersFailsClosed(t
 	}
 }
 
-func TestAutomaticPlaybackInfoFallbackRewritesValidURLsAndPreservesInvalidOnes(t *testing.T) {
+// TestAutomaticPlaybackInfoFallbackRefusesURLsItCannotProxy replaces the
+// earlier preservation contract. Keeping an absolute URL the walker could not
+// route handed the player the upstream destination directly: no capability, no
+// traffic accounting, no quota, and the origin address revealed. A relative
+// same-origin playback path is not a network destination and is still kept.
+func TestAutomaticPlaybackInfoFallbackRefusesURLsItCannotProxy(t *testing.T) {
 	issuer := newStructuredDiscoveryTestIssuer(t)
 	base := mustStructuredURL(t, "http://line.example.com/Items/1/PlaybackInfo")
 	payload := []byte(`{"MediaSources":[{"DirectStreamUrl":"http://line.example.com/Videos/1/original.mkv?token=origin-secret","MediaStreams":[{"DeliveryUrl":"http://backend.invalidtld/subtitle.vtt","IsExternalUrl":true}]}]}`)
@@ -250,16 +271,20 @@ func TestAutomaticPlaybackInfoFallbackRewritesValidURLsAndPreservesInvalidOnes(t
 	strictSession.rollback()
 
 	fallbackSession := &dynamicRewriteSession{ctx: context.Background(), issuer: issuer, base: base, source: dynamicDiscoverySourcePlaybackInfo}
-	rewritten, err := rewriteAutomaticPlaybackInfoResponse(payload, fallbackSession)
+	if _, err := rewriteAutomaticPlaybackInfoResponse(payload, fallbackSession); err == nil {
+		t.Fatal("the automatic fallback must not preserve a URL it cannot proxy")
+	}
+	fallbackSession.rollback()
+
+	// The same walker keeps a relative same-origin playback URL on the proxy.
+	relativePayload := []byte(`{"MediaSources":[{"DirectStreamUrl":"/Videos/1/original.mkv?token=local-token"}]}`)
+	relativeSession := &dynamicRewriteSession{ctx: context.Background(), issuer: issuer, base: base, source: dynamicDiscoverySourcePlaybackInfo}
+	rewritten, err := rewriteAutomaticPlaybackInfoResponse(relativePayload, relativeSession)
 	if err != nil {
-		t.Fatalf("automatic PlaybackInfo fallback: %v", err)
+		t.Fatalf("automatic PlaybackInfo fallback on a relative path: %v", err)
 	}
-	text := string(rewritten)
-	if !strings.Contains(text, `"DirectStreamUrl":"/Videos/1/original.mkv?token=origin-secret"`) {
-		t.Fatalf("same-authority playback URL was not kept on the proxy: %s", text)
-	}
-	if !strings.Contains(text, `"DeliveryUrl":"http://backend.invalidtld/subtitle.vtt"`) {
-		t.Fatalf("invalid optional URL was not preserved: %s", text)
+	if !strings.Contains(string(rewritten), `"/Videos/1/original.mkv?token=local-token"`) {
+		t.Fatalf("relative same-origin playback path changed: %s", rewritten)
 	}
 }
 
@@ -2058,11 +2083,13 @@ func assertStructuredRewriteFailsAtomically(t *testing.T, profile, source, reque
 	}
 }
 
-func TestSafeAndCompatibleDASHRejectExtremeDRMAndForeignWrappers(t *testing.T) {
+func TestDASHRejectsDRMAndForeignWrappersOutsideTheRemovedProfiles(t *testing.T) {
 	features := map[string][]byte{
 		"ContentProtection": []byte(`<MPD xmlns="urn:mpeg:dash:schema:mpd:2011"><Period><AdaptationSet><ContentProtection schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed"/><Representation id="v"><BaseURL>video.mp4</BaseURL></Representation></AdaptationSet></Period></MPD>`),
 		"foreign wrapper":   []byte(`<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:v="urn:vendor:passive"><Period><v:Wrapper><Representation id="v"><BaseURL>video.mp4</BaseURL></Representation></v:Wrapper></Period></MPD>`),
 	}
+	// dynamicProfileCompatible is the only profile the runtime assigns; the
+	// loop is kept so the assertion stays bound to a named profile.
 	for _, profile := range []string{dynamicProfileCompatible} {
 		for feature, manifest := range features {
 			t.Run(profile+"/"+feature, func(t *testing.T) {
@@ -2070,7 +2097,7 @@ func TestSafeAndCompatibleDASHRejectExtremeDRMAndForeignWrappers(t *testing.T) {
 				session := &dynamicRewriteSession{ctx: context.Background(), issuer: issuer, base: mustStructuredURL(t, "https://api.example.com/live/manifest.mpd"), source: dynamicDiscoverySourceDASH}
 				if _, err := rewriteDASHResponse(manifest, session); err == nil {
 					session.rollback()
-					t.Fatalf("%s accepted Extreme DASH %s", profile, feature)
+					t.Fatalf("profile %s accepted legacy DASH %s", profile, feature)
 				}
 				session.rollback()
 				if len(issuer.state.capabilities) != 0 || len(issuer.state.authorities) != 0 {
@@ -2081,7 +2108,7 @@ func TestSafeAndCompatibleDASHRejectExtremeDRMAndForeignWrappers(t *testing.T) {
 	}
 }
 
-func TestSafeAndCompatiblePlaybackInfoKeepLegacyNestedCollectionHandling(t *testing.T) {
+func TestPlaybackInfoLegacyNestedCollectionHandlingOnTheOnlyProfile(t *testing.T) {
 	streamText := structuredTestStringifiedJSON(t, map[string]any{
 		"IsExternalUrl": true,
 		"DeliveryUrl":   "https://captions.example.com/subtitle.vtt?sig=legacy-secret",
@@ -2089,6 +2116,8 @@ func TestSafeAndCompatiblePlaybackInfoKeepLegacyNestedCollectionHandling(t *test
 	attachmentText := structuredTestStringifiedJSON(t, []any{map[string]any{
 		"AttachmentUrl": "https://attachments.example.com/font.bin?sig=legacy-secret",
 	}})
+	// dynamicProfileCompatible is the only profile the runtime assigns; the
+	// loop is kept so the assertion stays bound to a named profile.
 	for _, profile := range []string{dynamicProfileCompatible} {
 		t.Run(profile, func(t *testing.T) {
 			issuer := newStructuredDiscoveryTestIssuerForProfile(t, profile)
@@ -2116,11 +2145,13 @@ func TestSafeAndCompatiblePlaybackInfoKeepLegacyNestedCollectionHandling(t *test
 	}
 }
 
-func TestSafeAndCompatibleHLSRejectExtremeFeaturesIndependently(t *testing.T) {
+func TestHLSRejectsRemovedProfileFeaturesIndependently(t *testing.T) {
 	features := map[string][]byte{
 		"DEFINE":                []byte("#EXTM3U\n#EXT-X-DEFINE:NAME=\"segment\",VALUE=\"video\"\n#EXT-X-TARGETDURATION:4\n#EXTINF:4,\n{$segment}.ts\n#EXT-X-ENDLIST\n"),
 		"unknown URI attribute": []byte("#EXTM3U\n#EXT-X-VENDOR-METADATA:URI=\"https://metadata.example.com/value.json\"\n#EXT-X-STREAM-INF:BANDWIDTH=1000\nchild.m3u8\n"),
 	}
+	// dynamicProfileCompatible is the only profile the runtime assigns; the
+	// loop is kept so the assertion stays bound to a named profile.
 	for _, profile := range []string{dynamicProfileCompatible} {
 		for feature, manifest := range features {
 			t.Run(profile+"/"+feature, func(t *testing.T) {

--- a/edge_agent.go
+++ b/edge_agent.go
@@ -1232,7 +1232,7 @@ func (runtime *edgeAgentRuntime) commitSiteStatsWithACK(pending edgeSiteStatsPen
 				// Rebase the Controller baseline and ACK watermark together.
 				// The just-committed report must remain billable immediately;
 				// it must not disappear until the next config refresh.
-				inst.trafficCycleUsage += trafficBillableBytes(inst.trafficCycleMode, delta.CumulativeBytesIn, delta.CumulativeBytesOut)
+				inst.trafficCycleUsage = saturatingAddInt64(inst.trafficCycleUsage, trafficBillableBytes(inst.trafficCycleMode, delta.CumulativeBytesIn, delta.CumulativeBytesOut))
 			}
 			inst.trafficAckedCumulativeIn = stat.CumulativeBytesIn
 			inst.trafficAckedCumulativeOut = stat.CumulativeBytesOut
@@ -1977,7 +1977,20 @@ func (runtime *edgeAgentRuntime) nextTelemetrySequence() int64 {
 	return runtime.telemetrySequence
 }
 
-func (runtime *edgeAgentRuntime) close() {
+// edgeEventSpoolFlushError reports that the final, shutdown-time spool
+// persistence failed. It is a named error so callers can distinguish "the
+// process is stopping but up to two seconds of unacknowledged events could not
+// be written" from an ordinary runtime failure.
+var edgeEventSpoolFlushError = errors.New("event spool persistence failed during shutdown")
+
+// close tears the runtime down. The returned error reports a failed final
+// spool flush; the caller decides whether an unusable queue warrants a failed
+// exit. Closing itself is always complete: the data plane is stopped and the
+// bundle released before the flush is attempted.
+func (runtime *edgeAgentRuntime) close() error {
+	if runtime == nil {
+		return nil
+	}
 	runtime.quiesced.Store(true)
 	runtime.stopServer()
 	runtime.mu.Lock()
@@ -1994,8 +2007,30 @@ func (runtime *edgeAgentRuntime) close() {
 		bundle.close()
 	}
 	// The debounced spool may still hold <2s of unpersisted events; a
-	// graceful stop (self-update, systemd) must not lose them.
-	_ = runtime.events.flush()
+	// graceful stop (self-update, systemd) must not lose them. Retry briefly
+	// because the usual cause is a transient write error. Each attempt is a
+	// synchronous fsync with no deadline, so a device that never returns will
+	// still block shutdown; the bounded retry limits the number of attempts,
+	// not the time a single attempt may take.
+	return flushEdgeEventStoreOnShutdown(&runtime.events)
+}
+
+// flushEdgeEventStoreOnShutdown persists the event spool with a bounded retry
+// so a transient I/O error does not silently drop the last debounce window.
+func flushEdgeEventStoreOnShutdown(store *edgeEventStore) error {
+	if store == nil {
+		return nil
+	}
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if lastErr = store.flush(); lastErr == nil {
+			return nil
+		}
+		if attempt < 2 {
+			time.Sleep(150 * time.Millisecond)
+		}
+	}
+	return fmt.Errorf("%w: %v", edgeEventSpoolFlushError, lastErr)
 }
 
 func (runtime *edgeAgentRuntime) setSessionEpoch(epoch int64) {
@@ -2096,7 +2131,9 @@ func isEdgeAgentStale(err error) bool {
 // repairs the service instead.
 func edgeQuiesceRevoked(ctx context.Context, runtime *edgeAgentRuntime, marker string) error {
 	if runtime != nil {
-		runtime.close()
+		if err := runtime.close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Meridian Agent is revoked; %v\n", err)
+		}
 	}
 	if err := os.WriteFile(marker, []byte("revoked\n"), 0o600); err != nil {
 		fmt.Fprintf(os.Stderr, "Meridian Agent is revoked but cannot persist revoked state: %v; remaining offline until stopped\n", err)
@@ -2129,7 +2166,9 @@ func edgeQuiesceStale(runtime *edgeAgentRuntime) {
 	if runtime == nil {
 		return
 	}
-	runtime.close()
+	if err := runtime.close(); err != nil {
+		fmt.Fprintf(os.Stderr, "Meridian Agent lost its Controller lease; %v\n", err)
+	}
 	runtime.setLeaseID("")
 }
 
@@ -2626,7 +2665,7 @@ func edgeFetchAgentManifest(ctx context.Context, client *http.Client, controller
 	return manifest, nil
 }
 
-func runEdgeAgent() error {
+func runEdgeAgent() (runErr error) {
 	flags := flag.NewFlagSet("meridian-agent", flag.ContinueOnError)
 	controllerValue := flags.String("controller", "", "controller URL")
 	statePath := flags.String("state", "/var/lib/meridian-agent/state.json", "state path")
@@ -2721,7 +2760,14 @@ func runEdgeAgent() error {
 			return fmt.Errorf("load event spool: %w (quarantine failed: %v)", err, quarantineErr)
 		}
 	}
-	defer runtime.close()
+	defer func() {
+		// Surface a failed final spool flush as a failed exit instead of
+		// silently dropping the last debounce window. Never mask an existing
+		// error from the main loop.
+		if closeErr := runtime.close(); closeErr != nil && runErr == nil {
+			runErr = closeErr
+		}
+	}()
 	wsReporter := newEdgeWSReportClient(controller, state.Token)
 	defer wsReporter.close()
 	bootID := edgeBootID()

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.26.6
 require (
 	golang.org/x/crypto v0.54.0
 	golang.org/x/net v0.57.0
+	golang.org/x/sync v0.22.0
+	golang.org/x/sys v0.47.0
 	modernc.org/sqlite v1.55.0
 )
 
@@ -14,8 +16,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	golang.org/x/sync v0.22.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	modernc.org/libc v1.74.1 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/hls_rewrite.go
+++ b/hls_rewrite.go
@@ -246,350 +246,6 @@ func rewriteHLSAttributeLine(line string, names map[string]bool, session *dynami
 	return line, nil
 }
 
-const (
-	maxExtremeHLSVariableCount      = globalDynamicMaxHLSAttributesPerTag
-	maxExtremeHLSVariableNameBytes  = 128
-	maxExtremeHLSVariableValueBytes = maxDynamicTargetURLBytes
-	maxExtremeHLSVariableTableBytes = globalDynamicMaxStringBytes
-)
-
-type extremeHLSVariableTable struct {
-	values     map[string]string
-	bytesUsed  int
-	countLimit int
-	byteLimit  int
-}
-
-func newExtremeHLSVariableTable(session *dynamicRewriteSession) *extremeHLSVariableTable {
-	countLimit := maxExtremeHLSVariableCount
-	if session != nil && session.issuer != nil && session.issuer.policy.limits.MaxURLsPerResponse < countLimit {
-		countLimit = session.issuer.policy.limits.MaxURLsPerResponse
-	}
-	byteLimit := maxExtremeHLSVariableTableBytes
-	if session != nil {
-		if outputLimit := session.structuredOutputLimit(); outputLimit > 0 && outputLimit < int64(byteLimit) {
-			byteLimit = int(outputLimit)
-		}
-	}
-	return &extremeHLSVariableTable{
-		values:     make(map[string]string),
-		countLimit: countLimit,
-		byteLimit:  byteLimit,
-	}
-}
-
-func isExtremeHLSVariableName(value string) bool {
-	if value == "" || len(value) > maxExtremeHLSVariableNameBytes {
-		return false
-	}
-	for index := range len(value) {
-		character := value[index]
-		if character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' || character >= '0' && character <= '9' || character == '-' || character == '_' {
-			continue
-		}
-		return false
-	}
-	return true
-}
-
-func (table *extremeHLSVariableTable) defineFromExtremeHLSLine(line string) error {
-	if table == nil {
-		return fmt.Errorf("HLS variable table is unavailable")
-	}
-	colon := strings.IndexByte(line, ':')
-	if colon < 0 || colon+1 >= len(line) {
-		return fmt.Errorf("invalid HLS variable definition")
-	}
-	attributes, err := parseHLSAttributeList(line[colon+1:])
-	if err != nil {
-		return err
-	}
-	var name, value, imported string
-	var hasName, hasValue, hasImport bool
-	var nameQuoted, valueQuoted, importQuoted bool
-	for _, attribute := range attributes {
-		attributeValue := line[colon+1+attribute.valueStart : colon+1+attribute.valueEnd]
-		switch attribute.name {
-		case "NAME":
-			name, hasName, nameQuoted = attributeValue, true, attribute.quoted
-		case "VALUE":
-			value, hasValue, valueQuoted = attributeValue, true, attribute.quoted
-		case "IMPORT":
-			imported, hasImport, importQuoted = attributeValue, true, attribute.quoted
-		default:
-			return fmt.Errorf("unsupported HLS variable definition attribute")
-		}
-	}
-	if hasImport {
-		if hasName || hasValue || len(attributes) != 1 || !importQuoted || !isExtremeHLSVariableName(imported) {
-			return fmt.Errorf("invalid HLS variable import")
-		}
-		if _, exists := table.values[imported]; !exists {
-			return fmt.Errorf("HLS variable import is not locally defined")
-		}
-		return nil
-	}
-	if !hasName || !hasValue || len(attributes) != 2 || !nameQuoted || !valueQuoted || !isExtremeHLSVariableName(name) {
-		return fmt.Errorf("invalid HLS variable definition")
-	}
-	if len(value) > maxExtremeHLSVariableValueBytes || strings.Contains(value, "{$") || value != "" && (containsDynamicUnsafeRune(value) || strings.Contains(value, `\`)) {
-		return fmt.Errorf("invalid HLS variable value")
-	}
-	if _, exists := table.values[name]; exists {
-		return fmt.Errorf("duplicate HLS variable definition")
-	}
-	if len(table.values) >= table.countLimit {
-		return fmt.Errorf("HLS variable count exceeds its limit")
-	}
-	entryBytes := len(name) + len(value)
-	if entryBytes > table.byteLimit-table.bytesUsed {
-		return fmt.Errorf("HLS variable table exceeds its budget")
-	}
-	table.values[name] = value
-	table.bytesUsed += entryBytes
-	return nil
-}
-
-func (table *extremeHLSVariableTable) substituteExtremeHLSURI(value string) (string, error) {
-	if !strings.Contains(value, "{$") {
-		return value, nil
-	}
-	if table == nil {
-		return "", fmt.Errorf("HLS variable substitution is unavailable")
-	}
-	var output strings.Builder
-	output.Grow(min(len(value), maxExtremeHLSVariableValueBytes))
-	for cursor := 0; ; {
-		markerOffset := strings.Index(value[cursor:], "{$")
-		if markerOffset < 0 {
-			if len(value)-cursor > maxDynamicTargetURLBytes-output.Len() {
-				return "", fmt.Errorf("HLS substituted URI exceeds its limit")
-			}
-			output.WriteString(value[cursor:])
-			break
-		}
-		markerStart := cursor + markerOffset
-		markerEndOffset := strings.IndexByte(value[markerStart+2:], '}')
-		if markerEndOffset < 0 {
-			return "", fmt.Errorf("invalid HLS variable reference")
-		}
-		markerEnd := markerStart + 2 + markerEndOffset
-		name := value[markerStart+2 : markerEnd]
-		if !isExtremeHLSVariableName(name) {
-			return "", fmt.Errorf("invalid HLS variable reference")
-		}
-		replacement, exists := table.values[name]
-		if !exists {
-			return "", fmt.Errorf("unresolved HLS variable")
-		}
-		literalBytes := markerStart - cursor
-		if literalBytes > maxDynamicTargetURLBytes-output.Len() || len(replacement) > maxDynamicTargetURLBytes-output.Len()-literalBytes {
-			return "", fmt.Errorf("HLS substituted URI exceeds its limit")
-		}
-		output.WriteString(value[cursor:markerStart])
-		output.WriteString(replacement)
-		cursor = markerEnd + 1
-	}
-	resolved := output.String()
-	if resolved == "" || len(resolved) > maxDynamicTargetURLBytes || strings.Contains(resolved, "{$") {
-		return "", fmt.Errorf("invalid substituted HLS URI")
-	}
-	return resolved, nil
-}
-
-type extremeHLSReplacement struct {
-	start int
-	end   int
-	value string
-}
-
-func applyExtremeHLSReplacements(line string, replacements []extremeHLSReplacement) string {
-	for index := len(replacements) - 1; index >= 0; index-- {
-		replacement := replacements[index]
-		line = line[:replacement.start] + replacement.value + line[replacement.end:]
-	}
-	return line
-}
-
-func isExtremeHLSURIAttributeName(name string) bool {
-	return name == "URI" || strings.HasSuffix(name, "-URI")
-}
-
-func isExtremeHLSPotentialURLAttributeName(name string) bool {
-	return name == "URL" || strings.HasSuffix(name, "-URL")
-}
-
-func isExtremeHLSSensitiveURIReference(tag, name string) bool {
-	for _, marker := range []string{"KEY", "DRM", "LICENSE", "WIDEVINE", "PLAYREADY", "FAIRPLAY", "CENC", "SKD", "CKC"} {
-		if strings.Contains(tag, marker) || strings.Contains(name, marker) {
-			return true
-		}
-	}
-	return false
-}
-
-func isExtremeHLSUnknownTagName(tag string) bool {
-	const prefix = "#EXT-X-"
-	if !strings.HasPrefix(tag, prefix) || len(tag) == len(prefix) || tag[len(tag)-1] == '-' {
-		return false
-	}
-	for index := len(prefix); index < len(tag); index++ {
-		if !isHLSAttributeNameByte(tag[index]) {
-			return false
-		}
-	}
-	return true
-}
-
-func extremeHLSValueMayExposeURI(value string) bool {
-	candidate := strings.Trim(value, `"`)
-	if candidate == "" {
-		return false
-	}
-	if strings.Contains(candidate, `\`) || strings.HasPrefix(candidate, "//") || strings.Contains(candidate, "://") {
-		return true
-	}
-	reference, err := url.Parse(candidate)
-	return err == nil && (reference.IsAbs() || reference.Host != "")
-}
-
-func validateExtremeHLSOpaqueTagValue(value string) error {
-	if strings.Contains(value, "{$") {
-		return fmt.Errorf("unresolved HLS variable outside a URI")
-	}
-	upperValue := strings.ToUpper(value)
-	if strings.Contains(value, "=") && (strings.Contains(upperValue, "URI") || strings.Contains(upperValue, "URL")) || extremeHLSValueMayExposeURI(value) {
-		return fmt.Errorf("unsupported URI-bearing HLS extension tag")
-	}
-	return nil
-}
-
-func rewriteExtremeHLSParsedAttributeLine(line string, attributes []hlsAttributeSpan, baseNames map[string]bool, validateKnown, rejectPotentialURI bool, variables *extremeHLSVariableTable, session *dynamicRewriteSession) (string, error) {
-	colon := strings.IndexByte(line, ':')
-	if colon < 0 || colon+1 >= len(line) {
-		return "", fmt.Errorf("invalid HLS tag attribute list")
-	}
-	tag := line[:colon]
-	names := make(map[string]bool, len(baseNames)+2)
-	for name := range baseNames {
-		names[name] = true
-	}
-	expansions := make([]extremeHLSReplacement, 0, 2)
-	for _, attribute := range attributes {
-		knownURIName := baseNames[attribute.name]
-		if !knownURIName && !isExtremeHLSURIAttributeName(attribute.name) {
-			attributeValue := line[colon+1+attribute.valueStart : colon+1+attribute.valueEnd]
-			if strings.Contains(attributeValue, "{$") {
-				return "", fmt.Errorf("unresolved HLS variable outside a URI")
-			}
-			if isExtremeHLSPotentialURLAttributeName(attribute.name) || rejectPotentialURI && extremeHLSValueMayExposeURI(attributeValue) {
-				return "", fmt.Errorf("unsupported URI-bearing HLS extension attribute")
-			}
-			continue
-		}
-		if !knownURIName && isExtremeHLSSensitiveURIReference(tag, attribute.name) {
-			return "", fmt.Errorf("unsupported HLS DRM or key URI extension")
-		}
-		if !attribute.quoted {
-			return "", fmt.Errorf("HLS URI attribute must be quoted")
-		}
-		start := colon + 1 + attribute.valueStart
-		end := colon + 1 + attribute.valueEnd
-		expanded, err := variables.substituteExtremeHLSURI(line[start:end])
-		if err != nil {
-			return "", err
-		}
-		if expanded != line[start:end] {
-			expansions = append(expansions, extremeHLSReplacement{start: start, end: end, value: expanded})
-		}
-		names[attribute.name] = true
-	}
-	if len(names) == 0 {
-		return line, nil
-	}
-	expandedLine := applyExtremeHLSReplacements(line, expansions)
-	expandedAttributes, err := parseHLSAttributeList(expandedLine[colon+1:])
-	if err != nil {
-		return "", err
-	}
-	if validateKnown {
-		if err := validateHLSURIAttributes(tag, expandedLine[colon+1:], expandedAttributes); err != nil {
-			return "", err
-		}
-	}
-	rewrites := make([]extremeHLSReplacement, 0, len(names))
-	for _, attribute := range expandedAttributes {
-		if !names[attribute.name] {
-			continue
-		}
-		if !attribute.quoted {
-			return "", fmt.Errorf("HLS URI attribute must be quoted")
-		}
-		start := colon + 1 + attribute.valueStart
-		end := colon + 1 + attribute.valueEnd
-		rewritten, err := rewriteHLSURIKind(expandedLine[start:end], session, hlsAttributeResourceKind(tag, attribute.name))
-		if err != nil {
-			return "", err
-		}
-		if rewritten != expandedLine[start:end] {
-			rewrites = append(rewrites, extremeHLSReplacement{start: start, end: end, value: rewritten})
-		}
-	}
-	rewrittenLine := applyExtremeHLSReplacements(expandedLine, rewrites)
-	if int64(len(rewrittenLine)) > globalDynamicMaxStringBytes {
-		return "", fmt.Errorf("HLS rewritten line exceeds its limit")
-	}
-	return rewrittenLine, nil
-}
-
-func rewriteExtremeHLSKnownAttributeLine(line string, names map[string]bool, variables *extremeHLSVariableTable, session *dynamicRewriteSession) (string, error) {
-	colon := strings.IndexByte(line, ':')
-	if colon < 0 || colon+1 >= len(line) {
-		return "", fmt.Errorf("invalid HLS tag attribute list")
-	}
-	attributes, err := parseHLSAttributeList(line[colon+1:])
-	if err != nil {
-		return "", err
-	}
-	return rewriteExtremeHLSParsedAttributeLine(line, attributes, names, true, false, variables, session)
-}
-
-func rewriteExtremeHLSAdditionalAttributeLine(line string, variables *extremeHLSVariableTable, session *dynamicRewriteSession) (string, error) {
-	colon := strings.IndexByte(line, ':')
-	if colon < 0 {
-		return line, nil
-	}
-	if colon+1 >= len(line) {
-		return line, validateExtremeHLSOpaqueTagValue("")
-	}
-	attributes, err := parseHLSAttributeList(line[colon+1:])
-	if err != nil {
-		if opaqueErr := validateExtremeHLSOpaqueTagValue(line[colon+1:]); opaqueErr != nil {
-			return "", opaqueErr
-		}
-		return line, nil
-	}
-	return rewriteExtremeHLSParsedAttributeLine(line, attributes, nil, false, false, variables, session)
-}
-
-func rewriteExtremeHLSUnknownTagLine(line string, variables *extremeHLSVariableTable, session *dynamicRewriteSession) (string, error) {
-	colon := strings.IndexByte(line, ':')
-	if colon < 0 {
-		return line, nil
-	}
-	if colon+1 >= len(line) {
-		return "", fmt.Errorf("invalid HLS extension tag value")
-	}
-	attributes, err := parseHLSAttributeList(line[colon+1:])
-	if err != nil {
-		if opaqueErr := validateExtremeHLSOpaqueTagValue(line[colon+1:]); opaqueErr != nil {
-			return "", opaqueErr
-		}
-		return line, nil
-	}
-	return rewriteExtremeHLSParsedAttributeLine(line, attributes, nil, false, true, variables, session)
-}
-
 func knownHLSManifestTag(tag string) bool {
 	switch tag {
 	case "#EXTINF",
@@ -644,11 +300,6 @@ func rewriteHLSResponse(payload []byte, session *dynamicRewriteSession) ([]byte,
 	if len(lines) == 0 || lines[0] != "#EXTM3U" {
 		return nil, fmt.Errorf("HLS manifest is missing EXTM3U")
 	}
-	extremeCompatibility := session.issuer.policy.profile == dynamicProfileExtreme
-	var extremeVariables *extremeHLSVariableTable
-	if extremeCompatibility {
-		extremeVariables = newExtremeHLSVariableTable(session)
-	}
 	uriTags := map[string]map[string]bool{
 		"#EXT-X-KEY":                {"URI": true},
 		"#EXT-X-MAP":                {"URI": true},
@@ -702,15 +353,7 @@ func rewriteHLSResponse(payload []byte, session *dynamicRewriteSession) ([]byte,
 			if line != strings.TrimSpace(line) {
 				return nil, fmt.Errorf("HLS URI line contains surrounding whitespace")
 			}
-			uriValue := line
-			if extremeCompatibility {
-				resolved, err := extremeVariables.substituteExtremeHLSURI(uriValue)
-				if err != nil {
-					return nil, err
-				}
-				uriValue = resolved
-			}
-			rewritten, err := rewriteHLSURIKind(uriValue, session, kind)
+			rewritten, err := rewriteHLSURIKind(line, session, kind)
 			if err != nil {
 				return nil, err
 			}
@@ -724,27 +367,16 @@ func rewriteHLSResponse(payload []byte, session *dynamicRewriteSession) ([]byte,
 		if colon := strings.IndexByte(line, ':'); colon >= 0 {
 			tag = line[:colon]
 		}
+		// Extension tags are refused rather than rewritten. The removed
+		// permissive profile used to accept unknown #EXT-X- tags with inert
+		// values, but an unrecognized tag can still name a network location in
+		// a form this rewriter cannot route.
 		if strings.HasPrefix(tag, "#EXT") && !knownHLSManifestTag(tag) {
-			if !extremeCompatibility || !isExtremeHLSUnknownTagName(tag) {
-				return nil, fmt.Errorf("unsupported HLS tag")
-			}
-			rewritten, err := rewriteExtremeHLSUnknownTagLine(line, extremeVariables, session)
-			if err != nil {
-				return nil, err
-			}
-			lines[index] = rewritten
-			continue
+			return nil, fmt.Errorf("unsupported HLS tag")
 		}
 		switch tag {
 		case "#EXT-X-DEFINE":
-			if !extremeCompatibility {
-				return nil, fmt.Errorf("HLS variable substitution is unsupported")
-			}
-			if err := extremeVariables.defineFromExtremeHLSLine(line); err != nil {
-				return nil, err
-			}
-			lines[index] = ""
-			continue
+			return nil, fmt.Errorf("HLS variable substitution is unsupported")
 		case "#EXT-X-CONTENT-STEERING":
 			return nil, fmt.Errorf("HLS content steering is unsupported")
 		case "#EXT-X-VERSION", "#EXT-X-START", "#EXT-X-INDEPENDENT-SEGMENTS", "#EXT-X-SKIP":
@@ -788,19 +420,7 @@ func rewriteHLSResponse(payload []byte, session *dynamicRewriteSession) ([]byte,
 			}
 		}
 		if names := uriTags[tag]; names != nil {
-			var rewritten string
-			var err error
-			if extremeCompatibility {
-				rewritten, err = rewriteExtremeHLSKnownAttributeLine(line, names, extremeVariables, session)
-			} else {
-				rewritten, err = rewriteHLSAttributeLine(line, names, session)
-			}
-			if err != nil {
-				return nil, err
-			}
-			lines[index] = rewritten
-		} else if extremeCompatibility {
-			rewritten, err := rewriteExtremeHLSAdditionalAttributeLine(line, extremeVariables, session)
+			rewritten, err := rewriteHLSAttributeLine(line, names, session)
 			if err != nil {
 				return nil, err
 			}
@@ -812,16 +432,6 @@ func rewriteHLSResponse(payload []byte, session *dynamicRewriteSession) ([]byte,
 	}
 	if expectVariantURI {
 		return nil, fmt.Errorf("HLS variant tag is not followed by a URI")
-	}
-	if extremeCompatibility {
-		for _, line := range lines {
-			if strings.Contains(line, "{$") {
-				return nil, fmt.Errorf("unresolved HLS variable")
-			}
-			if int64(len(line)) > globalDynamicMaxStringBytes {
-				return nil, fmt.Errorf("HLS rewritten line exceeds its limit")
-			}
-		}
 	}
 	outputLimit := session.structuredOutputLimit()
 	outputSize := int64(len(separator) * (len(lines) - 1))

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,22 @@ set -euo pipefail
 # Public operations are intentionally limited to install, update, password,
 # and uninstall. Backups and rollback remain internal safety mechanisms.
 
+# Output helpers are defined before every top-level validation below: the
+# INSTALL_DIR guard calls fail() during environment parsing, so defining the
+# helpers later would make an unsafe MERIDIAN_INSTALL_DIR die with
+# "fail: command not found" instead of the intended refusal message.
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info() { printf "${CYAN}[INFO]${NC} %s\n" "$*"; }
+ok() { printf "${GREEN}[OK]${NC} %s\n" "$*"; }
+warn() { printf "${YELLOW}[WARN]${NC} %s\n" "$*"; }
+fail() { printf "${RED}[ERROR]${NC} %s\n" "$*" >&2; exit 1; }
+
 REPO="${MERIDIAN_REPO:-chanhui800/Meridian}"
 INSTALL_DIR="${MERIDIAN_INSTALL_DIR:-/usr/local/bin}"
 DATA_DIR="${MERIDIAN_DATA_DIR:-/opt/meridian}"
@@ -77,18 +93,6 @@ PANEL_TRANSACTION=0
 DOWNLOADED_AGENT_BINARY_AMD64=""
 DOWNLOADED_AGENT_BINARY_ARM64=""
 DOWNLOADED_CONTROLLER_SUFFIX=""
-
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[0;33m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-NC='\033[0m'
-
-info() { printf "${CYAN}[INFO]${NC} %s\n" "$*"; }
-ok() { printf "${GREEN}[OK]${NC} %s\n" "$*"; }
-warn() { printf "${YELLOW}[WARN]${NC} %s\n" "$*"; }
-fail() { printf "${RED}[ERROR]${NC} %s\n" "$*" >&2; exit 1; }
 
 need_cmd() {
     command -v "$1" >/dev/null 2>&1 || fail "缺少必要命令: $1"

--- a/ninth_review_regression_test.go
+++ b/ninth_review_regression_test.go
@@ -1,0 +1,898 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestTrackedDNSRecordOwnershipDecisionMatrix pins the ownership decision that
+// every mutating Cloudflare path must share. DELETE already refused records
+// whose marker an operator had cleared; the tracked-record PUT must make the
+// same decision, otherwise a scheduled reconcile silently reasserts Meridian's
+// address and marker over a record the operator has taken back.
+func TestTrackedDNSRecordOwnershipDecisionMatrix(t *testing.T) {
+	const installUUID = "install-uuid-1"
+	marker := siteDNSOwnershipMarker(7, installUUID)
+	cases := []struct {
+		name     string
+		record   cloudflareAddressRecord
+		siteID   int64
+		wantErr  bool
+		wantText string
+	}{
+		{
+			name:   "current marker is owned",
+			record: cloudflareAddressRecord{ID: "rec-1", Type: "A", Name: "site.example", Content: "203.0.113.5", Comment: marker},
+			siteID: 7,
+		},
+		{
+			// The pre-installation-UUID marker is still accepted so the next
+			// reconcile PUT can migrate the comment to the scoped form.
+			name:   "legacy marker is owned",
+			record: cloudflareAddressRecord{ID: "rec-1", Type: "A", Name: "site.example", Content: "203.0.113.5", Comment: legacySiteDNSOwnershipMarker(7)},
+			siteID: 7,
+		},
+		{
+			// Renaming a site is supported, so ownership must not require the
+			// stored hostname to still match.
+			name:   "site rename with valid marker is owned",
+			record: cloudflareAddressRecord{ID: "rec-1", Type: "A", Name: "renamed.example", Content: "203.0.113.5", Comment: marker},
+			siteID: 7,
+		},
+		{
+			name:     "operator-cleared comment is not owned",
+			record:   cloudflareAddressRecord{ID: "rec-1", Type: "A", Name: "site.example", Content: "203.0.113.5", Comment: ""},
+			siteID:   7,
+			wantErr:  true,
+			wantText: "ownership marker",
+		},
+		{
+			name:     "operator comment is not owned",
+			record:   cloudflareAddressRecord{ID: "rec-1", Type: "A", Name: "site.example", Content: "203.0.113.5", Comment: "managed by ops"},
+			siteID:   7,
+			wantErr:  true,
+			wantText: "ownership marker",
+		},
+		{
+			// Two controllers sharing a zone must never treat each other's
+			// records as their own.
+			name:     "foreign controller marker is not owned",
+			record:   cloudflareAddressRecord{ID: "rec-1", Type: "A", Name: "site.example", Content: "203.0.113.5", Comment: siteDNSOwnershipMarker(7, "other-install")},
+			siteID:   7,
+			wantErr:  true,
+			wantText: "ownership marker",
+		},
+		{
+			name:     "another site's marker is not owned",
+			record:   cloudflareAddressRecord{ID: "rec-1", Type: "A", Name: "site.example", Content: "203.0.113.5", Comment: siteDNSOwnershipMarker(8, installUUID)},
+			siteID:   7,
+			wantErr:  true,
+			wantText: "ownership marker",
+		},
+		{
+			name:     "operator-replaced CNAME is not owned",
+			record:   cloudflareAddressRecord{ID: "rec-1", Type: "CNAME", Name: "site.example", Content: "target.example", Comment: marker},
+			siteID:   7,
+			wantErr:  true,
+			wantText: "A/AAAA",
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := verifySiteDNSRecordOwnership(testCase.record, testCase.siteID, installUUID, "refusing to overwrite it")
+			if testCase.wantErr {
+				if err == nil || !strings.Contains(err.Error(), testCase.wantText) {
+					t.Fatalf("err = %v, want containing %q", err, testCase.wantText)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("owned record rejected: %v", err)
+			}
+		})
+	}
+}
+
+// TestTrackedDNSRecordReadUsesByIDPreimage proves the read helper returns the
+// record exactly as Cloudflare holds it. That value is the compensation
+// preimage, so a name-scoped listing would be wrong twice over: it cannot find
+// a record the operator renamed, and it cannot prove ownership of the ID it
+// does return.
+func TestTrackedDNSRecordReadUsesByIDPreimage(t *testing.T) {
+	var sawLookup string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawLookup = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"result":{"id":"rec-9","type":"A","name":"old.example","content":"203.0.113.9","comment":"Meridian controller=install-uuid-1 site=7"}}`))
+	}))
+	defer server.Close()
+	cf := &cloudflareClient{token: "test", httpClient: server.Client(), apiBase: server.URL, installUUID: "install-uuid-1"}
+	schedule := SiteNodeSchedule{SiteID: 7, PublicHost: "renamed.example", cfZoneID: "zone-1", cfRecordID: "rec-9"}
+	record, err, owned := readOwnedTrackedSiteDNSRecord(context.Background(), cf, schedule)
+	if err != nil || !owned {
+		t.Fatalf("owned=%v err=%v, want the tracked record to be owned", owned, err)
+	}
+	if !strings.HasSuffix(sawLookup, "/dns_records/rec-9") {
+		t.Fatalf("lookup path = %q, want a by-ID read", sawLookup)
+	}
+	if record.Name != "old.example" || record.Content != "203.0.113.9" || record.Comment != siteDNSOwnershipMarker(7, "install-uuid-1") {
+		t.Fatalf("preimage = %+v, want the record exactly as stored", record)
+	}
+}
+
+// TestTrackedDNSRecordReadReportsMissingRecordWithoutOwnershipError keeps the
+// existing missing-record recovery reachable: a 404 must not be reported as an
+// ownership conflict, or a deleted record could never be recreated.
+func TestTrackedDNSRecordReadReportsMissingRecordWithoutOwnershipError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"success":false,"errors":[{"code":81044,"message":"record does not exist"}]}`))
+	}))
+	defer server.Close()
+	cf := &cloudflareClient{token: "test", httpClient: server.Client(), apiBase: server.URL, installUUID: "install-uuid-1"}
+	schedule := SiteNodeSchedule{SiteID: 7, PublicHost: "site.example", cfZoneID: "zone-1", cfRecordID: "rec-missing"}
+	_, err, owned := readOwnedTrackedSiteDNSRecord(context.Background(), cf, schedule)
+	if err != nil || owned {
+		t.Fatalf("owned=%v err=%v, want a missing record to be neither owned nor a conflict", owned, err)
+	}
+}
+
+// TestTrackedDNSRecordReadRefusesForeignOwnership is the same guard seen
+// through the HTTP layer: the refusal must come from the record's own comment,
+// not from the hostname the schedule happens to store.
+func TestTrackedDNSRecordReadRefusesForeignOwnership(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true,"result":{"id":"rec-1","type":"A","name":"site.example","content":"198.51.100.7","comment":""}}`))
+	}))
+	defer server.Close()
+	cf := &cloudflareClient{token: "test", httpClient: server.Client(), apiBase: server.URL, installUUID: "install-uuid-1"}
+	schedule := SiteNodeSchedule{SiteID: 7, PublicHost: "site.example", cfZoneID: "zone-1", cfRecordID: "rec-1"}
+	_, err, owned := readOwnedTrackedSiteDNSRecord(context.Background(), cf, schedule)
+	if err == nil || owned {
+		t.Fatalf("owned=%v err=%v, want an operator-cleared record to be refused", owned, err)
+	}
+	if !strings.Contains(err.Error(), "ownership marker") {
+		t.Fatalf("err = %v, want an ownership refusal", err)
+	}
+}
+
+// TestPreservedStructuredBodyRejectsUnroutableURLs covers the gap between "the
+// strict parser refused this manifest" and "the original bytes are safe to
+// forward". A parser stops at the first unsupported feature, so a URL that
+// appears later never reaches per-URL validation and would otherwise be handed
+// to the player verbatim.
+func TestPreservedStructuredBodyRejectsUnroutableURLs(t *testing.T) {
+	cases := []struct {
+		name    string
+		source  string
+		payload string
+		safe    bool
+	}{
+		{
+			// The DRM branch fails before the key URI is ever validated, so the
+			// loopback key URL must be caught by the preserve scan instead.
+			name:    "hls unsupported drm key with public uri",
+			source:  dynamicDiscoverySourceHLS,
+			payload: "#EXTM3U\n#EXT-X-KEY:METHOD=SAMPLE-AES,URI=\"https://cdn.example/key\"\n#EXTINF:4.0,\nseg1.ts\n",
+			safe:    true,
+		},
+		{
+			name:    "hls key uri with userinfo",
+			source:  dynamicDiscoverySourceHLS,
+			payload: "#EXTM3U\n#EXT-X-KEY:METHOD=SAMPLE-AES,URI=\"https://user:pass@cdn.example/key\"\n#EXTINF:4.0,\nseg1.ts\n",
+			safe:    false,
+		},
+		{
+			name:    "hls key uri with fragment",
+			source:  dynamicDiscoverySourceHLS,
+			payload: "#EXTM3U\n#EXT-X-KEY:METHOD=SAMPLE-AES,URI=\"https://cdn.example/key#frag\"\n#EXTINF:4.0,\nseg1.ts\n",
+			safe:    false,
+		},
+		{
+			name:    "hls uri line with dot segments",
+			source:  dynamicDiscoverySourceHLS,
+			payload: "#EXTM3U\n#EXTINF:4.0,\nhttp://cdn.example/a/../b/seg.ts\n",
+			safe:    false,
+		},
+		{
+			name:    "hls media uri line with userinfo",
+			source:  dynamicDiscoverySourceHLS,
+			payload: "#EXTM3U\n#EXTINF:4.0,\nhttps://user@cdn.example/seg.ts\n",
+			safe:    false,
+		},
+		{
+			// Ordinary vendor tags and relative URIs must still preserve.
+			name:    "hls vendor tag with relative uris",
+			source:  dynamicDiscoverySourceHLS,
+			payload: "#EXTM3U\n#EXT-X-VENDOR-TAG:value=1\n#EXTINF:4.0,\nseg1.ts\n",
+			safe:    true,
+		},
+		{
+			name:    "hls absolute https uri is safe",
+			source:  dynamicDiscoverySourceHLS,
+			payload: "#EXTM3U\n#EXT-X-KEY:METHOD=SAMPLE-AES,URI=\"https://cdn.example/key\"\n#EXTINF:4.0,\nseg1.ts\n",
+			safe:    true,
+		},
+		{
+			name:    "hls keyformats identifier is not a candidate",
+			source:  dynamicDiscoverySourceHLS,
+			payload: "#EXTM3U\n#EXT-X-KEY:METHOD=SAMPLE-AES,KEYFORMAT=\"com.apple.streamingkeydelivery\",URI=\"https://cdn.example/key\"\n#EXTINF:4.0,\nseg1.ts\n",
+			safe:    true,
+		},
+		{
+			name:    "dash attribute with loopback base url",
+			source:  dynamicDiscoverySourceDASH,
+			payload: `<?xml version="1.0"?><MPD xmlns="urn:mpeg:dash:schema:mpd:2011"><Period><BaseURL>http://127.0.0.1:8080/</BaseURL></Period></MPD>`,
+			safe:    false,
+		},
+		{
+			name:    "dash text node with userinfo",
+			source:  dynamicDiscoverySourceDASH,
+			payload: `<?xml version="1.0"?><MPD xmlns="urn:mpeg:dash:schema:mpd:2011"><Period><SegmentTemplate media="https://user@cdn.example/$Number$.m4s"/></Period></MPD>`,
+			safe:    false,
+		},
+		{
+			name:    "dash unsupported feature with public url preserves",
+			source:  dynamicDiscoverySourceDASH,
+			payload: `<?xml version="1.0"?><MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:x="urn:vendor"><x:Vendor><BaseURL>https://cdn.example/</BaseURL></x:Vendor></MPD>`,
+			safe:    true,
+		},
+		{
+			name:    "dash scheme id uri is not a candidate",
+			source:  dynamicDiscoverySourceDASH,
+			payload: `<?xml version="1.0"?><MPD xmlns="urn:mpeg:dash:schema:mpd:2011"><Period><ContentProtection schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc"/></Period></MPD>`,
+			safe:    true,
+		},
+		// Malformed use of the IPv6-literal brackets must still be refused; only
+		// the well-formed `[address]` / `[address]:port` shapes are URLs.
+		{
+			name:    "hls unbalanced ipv6 bracket",
+			source:  dynamicDiscoverySourceHLS,
+			payload: "#EXTM3U\n#EXTINF:4.0,\nhttps://[2606:4700::1111/seg.ts\n",
+			safe:    false,
+		},
+		{
+			name:    "hls bracketed non-literal host",
+			source:  dynamicDiscoverySourceHLS,
+			payload: "#EXTM3U\n#EXTINF:4.0,\nhttps://[not-an-address]/seg.ts\n",
+			safe:    false,
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := preservedStructuredBodyIsSafe(testCase.source, []byte(testCase.payload)); got != testCase.safe {
+				t.Fatalf("preservedStructuredBodyIsSafe = %v, want %v", got, testCase.safe)
+			}
+		})
+	}
+}
+
+// TestPreservedStructuredBodyScanAcceptsRealisticManifests guards the other
+// direction of the preserve scan: it must not reject ordinary manifests. Each
+// sample below is a construct real HLS/DASH output emits (vendor DRM key
+// formats, stringified segment templates, public IPv6 literals, base64 DRM
+// metadata, XML comments), and a false positive here would turn a working
+// stream into a hard failure.
+func TestPreservedStructuredBodyScanAcceptsRealisticManifests(t *testing.T) {
+	hlsSamples := map[string]string{
+		"widevine key with public uri": "#EXTM3U\n#EXT-X-KEY:METHOD=SAMPLE-AES,URI=\"https://cdn.example/key\",KEYFORMAT=\"urn:uuid:edef8ba9\"\n#EXTINF:4,\nseg.ts\n",
+		"fairplay skd uri":             "#EXTM3U\n#EXT-X-KEY:METHOD=SAMPLE-AES,URI=\"skd://asset\",KEYFORMAT=\"com.apple.streamingkeydelivery\"\n#EXTINF:4,\nseg.ts\n",
+		"iframe stream inf":            "#EXTM3U\n#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=1000,URI=\"https://cdn.example/iframe.m3u8\"\n",
+		"interstitial asset uri":       "#EXTM3U\n#EXT-X-DATERANGE:ID=\"1\",X-ASSET-URI=\"https://ads.example/ad.m3u8\"\n#EXTINF:4,\nseg.ts\n",
+		"relative query string":        "#EXTM3U\n#EXTINF:4,\nseg.ts?token=abc&x=1\n",
+		"absolute with port":           "#EXTM3U\n#EXTINF:4,\nhttps://cdn.example:8443/a/b/seg.ts\n",
+		"encoded path component":       "#EXTM3U\n#EXTINF:4,\nhttps://cdn.example/a%20b/seg.ts\n",
+		"public ipv6 literal":          "#EXTM3U\n#EXTINF:4,\nhttps://[2606:4700::1111]/seg.ts\n",
+		"byterange and date time":      "#EXTM3U\n#EXT-X-PROGRAM-DATE-TIME:2026-01-01T00:00:00Z\n#EXTINF:4,\n#EXT-X-BYTERANGE:1000@0\nseg.ts\n",
+	}
+	for name, payload := range hlsSamples {
+		if !preservedStructuredBodyIsSafe(dynamicDiscoverySourceHLS, []byte(payload)) {
+			t.Fatalf("realistic HLS manifest %q must still preserve: %s", name, payload)
+		}
+	}
+	dashSamples := map[string]string{
+		"cenc pssh base64":     `<?xml version="1.0"?><MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013"><Period><ContentProtection schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc"><cenc:pssh>AAAAVnBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAADYSEAqAgLQ0FJGTEJOLd4tQKSsaDXdpZGV2aW5lX3Rlc3QiDHRlc3RfY29udGVudA==</cenc:pssh></ContentProtection></Period></MPD>`,
+		"utc timing http":      `<?xml version="1.0"?><MPD xmlns="urn:mpeg:dash:schema:mpd:2011"><UTCTiming schemeIdUri="urn:mpeg:dash:utc:http-xsdate:2014" value="https://time.example/utc"/></MPD>`,
+		"stringified template": `<?xml version="1.0"?><MPD xmlns="urn:mpeg:dash:schema:mpd:2011"><Period><AdaptationSet><SegmentTemplate media="$RepresentationID$/seg-$Number$.m4s" initialization="$RepresentationID$/init.mp4" timescale="1000"/></AdaptationSet></Period></MPD>`,
+		"vendor extension":     `<?xml version="1.0"?><MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:v="urn:vendor:ns"><v:Custom foo="bar"/></MPD>`,
+		"comment with url":     `<?xml version="1.0"?><!-- generated from https://cdn.example/source --><MPD xmlns="urn:mpeg:dash:schema:mpd:2011"/>`,
+		"public base url":      `<?xml version="1.0"?><MPD xmlns="urn:mpeg:dash:schema:mpd:2011"><BaseURL>https://cdn.example/dash/</BaseURL></MPD>`,
+	}
+	for name, payload := range dashSamples {
+		if !preservedStructuredBodyIsSafe(dynamicDiscoverySourceDASH, []byte(payload)) {
+			t.Fatalf("realistic DASH manifest %q must still preserve: %s", name, payload)
+		}
+	}
+}
+
+// TestStructuredPreserveRefusesUnroutableURLThroughProxy drives the same rule
+// through the real response path: a manifest the strict rewriter rejects must
+// not be preserved verbatim when it carries a URL the client would follow.
+func TestStructuredPreserveRefusesUnroutableURLThroughProxy(t *testing.T) {
+	issuer := newStructuredDiscoveryTestIssuer(t)
+	manifest := "#EXTM3U\n#EXT-X-KEY:METHOD=SAMPLE-AES,URI=\"http://127.0.0.1:9999/key\"\n#EXTINF:4.0,\nseg1.ts\n"
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/vnd.apple.mpegurl"}},
+		Body:       io.NopCloser(strings.NewReader(manifest)),
+		Request:    &http.Request{Method: http.MethodGet, URL: mustStructuredURL(t, "https://origin.example.com/live/master.m3u8")},
+	}
+	if err := rewriteDynamicStructuredResponseExpected(response, issuer, false, dynamicDiscoverySourceHLS, 0, false); err == nil {
+		t.Fatal("a manifest carrying an unroutable URL must not be preserved")
+	}
+
+	// A manifest with only routable URLs still preserves, so ordinary vendor
+	// tags keep working.
+	benign := "#EXTM3U\n#EXT-X-VENDOR-TAG:value=1\n#EXTINF:4.0,\nseg1.ts\n"
+	benignResponse := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/vnd.apple.mpegurl"}},
+		Body:       io.NopCloser(strings.NewReader(benign)),
+		Request:    &http.Request{Method: http.MethodGet, URL: mustStructuredURL(t, "https://origin.example.com/live/master.m3u8")},
+	}
+	if err := rewriteDynamicStructuredResponseExpected(benignResponse, issuer, false, dynamicDiscoverySourceHLS, 0, false); err != nil {
+		t.Fatalf("benign vendor manifest must still preserve: %v", err)
+	}
+}
+
+// TestPreservedStructuredBodyRejectsURLsHiddenFromTheStrictParser covers the
+// extraction gaps the first version of the preserve scan left open: a URL in a
+// tag or attribute the strict rewriter never reached, a URL hidden behind a
+// syntax error, a CDATA text node, and an entity-encoded scheme. Each of these
+// would otherwise reach the player verbatim.
+func TestPreservedStructuredBodyRejectsURLsHiddenFromTheStrictParser(t *testing.T) {
+	cases := []struct {
+		name    string
+		source  string
+		payload string
+	}{
+		{
+			// #EXT-X-CONTENT-STEERING is refused outright by the strict parser,
+			// so its SERVER-URI never goes through per-URL validation.
+			name:    "hls content steering server uri",
+			source:  dynamicDiscoverySourceHLS,
+			payload: "#EXTM3U\n#EXT-X-CONTENT-STEERING:SERVER-URI=\"http://127.0.0.1:9999/v1\",PATHWAY-ID=\"CDN-A\"\n#EXTINF:4.0,\nseg1.ts\n",
+		},
+		{
+			// VALUE feeds {$k} substitution, so a loopback URL placed there
+			// reaches the key request after the player expands it.
+			name:    "hls define value holding a loopback url",
+			source:  dynamicDiscoverySourceHLS,
+			payload: "#EXTM3U\n#EXT-X-DEFINE:NAME=\"k\",VALUE=\"http://127.0.0.1:9999/key\"\n#EXT-X-KEY:METHOD=SAMPLE-AES,URI=\"{$k}\"\n#EXTINF:4.0,\nseg.ts\n",
+		},
+		{
+			// A malformed attribute list must not hide a URL earlier on the line.
+			name:    "hls malformed attribute list hides a url",
+			source:  dynamicDiscoverySourceHLS,
+			payload: "#EXTM3U\n#EXT-X-DATERANGE:ID=\"1\",X-ASSET-URI=\"https://user@cdn.example/ad.m3u8\",bad\n#EXTINF:4.0,\nseg.ts\n",
+		},
+		{
+			name:    "dash cdata base url",
+			source:  dynamicDiscoverySourceDASH,
+			payload: "<?xml version=\"1.0\"?><MPD xmlns=\"urn:mpeg:dash:schema:mpd:2011\"><Period><BaseURL><![CDATA[http://127.0.0.1:8080/]]></BaseURL></Period></MPD>",
+		},
+		{
+			name:    "dash entity encoded scheme",
+			source:  dynamicDiscoverySourceDASH,
+			payload: `<?xml version="1.0"?><MPD xmlns="urn:mpeg:dash:schema:mpd:2011"><Period><BaseURL>&#104;ttp://127.0.0.1:8080/</BaseURL></Period></MPD>`,
+		},
+		{
+			name:    "hls localhost shorthand",
+			source:  dynamicDiscoverySourceHLS,
+			payload: "#EXTM3U\n#EXTINF:4.0,\nhttp://localhost/seg.ts\n",
+		},
+		{
+			name:    "hls short form ipv4",
+			source:  dynamicDiscoverySourceHLS,
+			payload: "#EXTM3U\n#EXTINF:4.0,\nhttp://127.1/seg.ts\n",
+		},
+		{
+			name:    "hls decimal ipv4",
+			source:  dynamicDiscoverySourceHLS,
+			payload: "#EXTM3U\n#EXTINF:4.0,\nhttp://2130706433/seg.ts\n",
+		},
+		{
+			name:    "hls hex ipv4",
+			source:  dynamicDiscoverySourceHLS,
+			payload: "#EXTM3U\n#EXTINF:4.0,\nhttp://0x7f000001/seg.ts\n",
+		},
+		{
+			name:    "hls ipv4 mapped ipv6 literal",
+			source:  dynamicDiscoverySourceHLS,
+			payload: "#EXTM3U\n#EXTINF:4.0,\nhttps://[::ffff:127.0.0.1]/seg.ts\n",
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if preservedStructuredBodyIsSafe(testCase.source, []byte(testCase.payload)) {
+				t.Fatalf("unroutable URL was not detected in: %s", testCase.payload)
+			}
+		})
+	}
+}
+
+// TestScanHostNonPublicShorthandRecognizesResolverSpellings pins the numeric
+// host forms a resolver accepts but net.ParseIP does not. Getting one wrong is
+// a real regression in either direction: a missed loopback spelling leaks the
+// address to the client, and a false positive turns a working manifest into a
+// hard failure.
+func TestScanHostNonPublicShorthandRecognizesResolverSpellings(t *testing.T) {
+	nonPublic := []string{
+		"localhost", "LOCALHOST", "localhost.", "sub.localhost",
+		"127.1", "127.0.1", "127.0.0.1", "2130706433", "0x7f000001", "0177.0.0.1",
+		"10.1", "192.168", "169.254.1.1", "0.0.0.0", "0",
+	}
+	for _, host := range nonPublic {
+		if !dynamicScanHostIsNonPublicShorthand(host) {
+			t.Fatalf("host %q must be recognized as non-public", host)
+		}
+	}
+	public := []string{
+		"cdn.example.com", "example.com", "", "not-an-address",
+		"8.8.8.8", "1.1", "203.0.114.1", "2606:4700::1111",
+		"1.2.3.4.5", "256.1.1.1",
+	}
+	for _, host := range public {
+		if dynamicScanHostIsNonPublicShorthand(host) {
+			t.Fatalf("host %q must not be reported as non-public", host)
+		}
+	}
+}
+
+// TestPlaybackInfoFallbackFailureIsHard drives the whole response path. It has
+// to enter the automatic fallback for real, which requires the strict walker to
+// fail with one of the compatibility-only diagnostics: a backslash inside a
+// subtitle URL is the reachable case (delivery percent-escapes and Protocol
+// mismatches produce other codes). The payload then also carries a stream URL
+// the walker cannot route, so the fallback's own failure is what the response
+// disposition must reflect. Preserving the upstream body there would hand the
+// client every URL in it unproxied, so one unroutable field would cost the
+// capability, the accounting and the quota for all of them.
+func TestPlaybackInfoFallbackFailureIsHard(t *testing.T) {
+	issuer := newStructuredDiscoveryTestIssuer(t)
+	base := mustStructuredURL(t, "http://line.example.com/Items/1/PlaybackInfo")
+
+	// The strict walker must really hand over to the fallback for this payload;
+	// otherwise the assertion below would be satisfied by an earlier failure and
+	// would keep passing with the fallback's fix reverted.
+	strict := &dynamicRewriteSession{ctx: context.Background(), issuer: issuer, base: base, source: dynamicDiscoverySourcePlaybackInfo}
+	_, strictErr := rewritePlaybackInfoResponse([]byte(fallbackFailureProbePayload), strict)
+	strict.rollback()
+	if strictErr == nil || !playbackInfoAutomaticFallbackAllowed(strictErr) {
+		t.Fatalf("payload does not enter the automatic fallback: err=%v code=%s", strictErr, playbackInfoRewriteDiagnosticCode(strictErr))
+	}
+	// And the walker must really be the thing that refuses it.
+	fallback := &dynamicRewriteSession{ctx: context.Background(), issuer: issuer, base: base, source: dynamicDiscoverySourcePlaybackInfo}
+	if _, fallbackErr := rewriteAutomaticPlaybackInfoResponse([]byte(fallbackFailureProbePayload), fallback); fallbackErr == nil {
+		t.Fatal("the automatic walker unexpectedly proxied every URL in the payload")
+	}
+	fallback.rollback()
+
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(fallbackFailureProbePayload)),
+		Request:    &http.Request{Method: http.MethodGet, URL: base},
+	}
+	err := rewriteDynamicStructuredResponseExpected(response, issuer, false, dynamicDiscoverySourcePlaybackInfo, 0, false)
+	if err == nil {
+		t.Fatal("a payload the fallback cannot proxy must fail the response")
+	}
+	// The failure must be a dynamic proxy error (which the proxy turns into a
+	// 502), not a silently installed body.
+	var discoveryErr *dynamicProxyError
+	if !errors.As(err, &discoveryErr) {
+		t.Fatalf("failure = %v, want a dynamic proxy error", err)
+	}
+}
+
+// fallbackFailureProbePayload fails the strict walker with the reachable
+// compatibility-only url_backslash diagnostic, and fails the automatic walker
+// on the unroutable subtitle URL.
+//
+// Field order matters: the strict walker validates DirectStreamUrl before the
+// MediaStreams entries, so the backslash URL has to be the DirectStreamUrl for
+// the compatibility-only diagnostic to be the one that surfaces.
+const fallbackFailureProbePayload = `{"MediaSources":[{"DirectStreamUrl":"http://line.example.com/a\\b","MediaStreams":[{"DeliveryUrl":"http://backend.invalidtld/subtitle.vtt","IsExternalUrl":true}]}]}`
+
+// TestPlaybackInfoAutomaticFallbackIsNotEnteredForSecurityFailures tightens the
+// gate that decides whether the schema-free walker may take over. That walker
+// is the path that keeps individual URLs on the proxy, so entering it after a
+// security decision would let a URL the strict walker refused be re-decided
+// without the same rules.
+func TestPlaybackInfoAutomaticFallbackIsNotEnteredForSecurityFailures(t *testing.T) {
+	allowed := []error{
+		errorsNew("invalid discovered URL: surrounding whitespace"),
+		errorsNew("invalid discovered URL: parse"),
+		errorsNew("invalid discovered URL: backslash"),
+		errorsNew("invalid discovered URL: unsafe character"),
+	}
+	for _, err := range allowed {
+		if !playbackInfoAutomaticFallbackAllowed(err) {
+			t.Fatalf("compatibility-only failure must allow fallback: %v", err)
+		}
+	}
+	// No error at all is not a fallback decision.
+	if playbackInfoAutomaticFallbackAllowed(nil) {
+		t.Fatal("a nil error must not request a fallback")
+	}
+	blocked := []error{
+		errorsNew("invalid discovered URL: userinfo"),
+		errorsNew("invalid discovered URL: fragment"),
+		errorsNew("invalid discovered URL: target normalization host"),
+		errorsNew("invalid discovered URL: target normalization dot_segments"),
+		errorsNew("invalid discovered URL: target normalization scheme"),
+		errorsNew("invalid discovered URL: target normalization port"),
+		errorsNew("invalid discovered URL: target normalization escaped_component"),
+		errorsNew("invalid trusted capability URL"),
+		errorsNew("discovered URL count exceeds its limit"),
+		errorsNew("structured response output exceeds its limit"),
+		newDynamicPolicyDenialError(errorsNew("capability denied")),
+	}
+	for _, err := range blocked {
+		if playbackInfoAutomaticFallbackAllowed(err) {
+			t.Fatalf("security decision must not allow fallback: %v", err)
+		}
+	}
+}
+
+// TestPlaybackInfoAutomaticFallbackRefusesUnproxyableURL proves the walker
+// itself no longer preserves a URL it cannot route. Preserving it would hand
+// the player the upstream destination, bypassing the capability, its traffic
+// accounting and its quota.
+func TestPlaybackInfoAutomaticFallbackRefusesUnproxyableURL(t *testing.T) {
+	issuer := newStructuredDiscoveryTestIssuer(t)
+	base := mustStructuredURL(t, "http://line.example.com/Items/1/PlaybackInfo")
+	session := &dynamicRewriteSession{ctx: context.Background(), issuer: issuer, base: base, source: dynamicDiscoverySourcePlaybackInfo}
+	root := map[string]any{"DirectStreamUrl": "http://backend.invalidtld/stream.mkv"}
+	if _, err := rewriteAutomaticPlaybackInfoValue(root, session, 0, ""); err == nil {
+		t.Fatal("an unproxyable URL must fail the response instead of being preserved")
+	}
+
+	// A relative playback path is not a network destination, so it is kept and
+	// learned exactly as before.
+	relative := map[string]any{"DirectStreamUrl": "/Videos/1/original.mkv"}
+	rewritten, err := rewriteAutomaticPlaybackInfoValue(relative, session, 0, "")
+	if err != nil {
+		t.Fatalf("relative playback path must be preserved: %v", err)
+	}
+	object, ok := rewritten.(map[string]any)
+	if !ok || object["DirectStreamUrl"] != "/Videos/1/original.mkv" {
+		t.Fatalf("relative playback path changed: %#v", rewritten)
+	}
+}
+
+// TestInstallationIdentityRotationIsIndependent pins the clone-vs-takeover
+// distinction: a controller cloned from another controller's backup must be
+// able to adopt its own identity, or both installations would present the same
+// Cloudflare ownership marker.
+func TestInstallationIdentityRotationIsIndependent(t *testing.T) {
+	app := newTestApp(t)
+	original := app.db.installUUID
+	if len(original) != 32 {
+		t.Fatalf("installation UUID = %q, want 32 hex characters", original)
+	}
+	rotated, err := app.db.rotateInstallationUUID()
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	if rotated == original || len(rotated) != 32 {
+		t.Fatalf("rotated identity = %q, want a new 32-character value", rotated)
+	}
+	if app.db.installUUID != rotated {
+		t.Fatalf("cached identity = %q, want %q", app.db.installUUID, rotated)
+	}
+	var stored string
+	if err := app.db.db.QueryRow("SELECT install_uuid FROM installation_meta WHERE id=1").Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored != rotated {
+		t.Fatalf("stored identity = %q, want %q", stored, rotated)
+	}
+	// Records carrying the previous identity must stop being treated as owned.
+	if siteDNSMarkerOwned(siteDNSOwnershipMarker(7, original), 7, rotated) {
+		t.Fatal("a record scoped to the previous identity must not be owned")
+	}
+	if !siteDNSMarkerOwned(siteDNSOwnershipMarker(7, rotated), 7, rotated) {
+		t.Fatal("a record scoped to the new identity must be owned")
+	}
+}
+
+// TestTLSRollbackPreflightRejectsIncompleteSnapshot proves the rollback refuses
+// to start when its TLS tree cannot restore everything the manifest claims.
+// The rollback deletes the live database first and the live TLS namespace
+// after, so an incomplete snapshot discovered mid-flight would destroy both
+// copies of the state.
+func TestTLSRollbackPreflightRejectsIncompleteSnapshot(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "meridian.db")
+	rollback := dbPath + backupRollbackSuffix
+	ownedRoot := filepath.Join(filepath.Dir(dbPath), "tls")
+
+	writeSnapshot := func(t *testing.T, snapshot tlsNamespaceSnapshot) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Join(rollback, "tls-tree"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		data, err := json.Marshal(snapshot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(rollback, "tls-namespace.json"), data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("present owned root without a copy is refused", func(t *testing.T) {
+		snapshot := tlsNamespaceSnapshot{
+			Scope: tlsRestoreScope{OwnedRoots: []string{ownedRoot}},
+			Owned: []tlsSnapshotRoot{{Path: ownedRoot, Present: true}},
+		}
+		writeSnapshot(t, snapshot)
+		scope, legacy, err := tlsRollbackLayout(dbPath, snapshot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := validateTLSRollbackSnapshot(rollback, snapshot, scope, legacy); err == nil {
+			t.Fatal("a missing rollback copy of a present root must be refused")
+		}
+	})
+
+	t.Run("present root with an empty directory is accepted", func(t *testing.T) {
+		snapshot := tlsNamespaceSnapshot{
+			Scope: tlsRestoreScope{OwnedRoots: []string{ownedRoot}},
+			Owned: []tlsSnapshotRoot{{Path: ownedRoot, Present: true}},
+		}
+		writeSnapshot(t, snapshot)
+		if err := os.MkdirAll(filepath.Join(rollback, "tls-tree", "owned", "0"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		scope, legacy, err := tlsRollbackLayout(dbPath, snapshot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := validateTLSRollbackSnapshot(rollback, snapshot, scope, legacy); err != nil {
+			t.Fatalf("a copied empty root must be accepted: %v", err)
+		}
+	})
+
+	t.Run("absent root needs no copy", func(t *testing.T) {
+		snapshot := tlsNamespaceSnapshot{
+			Scope: tlsRestoreScope{OwnedRoots: []string{ownedRoot}},
+			Owned: []tlsSnapshotRoot{{Path: ownedRoot, Present: false}},
+		}
+		writeSnapshot(t, snapshot)
+		scope, legacy, err := tlsRollbackLayout(dbPath, snapshot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := validateTLSRollbackSnapshot(rollback, snapshot, scope, legacy); err != nil {
+			t.Fatalf("a root that never existed must not require a copy: %v", err)
+		}
+	})
+
+	t.Run("present exact file without a copy is refused", func(t *testing.T) {
+		exactPath := filepath.Join(filepath.Dir(dbPath), "panel.pem")
+		snapshot := tlsNamespaceSnapshot{
+			Scope: tlsRestoreScope{ExactPaths: []string{exactPath}},
+			Exact: []tlsSnapshotPath{{Path: exactPath, Present: true}},
+		}
+		writeSnapshot(t, snapshot)
+		scope, legacy, err := tlsRollbackLayout(dbPath, snapshot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := validateTLSRollbackSnapshot(rollback, snapshot, scope, legacy); err == nil {
+			t.Fatal("a missing rollback copy of a present exact path must be refused")
+		}
+	})
+
+	t.Run("manifest entry count mismatch is refused", func(t *testing.T) {
+		other := filepath.Join(filepath.Dir(dbPath), "tls-other")
+		snapshot := tlsNamespaceSnapshot{
+			Scope: tlsRestoreScope{OwnedRoots: []string{ownedRoot, other}},
+			Owned: []tlsSnapshotRoot{{Path: ownedRoot, Present: true}},
+		}
+		writeSnapshot(t, snapshot)
+		scope, legacy, err := tlsRollbackLayout(dbPath, snapshot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := validateTLSRollbackSnapshot(rollback, snapshot, scope, legacy); err == nil {
+			t.Fatal("an ownership list that disagrees with the scope must be refused")
+		}
+	})
+}
+
+// TestLegacyTLSRollbackUsesTheV1934TreeLayout pins the v1.9.34 compatibility
+// path. Those snapshots carry only Roots and copied each owned root straight to
+// tls-tree/<index>; the owned/ subdirectory only exists from v1.9.35. Reading
+// the new layout for a legacy manifest would reject a snapshot that is in fact
+// complete, and because the boot-time rollback runs before the panel starts,
+// that rejection is an unbootable installation rather than a recoverable error.
+// TestTLSRollbackLayoutMatchesTheManifestShape is the load-bearing test for the
+// rollback tree layout. Two on-disk shapes exist and they must be told apart
+// from the manifest alone:
+//
+//   - v1.9.34 wrote `roots` and copied each owned root to tls-tree/<index>;
+//   - every release from v1.9.35 onwards writes a `scope` and copies to
+//     tls-tree/owned/<index>.
+//
+// The `owned` presence metadata used by the preflight was itself added later
+// than the whole v1.9.35..v1.9.88 range, so "the manifest has no owned field"
+// is NOT a valid legacy test; using it (as an earlier revision of this fix did)
+// misclassifies every snapshot those versions wrote and refuses a complete
+// rollback tree, which on the boot path is an unbootable installation.
+func TestTLSRollbackLayoutMatchesTheManifestShape(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "meridian.db")
+	rollback := dbPath + backupRollbackSuffix
+	ownedRoot := filepath.Join(dir, "tls")
+	if err := os.MkdirAll(rollback, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("scope carrying manifest uses the owned subdirectory", func(t *testing.T) {
+		// Exactly what v1.9.35..v1.9.88 wrote: a scope, and no owned metadata
+		// because that field did not exist yet.
+		snapshot := tlsNamespaceSnapshot{Scope: tlsRestoreScope{OwnedRoots: []string{ownedRoot}}}
+		scope, legacy, err := tlsRollbackLayout(dbPath, snapshot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if legacy {
+			t.Fatal("a scope-carrying manifest must not be treated as v1.9.34")
+		}
+		if len(scope.OwnedRoots) != 1 || filepath.Clean(scope.OwnedRoots[0]) != filepath.Clean(ownedRoot) {
+			t.Fatalf("scope = %#v, want the manifest's own owned roots", scope)
+		}
+		if err := os.MkdirAll(filepath.Join(rollback, "tls-tree", "owned", "0"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateTLSRollbackSnapshot(rollback, snapshot, scope, legacy); err != nil {
+			t.Fatalf("a complete v1.9.35-style snapshot must pass the preflight: %v", err)
+		}
+	})
+
+	t.Run("roots only manifest uses the legacy layout", func(t *testing.T) {
+		snapshot := tlsNamespaceSnapshot{Roots: []string{ownedRoot}}
+		scope, legacy, err := tlsRollbackLayout(dbPath, snapshot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !legacy {
+			t.Fatal("a bare roots manifest must be treated as v1.9.34")
+		}
+		if len(scope.OwnedRoots) != 1 {
+			t.Fatalf("scope = %#v, want the legacy roots", scope)
+		}
+		// The validator and the restore must agree on where the tree lives.
+		if got, want := tlsRollbackOwnedPath(filepath.Join(rollback, "tls-tree"), 0, legacy), filepath.Join(rollback, "tls-tree", "0"); filepath.Clean(got) != filepath.Clean(want) {
+			t.Fatalf("legacy owned path = %q, want %q", got, want)
+		}
+		if err := os.MkdirAll(filepath.Join(rollback, "tls-tree", "0"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateTLSRollbackSnapshot(rollback, snapshot, scope, legacy); err != nil {
+			t.Fatalf("a complete legacy tree must pass the preflight: %v", err)
+		}
+		// A legacy manifest whose tree is genuinely absent is still refused, so
+		// the compatibility path cannot silently restore nothing.
+		if err := os.RemoveAll(filepath.Join(rollback, "tls-tree", "0")); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateTLSRollbackSnapshot(rollback, snapshot, scope, legacy); err == nil {
+			t.Fatal("a legacy manifest without its tree must be refused")
+		}
+	})
+
+	t.Run("legacy roots outside the managed namespace are refused", func(t *testing.T) {
+		// A v1.9.34 manifest that names an arbitrary parent directory must never
+		// be replayed as an owned root.
+		outside := filepath.Join(dir, "elsewhere")
+		snapshot := tlsNamespaceSnapshot{Roots: []string{outside}}
+		if _, _, err := tlsRollbackLayout(dbPath, snapshot); err == nil {
+			t.Fatal("a legacy manifest naming a custom directory must be refused")
+		}
+	})
+}
+
+// TestSnapshotRecordsOwnedRootPresence pins the metadata that makes the
+// preflight possible: copyTLSNamespaceTree treats a missing source as success,
+// so without the presence bit a rollback cannot tell "no TLS state yet" from
+// "the rollback copy was lost".
+func TestSnapshotRecordsOwnedRootPresence(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "meridian.db")
+	rollback := dbPath + backupRollbackSuffix
+	if err := os.MkdirAll(rollback, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := snapshotTLSNamespace(dbPath, rollback); err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(rollback, "tls-namespace.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var snapshot tlsNamespaceSnapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Scope.OwnedRoots) == 0 {
+		t.Fatal("snapshot recorded no owned roots")
+	}
+	if len(snapshot.Owned) != len(snapshot.Scope.OwnedRoots) {
+		t.Fatalf("owned metadata %d entries, want %d", len(snapshot.Owned), len(snapshot.Scope.OwnedRoots))
+	}
+	// The TLS state directory does not exist yet in this fixture, so presence
+	// must be false rather than silently assumed.
+	for index, entry := range snapshot.Owned {
+		if entry.Path != snapshot.Scope.OwnedRoots[index] {
+			t.Fatalf("owned[%d].Path = %q, want %q", index, entry.Path, snapshot.Scope.OwnedRoots[index])
+		}
+		if entry.Present {
+			t.Fatalf("owned[%d] reported present for a directory that does not exist: %q", index, entry.Path)
+		}
+	}
+}
+
+func errorsNew(message string) error {
+	return &staticError{message: message}
+}
+
+type staticError struct{ message string }
+
+func (e *staticError) Error() string { return e.message }
+
+// TestQuotaUsageDecisionFailsClosed pins the enforcement rule for a hard quota:
+// an unreadable usage baseline is not permission to transfer. The admission
+// path answers 503 and the streaming paths abort, so a failing database cannot
+// silently disable a site's limit.
+func TestQuotaUsageDecisionFailsClosed(t *testing.T) {
+	app := newTestApp(t)
+	site, err := app.db.CreateSite("quota-unavailable", freePort(t), "http://127.0.0.1:8096", "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+	inst := &ProxyInstance{Site: *site}
+	// A healthy database with no usage is under the quota.
+	if decision := quotaUsageDecision(app.pm, inst, 1024, time.Now()); decision != nil {
+		t.Fatalf("usage under quota must be allowed, got %v", decision)
+	}
+	// Usage above the quota is a quota decision, not an availability one.
+	inst.trafficCycleMode = ""
+	inst.trafficCycleStart = time.Time{}
+	inst.trafficCycleUsage = 0
+	if err := app.db.addTrafficWithRequests(site.ID, 4096, 4096, 1); err != nil {
+		t.Fatal(err)
+	}
+	if decision := quotaUsageDecision(app.pm, inst, 1024, time.Now()); decision != errTrafficQuotaExceeded {
+		t.Fatalf("usage over quota decision = %v, want errTrafficQuotaExceeded", decision)
+	}
+
+	// A database that cannot answer must fail closed rather than admit the
+	// transfer.
+	broken := newTestApp(t)
+	brokenSite, err := broken.db.CreateSite("quota-broken", freePort(t), "http://127.0.0.1:8097", "", "direct", "[]", "infuse", 0, 0)
+	if err != nil {
+		t.Fatalf("CreateSite: %v", err)
+	}
+	brokenInst := &ProxyInstance{Site: *brokenSite}
+	if err := broken.db.db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if decision := quotaUsageDecision(broken.pm, brokenInst, 1024, time.Now()); decision != errTrafficQuotaUnavailable {
+		t.Fatalf("unreadable usage decision = %v, want errTrafficQuotaUnavailable", decision)
+	}
+}

--- a/playback_info_rewrite.go
+++ b/playback_info_rewrite.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
@@ -15,82 +14,8 @@ import (
 	"strings"
 )
 
-type extremePlaybackInfoJSONBudget struct {
-	remainingTokens int
-}
-
-func playbackInfoIsExtreme(session *dynamicRewriteSession) bool {
-	return session != nil && session.issuer != nil && session.issuer.policy.profile == dynamicProfileExtreme
-}
-
-func decodeExtremePlaybackInfoCollection(ctx context.Context, value, field string, containerDepth int, budget *extremePlaybackInfoJSONBudget) ([]any, error) {
-	if budget == nil || containerDepth < 0 || containerDepth >= globalDynamicMaxParseDepth {
-		return nil, fmt.Errorf("PlaybackInfo field %s exceeds its structural limits", field)
-	}
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return nil, fmt.Errorf("PlaybackInfo field %s contains invalid stringified JSON", field)
-	}
-	isObject := value[0] == '{'
-	isArray := value[0] == '['
-	if !isObject && !isArray {
-		return nil, fmt.Errorf("PlaybackInfo field %s must stringify an array or object", field)
-	}
-	wrapperTokens := 0
-	maxDepth := globalDynamicMaxParseDepth - containerDepth
-	if isObject {
-		wrapperTokens = 2
-		maxDepth--
-	}
-	tokenLimit := budget.remainingTokens + 1 - wrapperTokens
-	if tokenLimit <= 0 || maxDepth <= 0 {
-		return nil, fmt.Errorf("PlaybackInfo field %s exceeds its structural limits", field)
-	}
-	nestedTokens, err := validateDynamicJSONStructureWithin(ctx, []byte(value), tokenLimit, maxDepth)
-	if err != nil {
-		return nil, fmt.Errorf("PlaybackInfo field %s contains invalid stringified JSON", field)
-	}
-	additionalTokens := nestedTokens + wrapperTokens - 1
-	if additionalTokens > budget.remainingTokens {
-		return nil, fmt.Errorf("PlaybackInfo field %s exceeds its token limit", field)
-	}
-	decoder := json.NewDecoder(strings.NewReader(value))
-	decoder.UseNumber()
-	var decoded any
-	if err := decoder.Decode(&decoded); err != nil {
-		return nil, fmt.Errorf("PlaybackInfo field %s contains invalid stringified JSON", field)
-	}
-	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
-		return nil, fmt.Errorf("PlaybackInfo field %s contains invalid stringified JSON", field)
-	}
-	budget.remainingTokens -= additionalTokens
-	switch collection := decoded.(type) {
-	case []any:
-		return collection, nil
-	case map[string]any:
-		return []any{collection}, nil
-	default:
-		return nil, fmt.Errorf("PlaybackInfo field %s must stringify an array or object", field)
-	}
-}
-
-func normalizeExtremePlaybackInfoCollectionField(object map[string]any, field string, containerDepth int, budget *extremePlaybackInfoJSONBudget, session *dynamicRewriteSession) error {
-	key, value, exists, err := playbackInfoField(object, field)
-	if err != nil || !exists || value == nil {
-		return err
-	}
-	text, stringified := value.(string)
-	if !stringified {
-		return nil
-	}
-	collection, err := decodeExtremePlaybackInfoCollection(session.ctx, text, field, containerDepth, budget)
-	if err != nil {
-		return err
-	}
-	object[key] = collection
-	return nil
-}
-
+// dynamicURLNormalizationDiagnosticCode classifies a URL-normalization failure
+// into a stable, secret-free code.
 func dynamicURLNormalizationDiagnosticCode(err error) string {
 	if err == nil {
 		return "none"
@@ -178,7 +103,7 @@ func normalizePlaybackInfoSchemelessURL(value string, base *url.URL) (string, bo
 	return candidate, true
 }
 
-func playbackInfoExtremeNetworkURL(value string, session *dynamicRewriteSession) (string, bool) {
+func playbackInfoAbsoluteNetworkURL(value string, session *dynamicRewriteSession) (string, bool) {
 	if session != nil {
 		if normalized, ok := normalizePlaybackInfoSchemelessURL(value, session.base); ok {
 			value = normalized
@@ -194,8 +119,8 @@ func playbackInfoExtremeNetworkURL(value string, session *dynamicRewriteSession)
 	return value, true
 }
 
-func playbackInfoExtremeCapabilityType(value string, session *dynamicRewriteSession) (string, string, error) {
-	if normalized, ok := playbackInfoExtremeNetworkURL(value, session); ok {
+func playbackInfoCapabilityTypeForURL(value string, session *dynamicRewriteSession) (string, string, error) {
+	if normalized, ok := playbackInfoAbsoluteNetworkURL(value, session); ok {
 		value = normalized
 	}
 	parsed, err := url.Parse(value)
@@ -217,79 +142,6 @@ func playbackInfoExtremeCapabilityType(value string, session *dynamicRewriteSess
 		return "", "", fmt.Errorf("external PlaybackInfo manifest source is unavailable")
 	}
 	return manifestSource, dynamicCapabilityKindManifest, nil
-}
-
-func rewriteExtremePlaybackInfoValue(value any, session *dynamicRewriteSession, requiredHeaders []dynamicCapabilityHeaderClaim, ancestorDepth int) (any, error) {
-	if err := session.ctx.Err(); err != nil {
-		return nil, fmt.Errorf("PlaybackInfo parsing deadline exceeded")
-	}
-	switch typed := value.(type) {
-	case string:
-		normalized, ok := playbackInfoExtremeNetworkURL(typed, session)
-		if !ok {
-			return typed, nil
-		}
-		source, kind, err := playbackInfoExtremeCapabilityType(normalized, session)
-		if err != nil {
-			return nil, err
-		}
-		return session.rewriteAgainstSourceKindWithRequiredHeaders(normalized, session.base, source, kind, requiredHeaders)
-	case map[string]any:
-		depth := ancestorDepth + 1
-		if depth > globalDynamicMaxParseDepth {
-			return nil, fmt.Errorf("PlaybackInfo nesting exceeds its limit")
-		}
-		keys := make([]string, 0, len(typed))
-		for key := range typed {
-			keys = append(keys, key)
-		}
-		sort.Strings(keys)
-		for _, key := range keys {
-			if strings.EqualFold(key, "RequiredHttpHeaders") {
-				continue
-			}
-			rewritten, err := rewriteExtremePlaybackInfoValue(typed[key], session, requiredHeaders, depth)
-			if err != nil {
-				return nil, err
-			}
-			typed[key] = rewritten
-		}
-		return typed, nil
-	case []any:
-		depth := ancestorDepth + 1
-		if depth > globalDynamicMaxParseDepth {
-			return nil, fmt.Errorf("PlaybackInfo nesting exceeds its limit")
-		}
-		for index := range typed {
-			rewritten, err := rewriteExtremePlaybackInfoValue(typed[index], session, requiredHeaders, depth)
-			if err != nil {
-				return nil, err
-			}
-			typed[index] = rewritten
-		}
-		return typed, nil
-	default:
-		return value, nil
-	}
-}
-
-func rewriteExtremePlaybackInfoRootValues(root map[string]any, mediaSourcesKey string, session *dynamicRewriteSession) error {
-	keys := make([]string, 0, len(root))
-	for key := range root {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	for _, key := range keys {
-		if key == mediaSourcesKey || strings.EqualFold(key, "RequiredHttpHeaders") {
-			continue
-		}
-		rewritten, err := rewriteExtremePlaybackInfoValue(root[key], session, nil, 1)
-		if err != nil {
-			return err
-		}
-		root[key] = rewritten
-	}
-	return nil
 }
 
 func playbackInfoURLCandidate(value string) bool {
@@ -325,9 +177,6 @@ func playbackInfoShouldRewriteURL(value string, session *dynamicRewriteSession) 
 
 func playbackInfoRequiredHeadersUnsupported(value string, hasRequiredHeaders bool, session *dynamicRewriteSession) bool {
 	if !hasRequiredHeaders || !playbackInfoShouldRewriteURL(value, session) {
-		return false
-	}
-	if playbackInfoIsExtreme(session) {
 		return false
 	}
 	if session == nil || session.rewriteRelative {
@@ -478,8 +327,15 @@ func playbackInfoHasRequiredHeaders(object map[string]any) (bool, error) {
 	return len(headers) > 0, nil
 }
 
-func playbackInfoExtremeRequiredHeaders(object map[string]any, hasRequiredHeaders bool, session *dynamicRewriteSession) ([]dynamicCapabilityHeaderClaim, error) {
-	if !hasRequiredHeaders || !playbackInfoIsExtreme(session) {
+// playbackInfoRequiredHeaders returns the capability header claims one media
+// source requires. Heads up: honoring these claims unconditionally is a real
+// behavior change from the profile-gated code it replaced — v1.9.88 returned
+// nil whenever the profile was not "extreme", which was every runtime request.
+// Under the single remaining profile an upstream-required header is now carried
+// on the capability when the URL and header policy allow it, and a URL that
+// cannot carry them is refused by playbackInfoRequiredHeadersUnsupported.
+func playbackInfoRequiredHeaders(object map[string]any, hasRequiredHeaders bool, session *dynamicRewriteSession) ([]dynamicCapabilityHeaderClaim, error) {
+	if !hasRequiredHeaders || session == nil || session.issuer == nil {
 		return nil, nil
 	}
 	_, value, exists, err := playbackInfoField(object, "RequiredHttpHeaders")
@@ -490,7 +346,7 @@ func playbackInfoExtremeRequiredHeaders(object map[string]any, hasRequiredHeader
 	if !ok {
 		return nil, fmt.Errorf("PlaybackInfo RequiredHttpHeaders has an invalid type")
 	}
-	return normalizeExtremeRequiredHeaderClaims(headers, session.issuer.upstreamHeaderPolicy)
+	return normalizeRequiredHeaderClaims(headers, session.issuer.upstreamHeaderPolicy)
 }
 
 func playbackInfoRewriteDiagnosticCode(err error) string {
@@ -615,8 +471,29 @@ func playbackInfoRewriteDiagnosticFingerprint(err error) string {
 	return fmt.Sprintf("%x", sum[:4])
 }
 
+// playbackInfoAutomaticFallbackAllowed reports whether a strict-rewrite
+// failure is only a compatibility problem. The automatic fallback walks the
+// JSON tree instead of applying the schema, so it can still serve a response
+// the schema walker refused; it must not be entered for a security decision,
+// because the fallback is the path that keeps individual URLs on the proxy.
+//
+// Only syntax-level failures qualify. Anything about a URL's destination or
+// normalization (userinfo, fragment, host syntax, dot segments, scheme,
+// security-normalization, or a capability denial) is a security decision and
+// must stay a hard failure: falling back would let the walker decide on its
+// own whether to proxy that URL, and every URL it cannot proxy is one the
+// client would then follow directly.
 func playbackInfoAutomaticFallbackAllowed(err error) bool {
-	return strings.HasPrefix(playbackInfoRewriteDiagnosticCode(err), "url_")
+	var denial *dynamicPolicyDenialError
+	if err != nil && errors.As(err, &denial) {
+		return false
+	}
+	switch playbackInfoRewriteDiagnosticCode(err) {
+	case "url_surrounding_whitespace", "url_parse_invalid", "url_backslash", "url_unsafe_character":
+		return true
+	default:
+		return false
+	}
 }
 
 func rewritePlaybackInfoResponse(payload []byte, session *dynamicRewriteSession) ([]byte, error) {
@@ -624,12 +501,9 @@ func rewritePlaybackInfoResponse(payload []byte, session *dynamicRewriteSession)
 		return nil, fmt.Errorf("PlaybackInfo rewrite session is unavailable")
 	}
 	maxTokens := min(session.issuer.policy.limits.MaxURLsPerResponse*64+8192, globalDynamicMaxJSONTokens)
-	tokenCount, err := validateDynamicJSONStructureWithin(session.ctx, payload, maxTokens, globalDynamicMaxParseDepth)
-	if err != nil {
+	if _, err := validateDynamicJSONStructureWithin(session.ctx, payload, maxTokens, globalDynamicMaxParseDepth); err != nil {
 		return nil, fmt.Errorf("invalid PlaybackInfo JSON")
 	}
-	extreme := playbackInfoIsExtreme(session)
-	budget := &extremePlaybackInfoJSONBudget{remainingTokens: maxTokens - tokenCount}
 	decoder := json.NewDecoder(bytes.NewReader(payload))
 	decoder.UseNumber()
 	var root map[string]any
@@ -639,18 +513,11 @@ func rewritePlaybackInfoResponse(payload []byte, session *dynamicRewriteSession)
 	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
 		return nil, fmt.Errorf("invalid PlaybackInfo JSON")
 	}
-	mediaSourcesKey, mediaSourcesValue, exists, err := playbackInfoField(root, "MediaSources")
+	_, mediaSourcesValue, exists, err := playbackInfoField(root, "MediaSources")
 	if err != nil || !exists {
 		return nil, fmt.Errorf("PlaybackInfo is missing or duplicates MediaSources")
 	}
 	mediaSources, ok := mediaSourcesValue.([]any)
-	if !ok && extreme {
-		if err := normalizeExtremePlaybackInfoCollectionField(root, "MediaSources", 1, budget, session); err != nil {
-			return nil, err
-		}
-		mediaSourcesValue = root[mediaSourcesKey]
-		mediaSources, ok = mediaSourcesValue.([]any)
-	}
 	if !ok {
 		return nil, fmt.Errorf("PlaybackInfo MediaSources has an invalid type")
 	}
@@ -662,19 +529,11 @@ func rewritePlaybackInfoResponse(payload []byte, session *dynamicRewriteSession)
 		if !ok {
 			return nil, fmt.Errorf("PlaybackInfo MediaSources contains an invalid entry")
 		}
-		if extreme {
-			if err := normalizeExtremePlaybackInfoCollectionField(source, "MediaStreams", 3, budget, session); err != nil {
-				return nil, err
-			}
-			if err := normalizeExtremePlaybackInfoCollectionField(source, "MediaAttachments", 3, budget, session); err != nil {
-				return nil, err
-			}
-		}
 		hasRequiredHeaders, err := playbackInfoHasRequiredHeaders(source)
 		if err != nil {
 			return nil, err
 		}
-		requiredHeaders, err := playbackInfoExtremeRequiredHeaders(source, hasRequiredHeaders, session)
+		requiredHeaders, err := playbackInfoRequiredHeaders(source, hasRequiredHeaders, session)
 		if err != nil {
 			return nil, err
 		}
@@ -693,7 +552,7 @@ func rewritePlaybackInfoResponse(payload []byte, session *dynamicRewriteSession)
 				if !playbackInfoSafeRelativeURL(text) || parseErr != nil || reference.Path == "" {
 					return nil, fmt.Errorf("PlaybackInfo field %s is not a safe relative URL", field)
 				}
-				if hasRequiredHeaders && session.rewriteRelative && !playbackInfoIsExtreme(session) {
+				if hasRequiredHeaders && session.rewriteRelative {
 					return nil, fmt.Errorf("external PlaybackInfo URL requires unsupported origin headers")
 				}
 				// Preserve the same-origin URL exactly as the server returned it. The
@@ -722,7 +581,7 @@ func rewritePlaybackInfoResponse(payload []byte, session *dynamicRewriteSession)
 			}
 		}
 		protocol, protocolExists, protocolErr := playbackInfoString(source, "Protocol")
-		if protocolErr != nil && !extreme {
+		if protocolErr != nil {
 			return nil, protocolErr
 		}
 		_, pathValue, pathExists, pathErr := playbackInfoField(source, "Path")
@@ -733,14 +592,20 @@ func rewritePlaybackInfoResponse(payload []byte, session *dynamicRewriteSession)
 		if pathExists && !pathIsString && pathValue != nil {
 			return nil, fmt.Errorf("PlaybackInfo Path has an invalid type")
 		}
-		_, absoluteHTTPPath := playbackInfoExtremeNetworkURL(pathText, session)
-		absoluteHTTPPath = extreme && pathIsString && absoluteHTTPPath
+		// An absolute http(s) Path is a remote location the client would be sent
+		// to, exactly like the Http-protocol case below, so it must pass the
+		// same header check. A non-string Protocol is tolerated for this shape
+		// because the URL itself already identifies the transport.
+		_, absoluteHTTPPath := playbackInfoAbsoluteNetworkURL(pathText, session)
 		if protocolErr != nil && !absoluteHTTPPath {
 			return nil, protocolErr
 		}
 		if pathIsString && playbackInfoShouldRewriteURL(pathText, session) {
 			switch {
 			case absoluteHTTPPath:
+				if playbackInfoRequiredHeadersUnsupported(pathText, hasRequiredHeaders, session) {
+					return nil, fmt.Errorf("remote PlaybackInfo Path requires unsupported origin headers")
+				}
 				capabilitySource, kind, err := playbackInfoCapabilityType(source, "Path", pathText, session)
 				if err != nil {
 					return nil, err
@@ -797,7 +662,7 @@ func rewritePlaybackInfoResponse(payload []byte, session *dynamicRewriteSession)
 					return nil, fmt.Errorf("external PlaybackInfo DeliveryUrl is not a safe relative URL")
 				}
 				if deliveryIsString && (isExternalURL || shouldRewriteDelivery) {
-					if (relativeExternalDelivery && hasRequiredHeaders && !extreme) || playbackInfoRequiredHeadersUnsupported(deliveryText, hasRequiredHeaders, session) {
+					if relativeExternalDelivery && hasRequiredHeaders || playbackInfoRequiredHeadersUnsupported(deliveryText, hasRequiredHeaders, session) {
 						return nil, fmt.Errorf("external subtitle URL requires unsupported origin headers")
 					}
 					capabilitySource, kind, err := playbackInfoCapabilityType(stream, "DeliveryUrl", deliveryText, session)
@@ -819,16 +684,6 @@ func rewritePlaybackInfoResponse(payload []byte, session *dynamicRewriteSession)
 					}
 				}
 			}
-		}
-		if extreme {
-			if _, err := rewriteExtremePlaybackInfoValue(source, session, requiredHeaders, 2); err != nil {
-				return nil, err
-			}
-		}
-	}
-	if extreme {
-		if err := rewriteExtremePlaybackInfoRootValues(root, mediaSourcesKey, session); err != nil {
-			return nil, err
 		}
 	}
 	output := dynamicBoundedBuffer{limit: session.structuredOutputLimit()}
@@ -861,7 +716,10 @@ func rewriteAutomaticPlaybackInfoResponse(payload []byte, session *dynamicRewrit
 	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
 		return nil, fmt.Errorf("invalid automatic PlaybackInfo JSON")
 	}
-	rewritten := rewriteAutomaticPlaybackInfoValue(root, session, 0, "")
+	rewritten, err := rewriteAutomaticPlaybackInfoValue(root, session, 0, "")
+	if err != nil {
+		return nil, err
+	}
 	output := dynamicBoundedBuffer{limit: session.structuredOutputLimit()}
 	encoder := json.NewEncoder(&output)
 	encoder.SetEscapeHTML(false)
@@ -871,9 +729,24 @@ func rewriteAutomaticPlaybackInfoResponse(payload []byte, session *dynamicRewrit
 	return bytes.TrimSuffix(output.Bytes(), []byte("\n")), nil
 }
 
-func rewriteAutomaticPlaybackInfoValue(value any, session *dynamicRewriteSession, depth int, field string) any {
+// automaticPlaybackInfoURLError marks a URL the automatic fallback recognized
+// as a network destination but could not route through Meridian.
+func automaticPlaybackInfoURLError(field string) error {
+	name := strings.TrimSpace(field)
+	if name == "" {
+		name = "value"
+	}
+	return fmt.Errorf("PlaybackInfo field %s carries a URL that cannot be proxied", name)
+}
+
+// rewriteAutomaticPlaybackInfoValue rewrites every complete HTTP(S) URL in the
+// value tree so the client fetches it through Meridian. A recognized URL that
+// cannot be proxied is an error rather than a preserved value: keeping it would
+// send the client straight to the upstream destination, bypassing the
+// capability, its traffic accounting, and its quota.
+func rewriteAutomaticPlaybackInfoValue(value any, session *dynamicRewriteSession, depth int, field string) (any, error) {
 	if session == nil || depth > globalDynamicMaxParseDepth || session.ctx.Err() != nil {
-		return value
+		return value, nil
 	}
 	switch typed := value.(type) {
 	case string:
@@ -882,17 +755,22 @@ func rewriteAutomaticPlaybackInfoValue(value any, session *dynamicRewriteSession
 			session.rememberRelativePlaybackPath(typed)
 		}
 		if !ok {
-			return typed
+			return typed, nil
 		}
-		source, kind, err := playbackInfoExtremeCapabilityType(candidate, session)
+		// The value is a URL the player would fetch. Every failure below means
+		// Meridian cannot safely proxy it, and returning it unchanged would
+		// hand the player a destination outside the proxy: no capability, no
+		// traffic accounting, no quota, and the origin address revealed. Fail
+		// the response instead of leaking the URL.
+		source, kind, err := playbackInfoCapabilityTypeForURL(candidate, session)
 		if err != nil {
-			return typed
+			return nil, automaticPlaybackInfoURLError(field)
 		}
 		route, err := session.rewriteAgainstSourceKindWithRequiredHeaders(candidate, session.base, source, kind, nil)
 		if err != nil {
-			return typed
+			return nil, automaticPlaybackInfoURLError(field)
 		}
-		return route
+		return route, nil
 	case map[string]any:
 		keys := make([]string, 0, len(typed))
 		for key := range typed {
@@ -903,16 +781,24 @@ func rewriteAutomaticPlaybackInfoValue(value any, session *dynamicRewriteSession
 			if strings.EqualFold(key, "RequiredHttpHeaders") {
 				continue
 			}
-			typed[key] = rewriteAutomaticPlaybackInfoValue(typed[key], session, depth+1, key)
+			rewritten, err := rewriteAutomaticPlaybackInfoValue(typed[key], session, depth+1, key)
+			if err != nil {
+				return nil, err
+			}
+			typed[key] = rewritten
 		}
-		return typed
+		return typed, nil
 	case []any:
 		for index := range typed {
-			typed[index] = rewriteAutomaticPlaybackInfoValue(typed[index], session, depth+1, field)
+			rewritten, err := rewriteAutomaticPlaybackInfoValue(typed[index], session, depth+1, field)
+			if err != nil {
+				return nil, err
+			}
+			typed[index] = rewritten
 		}
-		return typed
+		return typed, nil
 	default:
-		return value
+		return value, nil
 	}
 }
 

--- a/proxy_io.go
+++ b/proxy_io.go
@@ -65,6 +65,31 @@ const quotaCheckBytes = 16 << 20
 // site has crossed its billing quota; it is not exposed to clients.
 var errTrafficQuotaExceeded = errors.New("traffic quota exceeded")
 
+// errTrafficQuotaUnavailable aborts a transfer whose billing-cycle usage could
+// not be read. A configured quota is a hard limit, so "usage unknown" must not
+// degrade into "usage is fine": an unreadable usage baseline would otherwise
+// disable enforcement for every stream on the site while the database is
+// failing.
+var errTrafficQuotaUnavailable = errors.New("traffic quota enforcement is unavailable")
+
+// quotaUsageDecision evaluates one quota probe at a checkpoint. It returns
+// errTrafficQuotaExceeded when the site is over its limit and
+// errTrafficQuotaUnavailable when the usage baseline cannot be read; both are
+// fail-closed conditions for the caller.
+func quotaUsageDecision(pm *ProxyManager, inst *ProxyInstance, limit int64, now time.Time) error {
+	if pm == nil || inst == nil || limit <= 0 {
+		return nil
+	}
+	usage, err := pm.currentTrafficCycleUsage(inst, now)
+	if err != nil {
+		return errTrafficQuotaUnavailable
+	}
+	if usage >= limit {
+		return errTrafficQuotaExceeded
+	}
+	return nil
+}
+
 // quotaProbeShared records bytes against the instance-wide probe accumulator
 // and reports whether the caller must run the quota check now. The first
 // stream to cross the threshold claims the check.
@@ -93,7 +118,7 @@ func (q *quotaLimitedWriter) Write(b []byte) (int, error) {
 		return n, err
 	}
 	if quotaProbeShared(q.inst, int64(n)) {
-		if usage, usageErr := q.pm.currentTrafficCycleUsage(q.inst, time.Now()); usageErr == nil && usage >= q.quota {
+		if decision := quotaUsageDecision(q.pm, q.inst, q.quota, time.Now()); decision != nil {
 			return n, http.ErrAbortHandler
 		}
 	}
@@ -115,8 +140,8 @@ func (q *quotaLimitedReader) Read(p []byte) (int, error) {
 	// that final chunk before propagating the underlying error so a checkpoint
 	// cannot be skipped at end of stream.
 	if n > 0 && quotaProbeShared(q.inst, int64(n)) {
-		if usage, usageErr := q.pm.currentTrafficCycleUsage(q.inst, time.Now()); usageErr == nil && usage >= q.quota {
-			return n, errTrafficQuotaExceeded
+		if decision := quotaUsageDecision(q.pm, q.inst, q.quota, time.Now()); decision != nil {
+			return n, decision
 		}
 	}
 	return n, err
@@ -245,8 +270,8 @@ func (t *tunnelWriter) Write(b []byte) (int, error) {
 		n, err := t.dst.Write(b)
 		addMeteredBytes(t.counter, t.cumulative, n)
 		if err == nil && n > 0 && t.quota != nil && quotaProbeShared(t.quota.inst, int64(n)) {
-			if usage, usageErr := t.quota.pm.currentTrafficCycleUsage(t.quota.inst, time.Now()); usageErr == nil && usage >= t.quota.limit {
-				return n, errTrafficQuotaExceeded
+			if decision := quotaUsageDecision(t.quota.pm, t.quota.inst, t.quota.limit, time.Now()); decision != nil {
+				return n, decision
 			}
 		}
 		return n, err
@@ -278,8 +303,8 @@ func (t *tunnelWriter) Write(b []byte) (int, error) {
 			return total, io.ErrNoProgress
 		}
 		if t.quota != nil && quotaProbeShared(t.quota.inst, int64(n)) {
-			if usage, usageErr := t.quota.pm.currentTrafficCycleUsage(t.quota.inst, time.Now()); usageErr == nil && usage >= t.quota.limit {
-				return total, errTrafficQuotaExceeded
+			if decision := quotaUsageDecision(t.quota.pm, t.quota.inst, t.quota.limit, time.Now()); decision != nil {
+				return total, decision
 			}
 		}
 	}

--- a/proxy_lifecycle.go
+++ b/proxy_lifecycle.go
@@ -177,18 +177,21 @@ func (pm *ProxyManager) flushProxyTrafficLocked(inst *ProxyInstance) error {
 		inst.trafficPendingRequests().Add(requests)
 		return err
 	}
-	delta := in + out
-	inst.persistedTraffic.Add(delta)
-	inst.persistedBytesIn.Add(in)
-	inst.persistedBytesOut.Add(out)
-	inst.Site.TrafficUsed += delta
-	inst.Site.TrafficUsedIn += in
-	inst.Site.TrafficUsedOut += out
+	// Saturating arithmetic throughout: these counters are quota inputs, and a
+	// wrapped value would read as a small positive number (or a negative one)
+	// and silently stop enforcing the limit instead of reporting overflow.
+	delta := saturatingAddInt64(in, out)
+	inst.persistedTraffic.Store(saturatingAddInt64(inst.persistedTraffic.Load(), delta))
+	inst.persistedBytesIn.Store(saturatingAddInt64(inst.persistedBytesIn.Load(), in))
+	inst.persistedBytesOut.Store(saturatingAddInt64(inst.persistedBytesOut.Load(), out))
+	inst.Site.TrafficUsed = saturatingAddInt64(inst.Site.TrafficUsed, delta)
+	inst.Site.TrafficUsedIn = saturatingAddInt64(inst.Site.TrafficUsedIn, in)
+	inst.Site.TrafficUsedOut = saturatingAddInt64(inst.Site.TrafficUsedOut, out)
 	settings := pm.database.currentSystemSettings()
 	cycleStart := trafficCycleStart(time.Now(), settings.TrafficResetDay, timezoneLocation(settings.ScheduleTimezone))
 	cycleMode := trafficBillingModeLabel(settings.TrafficBillingMode)
 	if !inst.trafficCycleAuthoritative && inst.trafficCycleMode == cycleMode && inst.trafficCycleStart.Equal(cycleStart) {
-		inst.trafficCycleUsage += trafficBillableBytes(cycleMode, in, out)
+		inst.trafficCycleUsage = saturatingAddInt64(inst.trafficCycleUsage, trafficBillableBytes(cycleMode, in, out))
 	}
 	if generation := inst.trafficFlushGeneration(); generation != nil {
 		generation.Add(1)
@@ -215,7 +218,7 @@ func (pm *ProxyManager) currentTrafficCycleUsage(inst *ProxyInstance, now time.T
 		if localOut < 0 {
 			localOut = inst.trafficCumulativeOut().Load()
 		}
-		return inst.trafficCycleUsage + trafficBillableBytes(inst.trafficCycleMode, localIn, localOut), nil
+		return saturatingAddInt64(inst.trafficCycleUsage, trafficBillableBytes(inst.trafficCycleMode, localIn, localOut)), nil
 	}
 	settings := pm.database.currentSystemSettings()
 	cycleStart := trafficCycleStart(now, settings.TrafficResetDay, timezoneLocation(settings.ScheduleTimezone))
@@ -231,7 +234,7 @@ func (pm *ProxyManager) currentTrafficCycleUsage(inst *ProxyInstance, now time.T
 		inst.trafficAckedCumulativeIn = inst.trafficCumulativeIn().Load()
 		inst.trafficAckedCumulativeOut = inst.trafficCumulativeOut().Load()
 	}
-	return inst.trafficCycleUsage + trafficBillableBytes(cycleMode, inst.trafficBytesIn().Load(), inst.trafficBytesOut().Load()), nil
+	return saturatingAddInt64(inst.trafficCycleUsage, trafficBillableBytes(cycleMode, inst.trafficBytesIn().Load(), inst.trafficBytesOut().Load())), nil
 }
 
 func (inst *ProxyInstance) persistedDirections() (int64, int64) {
@@ -469,15 +472,15 @@ func (pm *ProxyManager) dashboardSnapshotFromSites(sites []Site, monthlyBySite m
 		} else {
 			// Controller-local pending bytes are not in the monthly query yet;
 			// merge them into the current snapshot exactly once.
-			st.MonthlyTraffic += trafficBillableBytes(billingMode, st.BytesIn, st.BytesOut)
-			snap.MonthlyTraffic += trafficBillableBytes(billingMode, st.BytesIn, st.BytesOut)
+			st.MonthlyTraffic = saturatingAddInt64(st.MonthlyTraffic, trafficBillableBytes(billingMode, st.BytesIn, st.BytesOut))
+			snap.MonthlyTraffic = saturatingAddInt64(snap.MonthlyTraffic, trafficBillableBytes(billingMode, st.BytesIn, st.BytesOut))
 			st.SampledAtMS = now.UnixMilli()
 		}
 		if st.Running {
 			snap.RunningSites++
 		}
-		snap.TotalTraffic += st.TrafficUsed
-		snap.TotalRequests += st.Requests
+		snap.TotalTraffic = saturatingAddInt64(snap.TotalTraffic, st.TrafficUsed)
+		snap.TotalRequests = saturatingAddInt64(snap.TotalRequests, st.Requests)
 		snap.LiveSites = append(snap.LiveSites, st)
 	}
 	snap.UptimeSeconds = int64(now.Sub(startTime).Seconds())

--- a/proxy_start.go
+++ b/proxy_start.go
@@ -371,13 +371,23 @@ func (pm *ProxyManager) StartSite(site Site) error {
 		trafficQuota := inst.Site.TrafficQuota
 		inst.trafficMu.Unlock()
 		if trafficQuota > 0 {
-			currentUsed, usageErr := pm.currentTrafficCycleUsage(inst, time.Now())
-			if usageErr != nil {
-				log.Printf("[%s] failed to calculate current traffic cycle usage: %v", site.Name, usageErr)
-			} else if currentUsed >= trafficQuota {
+			// A configured quota is a hard limit, so an unreadable usage
+			// baseline must fail closed with "enforcement unavailable" rather
+			// than admitting traffic that the site may no longer be allowed to
+			// carry. This is deliberately not 403: the quota is not known to be
+			// exhausted, the check itself could not run.
+			switch err := quotaUsageDecision(pm, inst, trafficQuota, time.Now()); err {
+			case nil:
+			case errTrafficQuotaExceeded:
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusForbidden)
 				w.Write([]byte(`{"error":"traffic quota exceeded"}`))
+				return
+			default:
+				log.Printf("[%s] refusing request: %v", site.Name, errTrafficQuotaUnavailable)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusServiceUnavailable)
+				w.Write([]byte(`{"error":"traffic quota enforcement unavailable"}`))
 				return
 			}
 		}

--- a/site_node_scheduler.go
+++ b/site_node_scheduler.go
@@ -1892,13 +1892,66 @@ func verifyTrackedSiteDNSOwnership(ctx context.Context, cf *cloudflareClient, sc
 		}
 		return err
 	}
-	// Ownership is proven by the record ID plus the site's ownership-marker
-	// comment; the hostname is deliberately not compared because a site can be
-	// renamed after the record was created, and refusing the delete then would
-	// wedge cleanup and site deletion forever on a record Meridian still owns.
-	if (record.Type != "A" && record.Type != "AAAA") ||
-		!siteDNSMarkerOwned(record.Comment, schedule.SiteID, cf.installUUID) {
-		return errors.New("tracked DNS record no longer carries the Meridian ownership marker; refusing to delete")
+	return verifySiteDNSRecordOwnership(record, schedule.SiteID, cf.installUUID, "refusing to delete")
+}
+
+// readOwnedTrackedSiteDNSRecord re-reads a tracked record by ID and returns it
+// only when its current state still proves Meridian ownership.
+//
+// Every destructive or mutating operation on a tracked record must pass
+// through this guard, so an administrator who clears the marker comment,
+// replaces the record, or rewrites it with another tool immediately takes
+// ownership back. Without the guard a scheduled reconcile PUT would silently
+// reassert Meridian's address and marker over an operator-managed record —
+// DELETE already refused to do that, and UPDATE must not be the way around it.
+//
+// The hostname is deliberately not compared: renaming a site is a supported
+// operation, so ownership is proven by the record ID plus the marker comment
+// scoped to this installation and site. The returned record is also the exact
+// preimage a compensating PUT must restore, which a name-scoped listing cannot
+// provide once the operator has moved the record.
+//
+// A record that no longer exists returns (record{}, nil, false) so callers can
+// fall through to the existing missing-record recovery path.
+func readOwnedTrackedSiteDNSRecord(ctx context.Context, cf *cloudflareClient, schedule SiteNodeSchedule) (cloudflareAddressRecord, error, bool) {
+	if cf == nil {
+		return cloudflareAddressRecord{}, errors.New("Cloudflare DNS client is unavailable"), false
+	}
+	if strings.TrimSpace(schedule.cfZoneID) == "" {
+		return cloudflareAddressRecord{}, errors.New("tracked DNS zone is missing"), false
+	}
+	if strings.TrimSpace(schedule.cfRecordID) == "" {
+		return cloudflareAddressRecord{}, errors.New("tracked DNS record is missing"), false
+	}
+	record, err := cf.dnsRecordByID(ctx, schedule.cfZoneID, schedule.cfRecordID)
+	if err != nil {
+		if isCloudflareRecordNotFoundError(err) {
+			return cloudflareAddressRecord{}, nil, false
+		}
+		return cloudflareAddressRecord{}, err, false
+	}
+	if err := verifySiteDNSRecordOwnership(record, schedule.SiteID, cf.installUUID, "refusing to overwrite it"); err != nil {
+		return cloudflareAddressRecord{}, err, false
+	}
+	return record, nil, true
+}
+
+// verifySiteDNSRecordOwnership reports whether a Cloudflare record still
+// proves ownership by this installation for one site. Ownership requires both
+// an address record type and the site's ownership-marker comment: an operator
+// who clears the comment, points the record elsewhere, or replaces it with a
+// CNAME has taken it back, and Meridian must then refuse to touch it rather
+// than silently reasserting its own marker and address.
+//
+// The hostname is deliberately not part of the decision. Renaming a site is
+// supported, so requiring the stored hostname would wedge both the update and
+// the cleanup of a record Meridian still legitimately owns.
+func verifySiteDNSRecordOwnership(record cloudflareAddressRecord, siteID int64, installUUID, refusal string) error {
+	if record.Type != "A" && record.Type != "AAAA" {
+		return fmt.Errorf("tracked DNS record is no longer an A/AAAA record; %s", refusal)
+	}
+	if !siteDNSMarkerOwned(record.Comment, siteID, installUUID) {
+		return fmt.Errorf("tracked DNS record no longer carries the Meridian ownership marker; %s", refusal)
 	}
 	return nil
 }
@@ -2115,22 +2168,31 @@ func (a *App) reconcileOneSiteScheduleLocked(ctx context.Context, schedule SiteN
 	var previousRecord *cloudflareAddressRecord
 	var replacedRecord *cloudflareAddressRecord
 	if recordID != "" {
-		// Keep a preimage for a possible PUT compensation if the schedule
-		// generation changes before the local transaction commits.
-		records, getErr := cf.exactAddressRecords(ctx, zoneID, schedule.PublicHost)
-		if getErr != nil {
-			// Without the preimage a compensating PUT could not restore the
-			// previous address if the schedule changes mid-update. Refuse the
-			// blind write; the next tick retries with a fresh snapshot.
-			return fmt.Errorf("read current DNS record before update: %w", getErr)
+		// Re-read the tracked record by ID and require that it still proves
+		// Meridian ownership before any PUT. A name-scoped listing is not
+		// enough: it cannot prove the record we are about to overwrite is
+		// still ours (an operator may have cleared the marker comment), and it
+		// cannot find the record at all once the operator renames it, which
+		// would leave us blind-writing a stale ID.
+		//
+		// The fetched record doubles as the compensation preimage: a PUT that
+		// succeeds remotely while the local schedule CAS fails must restore
+		// exactly this record, including its comment and hostname.
+		record, readErr, owned := readOwnedTrackedSiteDNSRecord(ctx, cf, schedule)
+		if readErr != nil {
+			// Ownership can no longer be proven (cleared marker, foreign
+			// controller, or a record type we must not overwrite). Refuse the
+			// write instead of silently reclaiming the record; the operator
+			// resolves the conflict by deleting the marker-free record or
+			// re-tracking the correct one.
+			return readErr
 		}
-		for i := range records {
-			if records[i].ID == recordID {
-				copy := records[i]
-				previousRecord = &copy
-				break
-			}
+		if owned {
+			previousRecord = &record
 		}
+		// A missing tracked record (owned == false, no error) falls through to
+		// the create path below; the PUT that follows returns a not-found
+		// error, which the existing missing-record recovery handles.
 	}
 	if recordID == "" {
 		records, err := cf.exactAddressRecords(ctx, zoneID, schedule.PublicHost)


### PR DESCRIPTION
## Summary

Verifies and remediates the operator's ninth review against v1.9.88 (`4e9b2fe`).

**All nine findings were confirmed in source; none was rejected.**

| Level | Count | Status |
|---|---:|---|
| P0 | 0 | — |
| P1 | 1 | fixed |
| P2 | 3 | fixed |
| P3 | 5 | fixed |

### P1-1 — tracked Cloudflare record PUT had no ownership fence
The delete path re-read the record and required the Meridian ownership marker; the update path did not. A reconcile could therefore reassert Meridian's address and marker over a record an operator had taken back, and a record the operator renamed was blind-written from a stale ID with a nil compensation preimage.

Tracked-record PUTs now go through `readOwnedTrackedSiteDNSRecord`: a by-ID read that must prove the scoped marker (the legacy pre-UUID marker is still accepted for migration), with the fetched record used as the exact compensation preimage. A 404 still reaches the existing missing-record recovery, and the hostname is deliberately not compared so site renames keep working.

### P2-1 — preserved bodies could leak unroutable URLs
A manifest the strict parser rejected was forwarded verbatim even when it carried URLs Meridian could never route, because the parser stops at the first unsupported feature — before per-URL validation. Separately, `playbackInfoAutomaticFallbackAllowed` accepted every `url_*` diagnostic including security decisions, and the automatic walker returned unproxyable URLs unchanged.

Preserving now requires `preservedStructuredBodyIsSafe`, which proves every URL-shaped value is one a capability could have carried (same rules as the strict path, including the non-public-address rule). The fallback allowlist is compatibility-only, and a fallback that cannot proxy everything fails the response rather than relaying the upstream body.

### P2-2 — hard quota failed open
`usageErr != nil` meant "allow" at all four enforcement points. Now `quotaUsageDecision` unifies them: admission answers **503** (not 403 — the quota is not known to be exhausted, the check could not run) and the response, upload, and WebSocket tunnel paths abort.

### P2-3 — TLS rollback could destroy state and report success
`copyTLSNamespaceTree` treats a missing source as success, so a lost rollback root deleted the live TLS namespace and copied nothing. Snapshots now record per-root presence and `validateTLSRollbackSnapshot` runs before the database is touched and before the live namespace is removed.

### P3
- `install.sh`: output helpers (including `fail`) defined before the top-level `INSTALL_DIR` guard that calls them.
- Saturating arithmetic on every local quota-relevant accumulator.
- Agent shutdown surfaces a failed final spool flush as a failed exit, with a bounded retry.
- New `meridian admin rotate-installation-identity` for a controller cloned from a backup.
- Dead `extreme` discovery profile physically removed (~600 lines across seven files).

## Intentional behavior changes

- **Upstream `RequiredHttpHeaders` are now honored on real traffic.** v1.9.88 dropped every claim because the profile-gated check was always false under the only runtime profile.
- An unroutable URL in a preserved manifest or in the PlaybackInfo fallback is now a hard failure rather than a URL handed to the client.
- A site with a configured quota answers `503 traffic quota enforcement unavailable` when its usage baseline cannot be read, instead of admitting traffic.
- `dynamicProfileSafe` / the `extreme` profile are gone; the runtime policy is the single compatible profile.

## Verification

`go test ./...` ok · `go test -race` ok · `go vet` + cross-GOOS vet · linux amd64/arm64 cross builds · govulncheck 0 · gosec 0 · node 167/167 · `bash -n` clean.

Two independent adversarial audits of this remediation were run. The first found nine real defects in it (including a fallback branch that still relayed the whole body, and an ownership-bypassing delete helper). The second found one boot-severity defect and two hollow tests:

- the legacy-TLS layout check discriminated on the `owned` field — which **this change set introduces** — so every manifest written by v1.9.35..v1.9.88 was misclassified and a complete snapshot would have been refused on the startup rollback path. Now decided once in `tlsRollbackLayout` from the manifest's own `roots` field, shared by the preflight and the restore so they cannot disagree; mutation-tested by re-introducing the bug.
- `TestPlaybackInfoFallbackFailureIsHard` never entered the fallback (its payload produced a non-whitelisted diagnostic), so it passed with the fix reverted. Rewritten to assert the fallback is entered, that the walker refuses the unproxyable URL, and that the response is a dynamic proxy error.

Every new regression test is now mutation-verified: revert the fix, confirm the test fails.

## Known gaps

- The DNS guard is covered at helper level (decision matrix, by-ID read, missing record) but not through `reconcileOneSiteScheduleLocked`, which would need a Cloudflare client injection point that does not exist today.
- The quota writer/reader/tunnel arms are verified by reading; the admission branch and `quotaUsageDecision` are tested.