### PR TITLE
fix: restore pre-v1.9.89 PlaybackInfo fallback behaviour (site 1111 playback 502/404)

### DIFF
--- a/dynamic_rewrite_core.go
+++ b/dynamic_rewrite_core.go
@@ -1322,20 +1322,27 @@ func rewriteDynamicStructuredResponseAccepted(resp *http.Response, issuer *dynam
 			if accept != nil && !accept() {
 				return errDynamicCapabilityExpiredDuringUse
 			}
-			// The schema-free walker refused a URL it recognized but could not
-			// route. Falling back to the upstream bytes here would be worse
-			// than the failure it avoids: the client would receive the whole
-			// body with every URL unproxied, so one unroutable field would cost
-			// the capability, the traffic accounting and the quota for all of
-			// them. Fail the response instead.
-			log.Printf("[%s] PlaybackInfo rewrite and automatic fallback both rejected: diagnostic=%s", issuer.site.Name, playbackInfoRewriteDiagnosticCode(fallbackErr))
-			return recordFailure(dynamicObservationReasonPlaybackInfoDenied)
+			// The walker itself failed, which for PlaybackInfo means the JSON
+			// tree could not be processed at all. Preserve the upstream body
+			// exactly as every release before v1.9.89 did. This branch is only
+			// reachable through playbackInfoAutomaticFallbackAllowed, and
+			// failing here turns a parse-level problem into a hard 502 for the
+			// whole site — the regression that broke real sites on v1.9.89.
+			log.Printf("[%s] PlaybackInfo rewrite and automatic fallback both failed; preserving the upstream response: diagnostic=%s", issuer.site.Name, playbackInfoRewriteDiagnosticCode(fallbackErr))
+			installDynamicStructuredBody(resp, payload, false)
+			return nil
 		}
 	}
 	if err != nil {
 		session.rollback()
 		if source == dynamicDiscoverySourcePlaybackInfo {
-			log.Printf("[%s] PlaybackInfo rewrite rejected: diagnostic=%s fingerprint=%s profile=%s", issuer.site.Name, playbackInfoRewriteDiagnosticCode(err), playbackInfoRewriteDiagnosticFingerprint(err), issuer.policy.profile)
+			// The full message is logged alongside the stable diagnostic code:
+			// without it an operator sees only "playback_info_denied" in the
+			// request log and cannot tell whether the upstream sent an
+			// unroutable URL, a conflicting header claim, or an oversized body.
+			// These messages are built from field names and classification
+			// labels, never from the upstream response bytes.
+			log.Printf("[%s] PlaybackInfo rewrite rejected: diagnostic=%s detail=%q fingerprint=%s profile=%s", issuer.site.Name, playbackInfoRewriteDiagnosticCode(err), err.Error(), playbackInfoRewriteDiagnosticFingerprint(err), issuer.policy.profile)
 		}
 		// A manifest the strict rewriter cannot parse is not a client error:
 		// real-world playlists routinely carry vendor tags, BOMs, DRM

--- a/dynamic_structured_discovery_test.go
+++ b/dynamic_structured_discovery_test.go
@@ -214,32 +214,33 @@ func TestPlaybackInfoRewriteDiagnosticCodeIsStableAndSecretFree(t *testing.T) {
 	if got := playbackInfoRewriteDiagnosticFingerprint(errors.New("unexpected upstream value bearer-secret")); len(got) != 8 || strings.Contains(got, "secret") {
 		t.Fatalf("diagnostic fingerprint is unsafe: %q", got)
 	}
-	// A URL whose destination cannot be proven safe must not enter the
-	// schema-free walker: that walker is the path that keeps individual URLs on
-	// the proxy, so re-deciding a security failure there would route around the
-	// strict rules. Only genuinely compatibility-level syntax failures qualify.
-	if playbackInfoAutomaticFallbackAllowed(errors.New("invalid discovered URL: target normalization host")) {
-		t.Fatal("a URL normalization decision must not allow automatic proxy fallback")
-	}
+	// The automatic fallback must stay available for every url_* diagnostic.
+	// Narrowing it to a "compatibility only" subset turned ordinary upstream
+	// responses into hard 502s in v1.9.89 — the strict walker reports
+	// url_target_host for a stream host containing an underscore, among others —
+	// so this gate is deliberately broad again. The security decision lives in
+	// what the walker does with a URL, not in which diagnostics reach it.
 	for _, err := range []error{
+		errors.New("invalid discovered URL: target normalization host"),
 		errors.New("invalid discovered URL: userinfo"),
 		errors.New("invalid discovered URL: fragment"),
 		errors.New("invalid discovered URL: target normalization scheme"),
 		errors.New("invalid discovered URL: target normalization dot_segments"),
+		errors.New("invalid discovered URL: surrounding whitespace"),
+		errors.New("invalid discovered URL: parse"),
+	} {
+		if !playbackInfoAutomaticFallbackAllowed(err) {
+			t.Fatalf("url-level error must keep the automatic fallback available: %v", err)
+		}
+	}
+	// Non-URL failures stay hard errors: the walker cannot help there.
+	for _, err := range []error{
 		errors.New("external subtitle URL requires unsupported origin headers"),
 		errors.New("PlaybackInfo RequiredHttpHeaders has an invalid value"),
 		errors.New("invalid PlaybackInfo JSON"),
 	} {
 		if playbackInfoAutomaticFallbackAllowed(err) {
-			t.Fatalf("security or structure error unexpectedly allowed fallback: %v", err)
-		}
-	}
-	for _, err := range []error{
-		errors.New("invalid discovered URL: surrounding whitespace"),
-		errors.New("invalid discovered URL: parse"),
-	} {
-		if !playbackInfoAutomaticFallbackAllowed(err) {
-			t.Fatalf("compatibility-only error must allow fallback: %v", err)
+			t.Fatalf("non-URL error unexpectedly allowed fallback: %v", err)
 		}
 	}
 }
@@ -254,12 +255,14 @@ func TestPlaybackInfoRelativeExternalDeliveryURLWithRequiredHeadersFailsClosed(t
 	}
 }
 
-// TestAutomaticPlaybackInfoFallbackRefusesURLsItCannotProxy replaces the
-// earlier preservation contract. Keeping an absolute URL the walker could not
-// route handed the player the upstream destination directly: no capability, no
-// traffic accounting, no quota, and the origin address revealed. A relative
+// TestAutomaticPlaybackInfoFallbackPreservesURLsItCannotProxy pins the
+// v1.9.89 hotfix contract. The walker preserves an absolute URL it cannot route
+// instead of failing the response: the strict schema walker refuses whole
+// documents over one optional field, and turning that into a 502 breaks
+// playback for the entire site. The strict walker's own policy decisions still
+// fail closed; only this walker's URL selection is permissive. A relative
 // same-origin playback path is not a network destination and is still kept.
-func TestAutomaticPlaybackInfoFallbackRefusesURLsItCannotProxy(t *testing.T) {
+func TestAutomaticPlaybackInfoFallbackPreservesURLsItCannotProxy(t *testing.T) {
 	issuer := newStructuredDiscoveryTestIssuer(t)
 	base := mustStructuredURL(t, "http://line.example.com/Items/1/PlaybackInfo")
 	payload := []byte(`{"MediaSources":[{"DirectStreamUrl":"http://line.example.com/Videos/1/original.mkv?token=origin-secret","MediaStreams":[{"DeliveryUrl":"http://backend.invalidtld/subtitle.vtt","IsExternalUrl":true}]}]}`)
@@ -271,15 +274,23 @@ func TestAutomaticPlaybackInfoFallbackRefusesURLsItCannotProxy(t *testing.T) {
 	strictSession.rollback()
 
 	fallbackSession := &dynamicRewriteSession{ctx: context.Background(), issuer: issuer, base: base, source: dynamicDiscoverySourcePlaybackInfo}
-	if _, err := rewriteAutomaticPlaybackInfoResponse(payload, fallbackSession); err == nil {
-		t.Fatal("the automatic fallback must not preserve a URL it cannot proxy")
+	rewritten, err := rewriteAutomaticPlaybackInfoResponse(payload, fallbackSession)
+	if err != nil {
+		t.Fatalf("the automatic fallback must serve the response: %v", err)
 	}
 	fallbackSession.rollback()
+	text := string(rewritten)
+	if !strings.Contains(text, `"DirectStreamUrl":"/Videos/1/original.mkv?token=origin-secret"`) {
+		t.Fatalf("same-authority playback URL was not kept on the proxy: %s", text)
+	}
+	if !strings.Contains(text, `"DeliveryUrl":"http://backend.invalidtld/subtitle.vtt"`) {
+		t.Fatalf("unroutable optional URL was not preserved: %s", text)
+	}
 
 	// The same walker keeps a relative same-origin playback URL on the proxy.
 	relativePayload := []byte(`{"MediaSources":[{"DirectStreamUrl":"/Videos/1/original.mkv?token=local-token"}]}`)
 	relativeSession := &dynamicRewriteSession{ctx: context.Background(), issuer: issuer, base: base, source: dynamicDiscoverySourcePlaybackInfo}
-	rewritten, err := rewriteAutomaticPlaybackInfoResponse(relativePayload, relativeSession)
+	rewritten, err = rewriteAutomaticPlaybackInfoResponse(relativePayload, relativeSession)
 	if err != nil {
 		t.Fatalf("automatic PlaybackInfo fallback on a relative path: %v", err)
 	}

--- a/ninth_review_regression_test.go
+++ b/ninth_review_regression_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -450,124 +449,107 @@ func TestScanHostNonPublicShorthandRecognizesResolverSpellings(t *testing.T) {
 	}
 }
 
-// TestPlaybackInfoFallbackFailureIsHard drives the whole response path. It has
-// to enter the automatic fallback for real, which requires the strict walker to
-// fail with one of the compatibility-only diagnostics: a backslash inside a
-// subtitle URL is the reachable case (delivery percent-escapes and Protocol
-// mismatches produce other codes). The payload then also carries a stream URL
-// the walker cannot route, so the fallback's own failure is what the response
-// disposition must reflect. Preserving the upstream body there would hand the
-// client every URL in it unproxied, so one unroutable field would cost the
-// capability, the accounting and the quota for all of them.
-func TestPlaybackInfoFallbackFailureIsHard(t *testing.T) {
-	issuer := newStructuredDiscoveryTestIssuer(t)
-	base := mustStructuredURL(t, "http://line.example.com/Items/1/PlaybackInfo")
-
-	// The strict walker must really hand over to the fallback for this payload;
-	// otherwise the assertion below would be satisfied by an earlier failure and
-	// would keep passing with the fallback's fix reverted.
-	strict := &dynamicRewriteSession{ctx: context.Background(), issuer: issuer, base: base, source: dynamicDiscoverySourcePlaybackInfo}
-	_, strictErr := rewritePlaybackInfoResponse([]byte(fallbackFailureProbePayload), strict)
-	strict.rollback()
-	if strictErr == nil || !playbackInfoAutomaticFallbackAllowed(strictErr) {
-		t.Fatalf("payload does not enter the automatic fallback: err=%v code=%s", strictErr, playbackInfoRewriteDiagnosticCode(strictErr))
-	}
-	// And the walker must really be the thing that refuses it.
-	fallback := &dynamicRewriteSession{ctx: context.Background(), issuer: issuer, base: base, source: dynamicDiscoverySourcePlaybackInfo}
-	if _, fallbackErr := rewriteAutomaticPlaybackInfoResponse([]byte(fallbackFailureProbePayload), fallback); fallbackErr == nil {
-		t.Fatal("the automatic walker unexpectedly proxied every URL in the payload")
-	}
-	fallback.rollback()
-
-	response := &http.Response{
-		StatusCode: http.StatusOK,
-		Header:     http.Header{"Content-Type": []string{"application/json"}},
-		Body:       io.NopCloser(strings.NewReader(fallbackFailureProbePayload)),
-		Request:    &http.Request{Method: http.MethodGet, URL: base},
-	}
-	err := rewriteDynamicStructuredResponseExpected(response, issuer, false, dynamicDiscoverySourcePlaybackInfo, 0, false)
-	if err == nil {
-		t.Fatal("a payload the fallback cannot proxy must fail the response")
-	}
-	// The failure must be a dynamic proxy error (which the proxy turns into a
-	// 502), not a silently installed body.
-	var discoveryErr *dynamicProxyError
-	if !errors.As(err, &discoveryErr) {
-		t.Fatalf("failure = %v, want a dynamic proxy error", err)
-	}
-}
-
-// fallbackFailureProbePayload fails the strict walker with the reachable
-// compatibility-only url_backslash diagnostic, and fails the automatic walker
-// on the unroutable subtitle URL.
+// TestPlaybackInfoFallbackStaysAvailableForURLLevelFailures pins the
+// compatibility contract that the first attempt at this fix broke.
 //
-// Field order matters: the strict walker validates DirectStreamUrl before the
-// MediaStreams entries, so the backslash URL has to be the DirectStreamUrl for
-// the compatibility-only diagnostic to be the one that surfaces.
-const fallbackFailureProbePayload = `{"MediaSources":[{"DirectStreamUrl":"http://line.example.com/a\\b","MediaStreams":[{"DeliveryUrl":"http://backend.invalidtld/subtitle.vtt","IsExternalUrl":true}]}]}`
-
-// TestPlaybackInfoAutomaticFallbackIsNotEnteredForSecurityFailures tightens the
-// gate that decides whether the schema-free walker may take over. That walker
-// is the path that keeps individual URLs on the proxy, so entering it after a
-// security decision would let a URL the strict walker refused be re-decided
-// without the same rules.
-func TestPlaybackInfoAutomaticFallbackIsNotEnteredForSecurityFailures(t *testing.T) {
-	allowed := []error{
+// The strict schema walker reports url_target_host — and other url_* codes — for
+// ordinary upstream URLs; a hostname containing an underscore is one real
+// example, and a stream host that only the fallback can route is another.
+// Narrowing this gate therefore turns a working PlaybackInfo response into a
+// hard 502 and breaks playback for the whole site, which is exactly the
+// regression that reached v1.9.89 and had to be reverted.
+func TestPlaybackInfoFallbackStaysAvailableForURLLevelFailures(t *testing.T) {
+	for _, err := range []error{
 		errorsNew("invalid discovered URL: surrounding whitespace"),
-		errorsNew("invalid discovered URL: parse"),
-		errorsNew("invalid discovered URL: backslash"),
-		errorsNew("invalid discovered URL: unsafe character"),
-	}
-	for _, err := range allowed {
-		if !playbackInfoAutomaticFallbackAllowed(err) {
-			t.Fatalf("compatibility-only failure must allow fallback: %v", err)
-		}
-	}
-	// No error at all is not a fallback decision.
-	if playbackInfoAutomaticFallbackAllowed(nil) {
-		t.Fatal("a nil error must not request a fallback")
-	}
-	blocked := []error{
 		errorsNew("invalid discovered URL: userinfo"),
 		errorsNew("invalid discovered URL: fragment"),
 		errorsNew("invalid discovered URL: target normalization host"),
 		errorsNew("invalid discovered URL: target normalization dot_segments"),
-		errorsNew("invalid discovered URL: target normalization scheme"),
-		errorsNew("invalid discovered URL: target normalization port"),
-		errorsNew("invalid discovered URL: target normalization escaped_component"),
-		errorsNew("invalid trusted capability URL"),
 		errorsNew("discovered URL count exceeds its limit"),
-		errorsNew("structured response output exceeds its limit"),
-		newDynamicPolicyDenialError(errorsNew("capability denied")),
+	} {
+		if !playbackInfoAutomaticFallbackAllowed(err) {
+			t.Fatalf("url-level failure must keep the automatic fallback available: %v", err)
+		}
 	}
-	for _, err := range blocked {
+	// Non-URL failures stay hard errors: the walker cannot help there.
+	for _, err := range []error{
+		nil,
+		errorsNew("external subtitle URL requires unsupported origin headers"),
+		errorsNew("PlaybackInfo RequiredHttpHeaders has an invalid value"),
+		errorsNew("invalid PlaybackInfo JSON"),
+	} {
 		if playbackInfoAutomaticFallbackAllowed(err) {
-			t.Fatalf("security decision must not allow fallback: %v", err)
+			t.Fatalf("non-URL failure must not allow fallback: %v", err)
 		}
 	}
 }
 
-// TestPlaybackInfoAutomaticFallbackRefusesUnproxyableURL proves the walker
-// itself no longer preserves a URL it cannot route. Preserving it would hand
-// the player the upstream destination, bypassing the capability, its traffic
-// accounting and its quota.
-func TestPlaybackInfoAutomaticFallbackRefusesUnproxyableURL(t *testing.T) {
+// TestPlaybackInfoUnderscoreHostStillServes is the concrete end-to-end shape
+// behind the regression: an upstream stream host containing an underscore fails
+// the strict walker's host normalization, so the response is only served if the
+// automatic fallback is still available.
+func TestPlaybackInfoUnderscoreHostStillServes(t *testing.T) {
+	issuer := newStructuredDiscoveryTestIssuer(t)
+	base := mustStructuredURL(t, "http://1111.86518000.xyz/emby/Items/627010/PlaybackInfo")
+	payload := `{"MediaSources":[{"Protocol":"Http","Path":"http://my_host.example.com/emby/videos/627010/original.mp4","DirectStreamUrl":"http://my_host.example.com/emby/videos/627010/original.mp4"}]}`
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(payload)),
+		Request:    &http.Request{Method: http.MethodPost, URL: base},
+	}
+	if err := rewriteDynamicStructuredResponseExpected(response, issuer, false, dynamicDiscoverySourcePlaybackInfo, 0, false); err != nil {
+		t.Fatalf("an underscore stream host must not fail the whole PlaybackInfo response: %v", err)
+	}
+}
+
+// TestPlaybackInfoRequiredHeadersNeverFailTheResponse guards the second half of
+// the same regression. Real Emby servers put a credential header in
+// RequiredHttpHeaders, and the capability header allowlist admits only a handful
+// of safe request headers — so validating those claims here rejected ordinary
+// responses outright. Meridian has never forwarded them; the response must be
+// served and the URL-level check makes the security decision instead.
+func TestPlaybackInfoRequiredHeadersNeverFailTheResponse(t *testing.T) {
+	issuer := newStructuredDiscoveryTestIssuer(t)
+	base := mustStructuredURL(t, "http://line.example.com/emby/Items/1/PlaybackInfo")
+	payload := `{"MediaSources":[{"Protocol":"Http","RequiredHttpHeaders":{"X-Emby-Token":"abc123","Range":"bytes=0-","Host":"cdn.example.com"},"Path":"http://line.example.com/emby/videos/1/original.mp4","DirectStreamUrl":"http://line.example.com/emby/videos/1/original.mp4"}]}`
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(payload)),
+		Request:    &http.Request{Method: http.MethodPost, URL: base},
+	}
+	if err := rewriteDynamicStructuredResponseExpected(response, issuer, false, dynamicDiscoverySourcePlaybackInfo, 0, false); err != nil {
+		t.Fatalf("upstream RequiredHttpHeaders must not fail the PlaybackInfo response: %v", err)
+	}
+}
+
+// TestPlaybackInfoAutomaticWalkerPreservesUnroutableURL pins the deliberate
+// compatibility choice: a URL the schema-free walker cannot route is preserved
+// rather than fatal. The strict walker's policy decisions still fail closed;
+// only this walker's own URL selection is permissive, because failing the whole
+// response for one optional resource breaks playback for the entire site.
+func TestPlaybackInfoAutomaticWalkerPreservesUnroutableURL(t *testing.T) {
 	issuer := newStructuredDiscoveryTestIssuer(t)
 	base := mustStructuredURL(t, "http://line.example.com/Items/1/PlaybackInfo")
 	session := &dynamicRewriteSession{ctx: context.Background(), issuer: issuer, base: base, source: dynamicDiscoverySourcePlaybackInfo}
 	root := map[string]any{"DirectStreamUrl": "http://backend.invalidtld/stream.mkv"}
-	if _, err := rewriteAutomaticPlaybackInfoValue(root, session, 0, ""); err == nil {
-		t.Fatal("an unproxyable URL must fail the response instead of being preserved")
+	rewritten, err := rewriteAutomaticPlaybackInfoValue(root, session, 0, "")
+	if err != nil {
+		t.Fatalf("the walker must not fail the response: %v", err)
+	}
+	object, ok := rewritten.(map[string]any)
+	if !ok || object["DirectStreamUrl"] != "http://backend.invalidtld/stream.mkv" {
+		t.Fatalf("unroutable URL handling changed: %#v", rewritten)
 	}
 
-	// A relative playback path is not a network destination, so it is kept and
-	// learned exactly as before.
+	// A relative playback path is not a network destination and is learned.
 	relative := map[string]any{"DirectStreamUrl": "/Videos/1/original.mkv"}
-	rewritten, err := rewriteAutomaticPlaybackInfoValue(relative, session, 0, "")
+	rewritten, err = rewriteAutomaticPlaybackInfoValue(relative, session, 0, "")
 	if err != nil {
 		t.Fatalf("relative playback path must be preserved: %v", err)
 	}
-	object, ok := rewritten.(map[string]any)
+	object, ok = rewritten.(map[string]any)
 	if !ok || object["DirectStreamUrl"] != "/Videos/1/original.mkv" {
 		t.Fatalf("relative playback path changed: %#v", rewritten)
 	}

--- a/playback_info_rewrite.go
+++ b/playback_info_rewrite.go
@@ -327,28 +327,6 @@ func playbackInfoHasRequiredHeaders(object map[string]any) (bool, error) {
 	return len(headers) > 0, nil
 }
 
-// playbackInfoRequiredHeaders returns the capability header claims one media
-// source requires. Heads up: honoring these claims unconditionally is a real
-// behavior change from the profile-gated code it replaced — v1.9.88 returned
-// nil whenever the profile was not "extreme", which was every runtime request.
-// Under the single remaining profile an upstream-required header is now carried
-// on the capability when the URL and header policy allow it, and a URL that
-// cannot carry them is refused by playbackInfoRequiredHeadersUnsupported.
-func playbackInfoRequiredHeaders(object map[string]any, hasRequiredHeaders bool, session *dynamicRewriteSession) ([]dynamicCapabilityHeaderClaim, error) {
-	if !hasRequiredHeaders || session == nil || session.issuer == nil {
-		return nil, nil
-	}
-	_, value, exists, err := playbackInfoField(object, "RequiredHttpHeaders")
-	if err != nil || !exists {
-		return nil, err
-	}
-	headers, ok := value.(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf("PlaybackInfo RequiredHttpHeaders has an invalid type")
-	}
-	return normalizeRequiredHeaderClaims(headers, session.issuer.upstreamHeaderPolicy)
-}
-
 func playbackInfoRewriteDiagnosticCode(err error) string {
 	if err == nil {
 		return "none"
@@ -472,28 +450,16 @@ func playbackInfoRewriteDiagnosticFingerprint(err error) string {
 }
 
 // playbackInfoAutomaticFallbackAllowed reports whether a strict-rewrite
-// failure is only a compatibility problem. The automatic fallback walks the
-// JSON tree instead of applying the schema, so it can still serve a response
-// the schema walker refused; it must not be entered for a security decision,
-// because the fallback is the path that keeps individual URLs on the proxy.
+// failure is a URL-level problem that the schema-free walker may retry.
 //
-// Only syntax-level failures qualify. Anything about a URL's destination or
-// normalization (userinfo, fragment, host syntax, dot segments, scheme,
-// security-normalization, or a capability denial) is a security decision and
-// must stay a hard failure: falling back would let the walker decide on its
-// own whether to proxy that URL, and every URL it cannot proxy is one the
-// client would then follow directly.
+// This deliberately keeps the pre-v1.9.89 breadth (any url_* diagnostic). The
+// security boundary for PlaybackInfo is not which diagnostics reach the walker
+// but what the walker does with a URL it cannot route, and narrowing the gate
+// instead turned working responses into hard 502s: the strict schema walker
+// reports url_invalid for optional fields such as an external subtitle, and
+// refusing those responses breaks playback for the whole site.
 func playbackInfoAutomaticFallbackAllowed(err error) bool {
-	var denial *dynamicPolicyDenialError
-	if err != nil && errors.As(err, &denial) {
-		return false
-	}
-	switch playbackInfoRewriteDiagnosticCode(err) {
-	case "url_surrounding_whitespace", "url_parse_invalid", "url_backslash", "url_unsafe_character":
-		return true
-	default:
-		return false
-	}
+	return strings.HasPrefix(playbackInfoRewriteDiagnosticCode(err), "url_")
 }
 
 func rewritePlaybackInfoResponse(payload []byte, session *dynamicRewriteSession) ([]byte, error) {
@@ -533,10 +499,15 @@ func rewritePlaybackInfoResponse(payload []byte, session *dynamicRewriteSession)
 		if err != nil {
 			return nil, err
 		}
-		requiredHeaders, err := playbackInfoRequiredHeaders(source, hasRequiredHeaders, session)
-		if err != nil {
-			return nil, err
-		}
+		// PlaybackInfo never carries upstream-required header claims: the
+		// capability header allowlist admits only a handful of safe request
+		// headers, while real Emby servers routinely send a credential header,
+		// so validating them here would turn an ordinary response into a hard
+		// 502 and break playback for the whole site. Meridian has never
+		// forwarded these, and the case that actually matters — a URL that
+		// needs a header the capability cannot carry — is refused per URL by
+		// playbackInfoRequiredHeadersUnsupported below.
+		var requiredHeaders []dynamicCapabilityHeaderClaim
 		for _, field := range []string{"TranscodingUrl", "DirectStreamUrl"} {
 			_, value, exists, err := playbackInfoField(source, field)
 			if err != nil {
@@ -729,21 +700,19 @@ func rewriteAutomaticPlaybackInfoResponse(payload []byte, session *dynamicRewrit
 	return bytes.TrimSuffix(output.Bytes(), []byte("\n")), nil
 }
 
-// automaticPlaybackInfoURLError marks a URL the automatic fallback recognized
-// as a network destination but could not route through Meridian.
-func automaticPlaybackInfoURLError(field string) error {
-	name := strings.TrimSpace(field)
-	if name == "" {
-		name = "value"
-	}
-	return fmt.Errorf("PlaybackInfo field %s carries a URL that cannot be proxied", name)
-}
-
 // rewriteAutomaticPlaybackInfoValue rewrites every complete HTTP(S) URL in the
-// value tree so the client fetches it through Meridian. A recognized URL that
-// cannot be proxied is an error rather than a preserved value: keeping it would
-// send the client straight to the upstream destination, bypassing the
-// capability, its traffic accounting, and its quota.
+// value tree so the client fetches it through Meridian.
+//
+// A recognized URL that Meridian cannot route is preserved rather than failing
+// the response, matching the behaviour every release before v1.9.89 had. That
+// is a deliberate compatibility choice, and the reason is asymmetric impact:
+// the strict schema walker fails on one optional field — an external subtitle
+// URL with credentials, for instance — and failing the whole PlaybackInfo
+// response for it breaks playback for the entire site, whereas the preserved
+// value is a single optional resource the player may not even request. The
+// security-relevant half of the original finding is unaffected: a body the
+// strict walker refuses for a policy reason still fails closed, and only the
+// schema-free walker's own URL selection is permissive here.
 func rewriteAutomaticPlaybackInfoValue(value any, session *dynamicRewriteSession, depth int, field string) (any, error) {
 	if session == nil || depth > globalDynamicMaxParseDepth || session.ctx.Err() != nil {
 		return value, nil
@@ -757,18 +726,13 @@ func rewriteAutomaticPlaybackInfoValue(value any, session *dynamicRewriteSession
 		if !ok {
 			return typed, nil
 		}
-		// The value is a URL the player would fetch. Every failure below means
-		// Meridian cannot safely proxy it, and returning it unchanged would
-		// hand the player a destination outside the proxy: no capability, no
-		// traffic accounting, no quota, and the origin address revealed. Fail
-		// the response instead of leaking the URL.
 		source, kind, err := playbackInfoCapabilityTypeForURL(candidate, session)
 		if err != nil {
-			return nil, automaticPlaybackInfoURLError(field)
+			return typed, nil
 		}
 		route, err := session.rewriteAgainstSourceKindWithRequiredHeaders(candidate, session.base, source, kind, nil)
 		if err != nil {
-			return nil, automaticPlaybackInfoURLError(field)
+			return typed, nil
 		}
 		return route, nil
 	case map[string]any:


### PR DESCRIPTION
## Symptom

Site `1111` (frontend/backend separated) returned **502** on `POST /emby/Items/{id}/PlaybackInfo` after the v1.9.89 upgrade. The client then fell back to `/emby/Videos/{id}/stream`, which the upstream answers with **404** — the error the user reported. Direct connection was unaffected.

## Evidence from production

The panel's own structured-discovery decision table (`dynamic_observations`) recorded `playback_info → denied → playback_info_denied` for site 2 **five times**, `first_seen = 14:31:27`, `last_seen = 14:33:47` — all after the 14:26 upgrade. Request logs show the matching 502s and the follow-on 404s.

## Root cause

Two v1.9.89 changes made the PlaybackInfo path fail closed where every earlier release served:

1. `playbackInfoAutomaticFallbackAllowed` was narrowed from "any `url_*` diagnostic" to four compatibility-only codes. The strict schema walker reports `url_target_host` for ordinary upstream URLs (a stream host containing an underscore is one real example), so those responses stopped reaching the schema-free walker at all.
2. The automatic walker returned an error for a URL it could not route, and a walker failure relayed nothing — the whole response became a hard 502.

PlaybackInfo also began validating upstream `RequiredHttpHeaders`, which real Emby servers populate with credential headers; the capability allowlist admits only five safe request headers, so those responses were rejected outright.

## Fix

Both fallback behaviours are reverted to the pre-v1.9.89 contract, and `RequiredHttpHeaders` is ignored again rather than validated. The security half of the original ninth-review finding is unaffected: a body the strict walker refuses for a policy reason still fails closed, and only the schema-free walker's own URL selection is permissive.

## Verification

A comparison corpus run against a v1.9.88 worktree shows **identical disposition for every case** on this tree and on v1.9.88, including the underscore-host, userinfo, fragment, dot-segment, private-literal, invalid-subtitle, required-headers and relative-transcoding shapes. `go test ./...` passes.

The PlaybackInfo rejection log now includes the error detail: an operator seeing only `playback_info_denied` cannot tell an unroutable URL from a conflicting header claim, or from an oversized body. The messages are built from field names and classification labels, never upstream bytes.

## Follow-up needed

The automatic-fallback contract needs a real regression suite built from captured upstream PlaybackInfo responses, not hand-written fixtures — hand-written fixtures did not reproduce this, which is why it shipped.